### PR TITLE
fix: resolve agent identity from $AGENTCHUTE_AGENT_ID in generated hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ Known wrappers and their canonical IDs:
 | Gemini CLI   | `gemini-cli`  | `google`    |
 | grok CLI     | `grok`        | `xai`       |
 
+The IDs above are single-wrapper defaults. **When several agents of one vendor share a bus** (e.g. `claude-l1`/`claude-l2`/`merger` all on the `claude-code` wrapper), each process must enroll under its own id — reusing the canonical default makes every lane read one inbox and silently pass the finish-gate against the wrong one. Give each its own roster id via `--as <roster-id>`, or set `AGENTCHUTE_AGENT_ID` in its environment and omit `--as` (the CLI resolves identity from that variable; a generated hook keeps the canonical default only as a last-resort fallback).
+
 **2. Lifecycle Hooks (Required for Context and Gates)**
 `agentchute setup` installs lifecycle hooks. If you are not using setup, run `agentchute hooks install` once per control repo. Hooks surface inbox/ledger context per turn and block finish while obligations remain.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ Canonical enrollment spec: [`AGENTS.md`](AGENTS.md). This file is a thin pointer
 
 **This agent**: `agent_id=claude-code`, `vendor=anthropic`.
 
+> **Several agents of this vendor on one bus?** `claude-code` is the single-wrapper default — don't let multiple panes share it. Give each process its own roster id via `--as <roster-id>`, or set `AGENTCHUTE_AGENT_ID` in its environment (the CLI reads it when `--as` is omitted). A shared id routes every lane to one inbox and defeats the finish-gate.
+
 **Setup** (one command per control repo):
 
 ```sh

--- a/CODEX.md
+++ b/CODEX.md
@@ -7,6 +7,8 @@ Canonical enrollment spec: [`AGENTS.md`](AGENTS.md). This file is a thin pointer
 
 **This agent**: `agent_id=codex`, `vendor=openai`.
 
+> **Several agents of this vendor on one bus?** `codex` is the single-wrapper default — don't let multiple panes share it. Give each process its own roster id via `--as <roster-id>`, or set `AGENTCHUTE_AGENT_ID` in its environment (the CLI reads it when `--as` is omitted). A shared id routes every lane to one inbox and defeats the finish-gate.
+
 **Setup** (one command per control repo):
 
 ```sh

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -7,6 +7,8 @@ Canonical enrollment spec: [`AGENTS.md`](AGENTS.md). This file is a thin pointer
 
 **This agent**: `agent_id=gemini-cli`, `vendor=google`.
 
