### PR TITLE
feat: migrate legacy .rehumanlabs/loop to .agentchute on setup/init

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -219,6 +219,8 @@ Triggers include malformed inbox filenames, unparseable frontmatter, or unparsea
 ## 14. Vendor namespace conventions
 Implementations namespace state under a vendor-owned identifier (e.g., `.agentchute/`, `.examplecorp/`). `AGENTCHUTE.md` is shared; vendor-specific notes live in `.<vendor>/loop/README.md`.
 
+> **Legacy namespace migration.** The reference implementation previously used the `.rehumanlabs/` namespace (renamed to `.agentchute/` in v0.2.2). Because discovery (§4.2) auto-matches any `.<vendor>/loop/`, a leftover `.rehumanlabs/loop` makes discovery ambiguous. `agentchute setup`/`init` migrate it for the current control repo: rename when the canonical namespace is absent, move a scaffold-only legacy loop aside, or promote legacy state over an empty canonical loop. If **both** hold live state it refuses and asks the operator to consolidate by hand — never an automatic merge. (`reHuman Labs` remains the maker's credit in `README.md`; that's brand, not a namespace.)
+
 ---
 
 ## Appendix B. Reference implementation hook templates

--- a/init.go
+++ b/init.go
@@ -219,7 +219,19 @@ func computeInitPlan(root, namespace string, inGit bool) (initPlan, error) {
 		EnrollmentBlocks: make(map[string]string),
 	}
 