+> **Several agents of this vendor on one bus?** `gemini-cli` is the single-wrapper default — don't let multiple panes share it. Give each process its own roster id via `--as <roster-id>`, or set `AGENTCHUTE_AGENT_ID` in its environment (the CLI reads it when `--as` is omitted). A shared id routes every lane to one inbox and defeats the finish-gate.
+
 **Setup** (one command per control repo):
 
 ```sh

--- a/examples/hooks/claude-code/.claude/settings.json
+++ b/examples/hooks/claude-code/.claude/settings.json
@@ -6,15 +6,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as claude-code --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as \"${AGENTCHUTE_AGENT_ID:-claude-code}\" --vendor anthropic --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as claude-code --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as \"${AGENTCHUTE_AGENT_ID:-claude-code}\" --vendor anthropic --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} boot --as claude-code --vendor anthropic --context-only"
+            "command": "${AGENTCHUTE_BIN:-agentchute} boot --as \"${AGENTCHUTE_AGENT_ID:-claude-code}\" --vendor anthropic --context-only"
           }
         ]
       }
@@ -24,15 +24,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as claude-code --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as \"${AGENTCHUTE_AGENT_ID:-claude-code}\" --vendor anthropic --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as claude-code --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as \"${AGENTCHUTE_AGENT_ID:-claude-code}\" --vendor anthropic --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} pending --as claude-code --claude-hook UserPromptSubmit"
+            "command": "${AGENTCHUTE_BIN:-agentchute} pending --as \"${AGENTCHUTE_AGENT_ID:-claude-code}\" --claude-hook UserPromptSubmit"
           }
         ]
       }
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} gate --as claude-code --before finish --json"
+            "command": "${AGENTCHUTE_BIN:-agentchute} gate --as \"${AGENTCHUTE_AGENT_ID:-claude-code}\" --before finish --json"
           }
         ]
       }

--- a/examples/hooks/codex/.codex/hooks.json
+++ b/examples/hooks/codex/.codex/hooks.json
@@ -6,17 +6,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as codex --vendor openai --quiet",
+            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as \"${AGENTCHUTE_AGENT_ID:-codex}\" --vendor openai --quiet",
             "statusMessage": "agentchute: self-check"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as codex --vendor openai --quiet",
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as \"${AGENTCHUTE_AGENT_ID:-codex}\" --vendor openai --quiet",
             "statusMessage": "agentchute: poller"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} boot --as codex --vendor openai --codex-hook SessionStart",
+            "command": "${AGENTCHUTE_BIN:-agentchute} boot --as \"${AGENTCHUTE_AGENT_ID:-codex}\" --vendor openai --codex-hook SessionStart",
             "statusMessage": "agentchute: boot"
           }
         ]
@@ -27,17 +27,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as codex --vendor openai --quiet",
+            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as \"${AGENTCHUTE_AGENT_ID:-codex}\" --vendor openai --quiet",
             "statusMessage": "agentchute: self-check"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as codex --vendor openai --quiet",
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as \"${AGENTCHUTE_AGENT_ID:-codex}\" --vendor openai --quiet",
             "statusMessage": "agentchute: poller"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} pending --as codex --codex-hook UserPromptSubmit",
+            "command": "${AGENTCHUTE_BIN:-agentchute} pending --as \"${AGENTCHUTE_AGENT_ID:-codex}\" --codex-hook UserPromptSubmit",
             "statusMessage": "agentchute: pending inbox"
           }
         ]
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} gate --as codex --before finish --codex-hook Stop",
+            "command": "${AGENTCHUTE_BIN:-agentchute} gate --as \"${AGENTCHUTE_AGENT_ID:-codex}\" --before finish --codex-hook Stop",
             "timeout": 30,
             "statusMessage": "agentchute: finish gate"
           }

--- a/examples/hooks/gemini/.gemini/settings.json
+++ b/examples/hooks/gemini/.gemini/settings.json
@@ -7,17 +7,17 @@
           {
             "name": "agentchute-self-check",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as gemini-cli --vendor google --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as \"${AGENTCHUTE_AGENT_ID:-gemini-cli}\" --vendor google --quiet"
           },
           {
             "name": "agentchute-poller",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as gemini-cli --vendor google --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as \"${AGENTCHUTE_AGENT_ID:-gemini-cli}\" --vendor google --quiet"
           },
           {
             "name": "agentchute-boot",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} boot --as gemini-cli --vendor google --context-only"
+            "command": "${AGENTCHUTE_BIN:-agentchute} boot --as \"${AGENTCHUTE_AGENT_ID:-gemini-cli}\" --vendor google --context-only"
           }
         ]
       }
@@ -29,22 +29,22 @@
           {
             "name": "agentchute-self-check",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as gemini-cli --vendor google --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --as \"${AGENTCHUTE_AGENT_ID:-gemini-cli}\" --vendor google --quiet"
           },
           {
             "name": "agentchute-poller",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as gemini-cli --vendor google --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --as \"${AGENTCHUTE_AGENT_ID:-gemini-cli}\" --vendor google --quiet"
           },
           {
             "name": "agentchute-pending",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} pending --as gemini-cli --json"
+            "command": "${AGENTCHUTE_BIN:-agentchute} pending --as \"${AGENTCHUTE_AGENT_ID:-gemini-cli}\" --json"
           },
           {
             "name": "agentchute-gate",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} gate --as gemini-cli --before finish --json"
+            "command": "${AGENTCHUTE_BIN:-agentchute} gate --as \"${AGENTCHUTE_AGENT_ID:-gemini-cli}\" --before finish --json"
           }
         ]
       }

--- a/templates/enrollment/agents.md
+++ b/templates/enrollment/agents.md
@@ -23,6 +23,8 @@ Known wrappers and their canonical IDs:
 | Gemini CLI   | `gemini-cli`  | `google`    |
 | grok CLI     | `grok`        | `xai`       |
 
+The IDs above are single-wrapper defaults. **When several agents of one vendor share a bus** (e.g. `claude-l1`/`claude-l2`/`merger` all on the `claude-code` wrapper), each process must enroll under its own id — reusing the canonical default makes every lane read one inbox and silently pass the finish-gate against the wrong one. Give each its own roster id via `--as <roster-id>`, or set `AGENTCHUTE_AGENT_ID` in its environment and omit `--as` (the CLI resolves identity from that variable; a generated hook keeps the canonical default only as a last-resort fallback).
+
 **2. Lifecycle Hooks (Required for Context and Gates)**
 `agentchute setup` installs lifecycle hooks. If you are not using setup, run `agentchute hooks install` once per control repo. Hooks surface inbox/ledger context per turn and block finish while obligations remain.
 

--- a/templates/enrollment/wrapper.md
+++ b/templates/enrollment/wrapper.md
@@ -5,6 +5,8 @@ Canonical enrollment spec: [`AGENTS.md`](AGENTS.md). This file is a thin pointer
 
 **This agent**: `agent_id={{AS}}`, `vendor={{VENDOR}}`.
 
+> **Several agents of this vendor on one bus?** `{{AS}}` is the single-wrapper default — don't let multiple panes share it. Give each process its own roster id via `--as <roster-id>`, or set `AGENTCHUTE_AGENT_ID` in its environment (the CLI reads it when `--as` is omitted). A shared id routes every lane to one inbox and defeats the finish-gate.
+
 **Setup** (one command per control repo):
 
 ```sh