-	if err := guardInitLoopNamespace(root, namespace); err != nil {
+	// 0. Legacy namespace migration (.rehumanlabs -> canonical). Must precede the
+	// ambiguity guard: a stranded legacy loop would otherwise trip the
+	// "multiple loop namespaces" refusal. Safe cases become an apply-time action
+	// (shown in dry-run); the unsafe both-live case errors here.
+	migrationAction, migratingRel, err := planLegacyMigration(root, namespace)
+	if err != nil {
+		return plan, err
+	}
+	if migrationAction != nil {
+		plan.Actions = append(plan.Actions, *migrationAction)
+	}
+
+	if err := guardInitLoopNamespace(root, namespace, migratingRel); err != nil {
 		return plan, err
 	}
 
@@ -280,7 +292,11 @@ func computeInitPlan(root, namespace string, inGit bool) (initPlan, error) {
 	return plan, nil
 }
 
-func guardInitLoopNamespace(root, namespace string) error {
+// guardInitLoopNamespace refuses to initialize when more than one loop namespace
+// would be discoverable (discovery would be ambiguous). ignoreRel, when non-empty,
+// is a loop rel path that a planned migration will remove before apply, so it is
+// not counted as a conflict.
+func guardInitLoopNamespace(root, namespace, ignoreRel string) error {
 	existing, err := findInitLoopDirs(root)
 	if err != nil {
 		return err
@@ -292,6 +308,9 @@ func guardInitLoopNamespace(root, namespace string) error {
 		if rel == target {
 			targetExists = true
 			continue
+		}
+		if ignoreRel != "" && rel == ignoreRel {
+			continue // a planned migration removes this loop before apply
 		}
 		conflicts = append(conflicts, rel)
 	}

--- a/install.sh
+++ b/install.sh
@@ -348,6 +348,9 @@ print_setup_next_steps() {
 	info "  agentchute setup"
 	info "then restart your agents"
 	info "optional check: agentchute doctor --as <agent-id>"
+	info "upgrading from an older release? setup migrates a legacy .rehumanlabs/loop"
+	info "in that repo to .agentchute/loop automatically (safe cases; it refuses to"
+	info "auto-merge if both hold live state)."
 }
 
 # ---------- main flow ----------

--- a/install.sh
+++ b/install.sh
@@ -349,7 +349,7 @@ print_setup_next_steps() {
 	info "then restart your agents"
 	info "optional check: agentchute doctor --as <agent-id>"
 	info "upgrading from an older release? setup migrates a legacy .rehumanlabs/loop"
-	info "in that repo to .agentchute/loop automatically (safe cases; it refuses to"
+	info "in your control repo to .agentchute/loop automatically (safe cases; it refuses to"
 	info "auto-merge if both hold live state)."
 }
 

--- a/migrate.go
+++ b/migrate.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// legacyNamespace is the pre-v0.2.2 dotdir namespace agentchute used before the
+// rename to .agentchute. Installs from that era leave a .rehumanlabs/loop behind.
+// Because loop.Discover scans every .<name>/loop, a stranded legacy loop either
+// collides with the canonical .agentchute/loop ("multiple vendor loop
+// directories") or silently runs the agent under vendor=rehumanlabs. setup/init
+// consolidate it into the canonical namespace.
+const legacyNamespace = "rehumanlabs"
+
+// dirExists reports whether path is an existing directory (symlinks resolved).
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// pathExists reports whether anything exists at path (without following links).
+func pathExists(path string) bool {
+	_, err := os.Lstat(path)
+	return err == nil
+}
+
+// isScaffoldFile reports whether name is a loop scaffold artifact rather than
+// real coordination state. Empty subdirs, READMEs, and *.example.md templates
+// are scaffolding; registrations, inbox messages, archive/malformed entries,
+// and runtime state files are not.
+func isScaffoldFile(name string) bool {
+	return name == "README.md" || strings.HasSuffix(name, ".example.md")
+}
+
+// countLoopState returns the number of real (non-scaffold) files under loopDir.
+// A fresh scaffold (only empty dirs and/or README/example files) returns 0.
+func countLoopState(loopDir string) (int, error) {
+	count := 0
+	err := filepath.WalkDir(loopDir, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || isScaffoldFile(d.Name()) {
+			return nil
+		}
+		count++
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// loopHasState reports whether loopDir holds live coordination state.
+func loopHasState(loopDir string) (bool, error) {
+	n, err := countLoopState(loopDir)
+	return n > 0, err
+}
+
+// planLegacyMigration inspects root for a legacy .rehumanlabs/loop and returns
+// an initAction that consolidates it into the canonical .<namespace>/loop for
+// the safe cases. It returns (nil, "", nil) when there is nothing to migrate
+// (idempotent), and an error for the unsafe both-live case where an automatic
+// merge could lose data or fabricate obligations — the operator resolves that
+// manually.
+//
+// The second return value is the rel loop path the migration will remove (e.g.
+// ".rehumanlabs/loop"); the caller excludes it from the ambiguity guard so the
+// pre-migration coexistence does not trip the "multiple loop namespaces" refusal.
+//
+// Scope is the control repo only (no $HOME scan), and symlinked namespace/loop
+// paths are rejected the same way init scaffolding rejects them.
+func planLegacyMigration(root, namespace string) (*initAction, string, error) {
+	if namespace == legacyNamespace {
+		return nil, "", nil // canonical IS the legacy name; nothing to do
+	}
+
+	legacyDir := filepath.Join(root, "."+legacyNamespace)
+	legacyLoop := filepath.Join(legacyDir, "loop")
+	if !dirExists(legacyLoop) {
+		return nil, "", nil // idempotent: already migrated / never present
+	}
+
+	canonDir := filepath.Join(root, "."+namespace)
+	canonLoop := filepath.Join(canonDir, "loop")
+	legacyRel := filepath.ToSlash(filepath.Join("."+legacyNamespace, "loop"))
+
+	// Refuse to operate through symlinked namespace/loop paths.
+	for _, p := range []string{legacyDir, legacyLoop, canonDir, canonLoop} {
+		if err := rejectSymlinkAncestor(p); err != nil {
+			return nil, "", err
+		}
+	}
+
+	// Case A: canonical loop absent — straight move, no possibility of collision.
+	if !dirExists(canonLoop) {
+		if !pathExists(canonDir) {
+			// Whole canonical namespace absent → atomic rename of the dotdir,
+			// preserving registrations, inboxes, archive, ledger and state.
+			return &initAction{
+				Target: "." + legacyNamespace,
+				Action: "migrate legacy namespace",
+				Detail: fmt.Sprintf("rename .%s -> .%s (legacy bus state preserved)", legacyNamespace, namespace),
+				Apply: func() error {
+					return os.Rename(legacyDir, canonDir)
+				},
+			}, legacyRel, nil
+		}
+		// Canonical dotdir exists but has no loop → move just the loop in.
+		return &initAction{
+			Target: legacyRel,
+			Action: "migrate legacy loop",
+			Detail: fmt.Sprintf("move .%s/loop -> .%s/loop", legacyNamespace, namespace),
+			Apply: func() error {
+				if err := loop.EnsurePrivateDir(canonDir); err != nil {
+					return err
+				}
+				return os.Rename(legacyLoop, canonLoop)
+			},
+		}, legacyRel, nil
+	}
+
+	// Canonical loop exists: classify by which side holds live state.
+	legacyLive, err := loopHasState(legacyLoop)
+	if err != nil {
+		return nil, "", err
+	}
+	canonLive, err := loopHasState(canonLoop)
+	if err != nil {
+		return nil, "", err
+	}
+
+	switch {
+	case !legacyLive:
+		// Case B: legacy is scaffold-only → move it aside. Back up the LOOP path
+		// (not the whole .rehumanlabs dotdir): a ".rehumanlabs.<backup>/loop"
+		// would still be auto-discovered as a vendor loop; ".rehumanlabs/loop.<backup>"
+		// is not (its basename is no longer "loop").
+		backup := setupBackupPath(legacyLoop)
+		return &initAction{
+			Target: legacyRel,
+			Action: "retire legacy scaffold",
+			Detail: fmt.Sprintf("move empty .%s/loop aside to %s", legacyNamespace, filepath.Base(backup)),
+			Apply: func() error {
+				return os.Rename(legacyLoop, backup)
+			},
+		}, legacyRel, nil
+
+	case !canonLive:
+		// Case C: canonical is scaffold-only but legacy has real state → back up
+		// the empty canonical loop, then move the legacy loop into place.
+		backup := setupBackupPath(canonLoop)
+		return &initAction{
+			Target: legacyRel,
+			Action: "migrate legacy loop",
+			Detail: fmt.Sprintf("back up empty .%s/loop to %s, then move .%s/loop -> .%s/loop", namespace, filepath.Base(backup), legacyNamespace, namespace),
+			Apply: func() error {
+				if err := os.Rename(canonLoop, backup); err != nil {
+					return err
+				}
+				return os.Rename(legacyLoop, canonLoop)
+			},
+		}, legacyRel, nil
+
+	default:
+		// Case D: both sides hold live state → refuse. Collisions in
+		// agents/inbox/state carry semantics; an automatic merge could lose mail
+		// or fabricate obligations. The operator moves one aside and re-runs.
+		legacyN, _ := countLoopState(legacyLoop)
+		canonN, _ := countLoopState(canonLoop)
+		return nil, "", fmt.Errorf(
+			"both .%s/loop (%d state file(s)) and .%s/loop (%d state file(s)) hold live coordination state; refusing to auto-merge because collisions in agents/inbox/state carry semantics. Move one aside manually (e.g. `mv .%s/loop .%s/loop.backup`) and re-run setup/init, or merge by hand",
+			legacyNamespace, legacyN, namespace, canonN, legacyNamespace, legacyNamespace)
+	}
+}

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mkLoop scaffolds .<ns>/loop under root. When live, it also writes a real
+// registration so loopHasState reports true. A README is always written to
+// prove scaffold artifacts are not counted as live state.
+func mkLoop(t *testing.T, root, ns string, live bool) string {
+	t.Helper()
+	loopDir := filepath.Join(root, "."+ns, "loop")
+	for _, sub := range []string{"agents", "inbox", "archive", "malformed"} {
+		if err := os.MkdirAll(filepath.Join(loopDir, sub), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(loopDir, "agents", "README.md"), []byte("scaffold"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if live {
+		if err := os.WriteFile(filepath.Join(loopDir, "agents", "claude-code.md"), []byte("registration"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(loopDir, "inbox", "claude-code"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(loopDir, "inbox", "claude-code", "msg-1.md"), []byte("mail"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return loopDir
+}
+
+func applyMigration(t *testing.T, root string) (*initAction, string, error) {
+	t.Helper()
+	action, rel, err := planLegacyMigration(root, "agentchute")
+	if err != nil {
+		return nil, rel, err
+	}
+	if action != nil && action.Apply != nil {
+		if err := action.Apply(); err != nil {
+			t.Fatalf("apply migration: %v", err)
+		}
+	}
+	return action, rel, nil
+}
+
+func fileContains(t *testing.T, path, want string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(b) != want {
+		t.Errorf("%s = %q, want %q", path, b, want)
+	}
+}
+
+// Idempotency: no legacy dir → no action, no error.
+func TestMigrateNoLegacyIsNoop(t *testing.T) {
+	root := t.TempDir()
+	mkLoop(t, root, "agentchute", true)
+	action, _, err := planLegacyMigration(root, "agentchute")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action != nil {
+		t.Errorf("expected no action when no legacy dir, got %+v", action)
+	}
+}
+
+// Case A1: legacy only, canonical absent → atomic rename of the dotdir.
+func TestMigrateRenamesWholeNamespace(t *testing.T) {
+	root := t.TempDir()
+	mkLoop(t, root, legacyNamespace, true)
+
+	action, _, err := applyMigration(t, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action == nil || action.Action != "migrate legacy namespace" {
+		t.Fatalf("expected rename action, got %+v", action)
+	}
+	fileContains(t, filepath.Join(root, ".agentchute", "loop", "agents", "claude-code.md"), "registration")
+	fileContains(t, filepath.Join(root, ".agentchute", "loop", "inbox", "claude-code", "msg-1.md"), "mail")
+	if pathExists(filepath.Join(root, "."+legacyNamespace)) {
+		t.Errorf("legacy dotdir should be gone after rename")
+	}
+	assertSingleLoop(t, root)
+}
+
+// Case A2: canonical dotdir exists but has no loop → move the loop in.
+func TestMigrateMovesLoopWhenCanonDirExistsWithoutLoop(t *testing.T) {
+	root := t.TempDir()
+	mkLoop(t, root, legacyNamespace, true)
+	if err := os.MkdirAll(filepath.Join(root, ".agentchute"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := applyMigration(t, root); err != nil {
+		t.Fatal(err)
+	}
+	fileContains(t, filepath.Join(root, ".agentchute", "loop", "agents", "claude-code.md"), "registration")
+	if dirExists(filepath.Join(root, "."+legacyNamespace, "loop")) {
+		t.Errorf("legacy loop should be gone")
+	}
+	assertSingleLoop(t, root)
+}
+
+// Case B: canonical live, legacy scaffold-only → legacy moved aside, NOT rediscovered.
+func TestMigrateRetiresLegacyScaffold(t *testing.T) {
+	root := t.TempDir()
+	mkLoop(t, root, legacyNamespace, false) // scaffold only
+	mkLoop(t, root, "agentchute", true)     // live canonical
+
+	action, _, err := applyMigration(t, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action == nil || action.Action != "retire legacy scaffold" {
+		t.Fatalf("expected retire action, got %+v", action)
+	}
+	// canonical state untouched
+	fileContains(t, filepath.Join(root, ".agentchute", "loop", "agents", "claude-code.md"), "registration")
+	if dirExists(filepath.Join(root, "."+legacyNamespace, "loop")) {
+		t.Errorf("legacy loop should be moved aside")
+	}
+	// The backup must NOT be rediscoverable as a vendor loop.
+	assertSingleLoop(t, root)
+}
+
+// Case C: canonical scaffold-only, legacy live → canonical backed up, legacy moved in.
+func TestMigratePromotesLegacyOverEmptyCanonical(t *testing.T) {
+	root := t.TempDir()
+	mkLoop(t, root, legacyNamespace, true) // live legacy
+	mkLoop(t, root, "agentchute", false)   // scaffold canonical
+
+	action, _, err := applyMigration(t, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if action == nil || action.Action != "migrate legacy loop" {
+		t.Fatalf("expected migrate action, got %+v", action)
+	}
+	fileContains(t, filepath.Join(root, ".agentchute", "loop", "agents", "claude-code.md"), "registration")
+	if dirExists(filepath.Join(root, "."+legacyNamespace, "loop")) {
+		t.Errorf("legacy loop should be gone")
+	}
+	assertSingleLoop(t, root)
+}
+
+// Case D: both live → refuse, no mutation.
+func TestMigrateRefusesWhenBothLive(t *testing.T) {
+	root := t.TempDir()
+	mkLoop(t, root, legacyNamespace, true)
+	mkLoop(t, root, "agentchute", true)
+
+	action, _, err := planLegacyMigration(root, "agentchute")
+	if err == nil {
+		t.Fatalf("expected refuse error, got action %+v", action)
+	}
+	if !strings.Contains(err.Error(), "live coordination state") {
+		t.Errorf("error should explain the live-both conflict, got: %v", err)
+	}
+	// Nothing moved.
+	if !dirExists(filepath.Join(root, "."+legacyNamespace, "loop")) || !dirExists(filepath.Join(root, ".agentchute", "loop")) {
+		t.Errorf("refuse must not mutate either loop dir")
+	}
+}
+
+// Symlinked legacy namespace is rejected.
+func TestMigrateRejectsSymlinkedNamespace(t *testing.T) {
+	root := t.TempDir()
+	realDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(realDir, "loop", "agents"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realDir, filepath.Join(root, "."+legacyNamespace)); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, _, err := planLegacyMigration(root, "agentchute"); err == nil {
+		t.Errorf("expected symlink rejection")
+	}
+}
+
+// computeInitPlan must not trip the ambiguity guard for a safe migration case,
+// and must include the migration action in the plan.
+func TestComputeInitPlanMigratesSafeCoexistence(t *testing.T) {
+	root := t.TempDir()
+	mkLoop(t, root, legacyNamespace, false) // scaffold legacy
+	mkLoop(t, root, "agentchute", true)     // live canonical
+
+	plan, err := computeInitPlan(root, "agentchute", false)
+	if err != nil {
+		t.Fatalf("computeInitPlan should not error for safe migration, got: %v", err)
+	}
+	found := false
+	for _, a := range plan.Actions {
+		if strings.HasPrefix(a.Action, "retire legacy") || strings.HasPrefix(a.Action, "migrate legacy") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("plan missing migration action: %+v", plan.Actions)
+	}
+}
+
+// assertSingleLoop verifies exactly one discoverable .<ns>/loop remains — the
+// canonical one — proving backups/aside-moves are not auto-discovered.
+func assertSingleLoop(t *testing.T, root string) {
+	t.Helper()
+	loops, err := findInitLoopDirs(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loops) != 1 || loops[0] != ".agentchute/loop" {
+		t.Errorf("expected exactly [.agentchute/loop], got %v", loops)
+	}
+}


### PR DESCRIPTION
## Problem

agentchute used the `.rehumanlabs/` namespace before the v0.2.2 rename to `.agentchute/`. Installs from that era leave a `.rehumanlabs/loop` behind. Discovery (`findVendorLoopDirs`) scans **every** `.<vendor>/loop`, so a leftover legacy loop either:

- collides with `.agentchute/loop` → `multiple vendor loop directories` failure (commands refuse), or
- is the only one found → the agent silently runs under `vendor=rehumanlabs`, orphaned from the canonical namespace.

## Fix

`planLegacyMigration` runs at the top of `computeInitPlan` (so both `agentchute setup` — which calls `init --yes` — and `agentchute init` get it), **before** the ambiguity guard, and is applied as a plan action so it shows in `--dry-run`:

| State | Action |
|---|---|
| canonical absent | rename `.rehumanlabs` → `.agentchute` (atomic; all state preserved) |
| canonical dir present, no loop | move `.rehumanlabs/loop` into place |
| legacy scaffold-only | move it aside (backup) |
| canonical scaffold-only, legacy live | back up empty canonical, promote legacy |
| **both hold live state** | **refuse** — operator consolidates by hand |

Design points (team consensus):
- **Back up the loop path, not the dotdir.** A `.rehumanlabs.backup-*/loop` would still be auto-discovered as a vendor loop; `.rehumanlabs/loop.backup-*` is not (basename ≠ `loop`). A test asserts exactly one discoverable loop remains.
- **Never auto-merge live state.** Collisions in `agents/inbox/state` carry semantics (lost mail / fabricated obligations). `--yes` applies only safe cases.
- **Liveness** ignores scaffold artifacts (`README.md`, `*.example.md`); real registrations/messages/state count.
- **Scope:** control repo only (no `$HOME` scan). Symlinked namespace/loop paths rejected (reuses `rejectSymlinkAncestor`).
- **install.sh stays thin** — next-step text only; no `mv`/merge in shell (the binary does the work).

## Testing

- `go test .` — 8 new migration tests pass (5 cases + idempotency + symlink guard + safe-coexistence guard path + backup-not-rediscovered). `TestInit*` / `TestTemplates*` still pass.
- `sh -n install.sh` clean.
- The 8 unrelated `defer`/`gate` failures are **pre-existing on `origin/main`** (date/time-bomb tests) — not introduced here.

## Scope / notes

The `reHuman Labs` credit in `README.md` / `web/index.html` is intentional maker attribution (brand, not namespace) and is left as-is. `prepare-pool` (separate plan path) is out of scope for this cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