### PR DESCRIPTION
## Problem

When several agents of the **same vendor** share one control repo (e.g. `claude-l1`, `claude-l2`, `merger` — all the `claude-code` wrapper), every one inherits the wrapper-default `agent_id` that `setup` / `hooks install` bake **literally** into the generated hooks. They then run `self-check` / `poller` / `boot` / `pending` / `gate` as that one id, so they:

- read the **wrong inbox** (never see their own mail),
- **cross-consume** each other's messages,
- pass the **finish-gate against an empty/foreign inbox** — exactly the condition the gate exists to prevent.

The bus routes correctly; this is an **identity-resolution** gap. See `PROPOSAL-multiagent-identity.md`.

## Fix

The CLI already falls back to `$AGENTCHUTE_AGENT_ID` when `--as` is omitted — but the hard-coded `--as` in the hooks beats it. This de-literalizes the embedded hook templates so identity resolves from the environment, with the wrapper default as a last resort:

```diff
- "${AGENTCHUTE_BIN:-agentchute} boot --as claude-code --vendor anthropic --context-only"
+ "${AGENTCHUTE_BIN:-agentchute} boot --as \"${AGENTCHUTE_AGENT_ID:-claude-code}\" --vendor anthropic --context-only"
```

Applied to all hook commands across the three wrappers (`self-check`, `poller ensure`, `boot`, `pending`, `gate`). Behavior:

| `AGENTCHUTE_AGENT_ID` | resolved `--as` |
|---|---|
| unset | `claude-code` (single-agent default, unchanged) |
| `claude-l2` | `claude-l2` (per-pane identity — the fix) |
| empty string | `claude-code` (`:-` triggers on empty; never emits `--as ""`) |

**No tmux probe in hooks** — wakes can be unix sockets (`agentchute-run`), not just tmux, so the env var is the portable carrier. The enrollment templates also gain a short multi-agent identity note (kept at `v10`, propagated to `CLAUDE/CODEX/GEMINI/AGENTS.md` via `init`'s drift-replace; advisory text only, no version bump).

## Testing

- `go test .` — templates-drift, init, and hooks tests all pass.
- Verified `/bin/sh` expansion for unset / set / empty env (table above).
- All three hook files validate as JSON (escaped inner quotes).
- 8 unrelated `defer`/`gate` test failures are **pre-existing on `origin/main`** (date/time-bomb tests now past their hardcoded dates) — not introduced here.

## Scope / follow-ups

This is the agreed **simple, root-cause** cut. Per team consensus (claude-code/codex/gemini-cli/grok), separate PRs will add: a centralized identity resolver with flag↔env mismatch guard (refuse on obligation commands, warn on read-only), an `agentchute env --as X` exporter, and `setup --multi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
