### PR TITLE
feat(wipe): clean wipe-and-reinstall (setup --reset --wipe-state + install.sh --fresh) [stacked on #5]

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,13 @@
 # available.
 #
 # Usage:
-#   sh install.sh [--version VERSION] [--to DIR] [--setup|--no-setup] [--wake MODE] [--dry-run]
+#   sh install.sh [--version VERSION] [--to DIR] [--setup|--no-setup] [--wake MODE] [--fresh] [--yes] [--dry-run]
 #   curl -fsSL https://raw.githubusercontent.com/agentchute/agentchute/main/install.sh | sh
+#
+# --fresh performs a DESTRUCTIVE clean reinstall: it installs the new binary and
+# then runs `agentchute setup --reset --wipe-state` to wipe loop runtime state
+# (the v0.7.0 -> v2 transition). In a non-interactive pipe it REFUSES unless you
+# explicitly confirm with --yes or AGENTCHUTE_YES=1.
 #
 # Equivalent env vars (flags win on conflict):
 #   AGENTCHUTE_VERSION       pin a specific tag (default: latest release)
@@ -15,8 +20,10 @@
 #   AGENTCHUTE_PROFILE       shell profile to update when PATH needs entries
 #   AGENTCHUTE_NO_PATH_UPDATE=1  do not update shell profile; print hints only
 #   AGENTCHUTE_SETUP=0       skip setup after install
-#   AGENTCHUTE_WAKE          pass --wake to setup (runner[,tmux][,herdr] | all)
+#   AGENTCHUTE_WAKE          pass --wake to setup (runner)
 #   AGENTCHUTE_WRAPPERS      pass --wrappers to setup (default: all)
+#   AGENTCHUTE_FRESH=1       DESTRUCTIVE clean reinstall (implies --setup, --wake runner)
+#   AGENTCHUTE_YES=1         confirm the destructive --fresh wipe non-interactively
 #   AGENTCHUTE_DRY_RUN=1     print the plan and exit; no mutation
 #
 # Security: this script verifies release checksums; piping the installer
@@ -374,12 +381,12 @@ print_setup_next_steps() {
 	info "next: run setup from the repo where your agents will coordinate:"
 	info "  agentchute setup"
 	info "then restart your agents; setup resets local agentchute runtime state"
-	info "and clears stale registrations/Herdr names so wrappers re-enroll cleanly"
+	info "and clears stale registrations so wrappers re-enroll cleanly"
 	info "optional check: agentchute doctor --as <agent-id>"
 	info "upgrading from an older release? re-run setup in each control repo to"
-	info "refresh ENROLLMENT blocks; setup also migrates a legacy .rehumanlabs/loop"
-	info "to .agentchute/loop automatically in safe cases and refuses to auto-merge"
-	info "if both hold live state."
+	info "refresh ENROLLMENT blocks. For a clean cutover to the pull-only protocol,"
+	info "'install.sh --fresh' (or 'agentchute setup --reset --wipe-state') wipes the"
+	info "old loop state and reinstalls fresh."
 }
 
 # ---------- main flow ----------
@@ -397,6 +404,10 @@ main() {
 	setup_wrappers="${AGENTCHUTE_WRAPPERS:-all}"
 	dry_run=0
 	[ "${AGENTCHUTE_DRY_RUN:-0}" = "1" ] && dry_run=1
+	fresh=0
+	[ "${AGENTCHUTE_FRESH:-0}" = "1" ] && fresh=1
+	assume_yes=0
+	[ "${AGENTCHUTE_YES:-0}" = "1" ] && assume_yes=1
 
 	# Flag parsing.
 	while [ $# -gt 0 ]; do
@@ -411,28 +422,35 @@ main() {
 			--wake=*)    setup_wake="${1#--wake=}" ;;
 			--wrappers)  shift; setup_wrappers="${1:-}"; [ -n "$setup_wrappers" ] || err "--wrappers requires a value" ;;
 			--wrappers=*) setup_wrappers="${1#--wrappers=}" ;;
+			--fresh)     fresh=1 ;;
+			--yes|-y)    assume_yes=1 ;;
 			--dry-run)   dry_run=1 ;;
 			-h|--help)
 				cat <<EOF
 agentchute install — fetches the latest release binary and installs it.
 
 usage:
-  sh install.sh [--version VERSION] [--to DIR] [--setup|--no-setup] [--wake MODE] [--wrappers SET] [--dry-run]
+  sh install.sh [--version VERSION] [--to DIR] [--setup|--no-setup] [--wake MODE] [--wrappers SET] [--fresh] [--yes] [--dry-run]
 
 flags:
   --version   pin a specific tag (default: latest release)
   --to DIR    install dir (default: ~/.local/bin)
   --setup     run \`agentchute setup\` after install (default when a tty exists)
   --no-setup  skip setup and print the command to run later
-  --wake MODE pass --wake to setup (runner[,tmux][,herdr] | all)
+  --wake MODE pass --wake to setup (runner)
   --wrappers  pass --wrappers to setup (default: all)
+  --fresh     DESTRUCTIVE clean reinstall: install, then run
+              \`agentchute setup --reset --wipe-state\` to wipe loop runtime
+              state. Implies --setup and --wake runner. Conflicts with
+              --no-setup. In a non-interactive pipe requires --yes/AGENTCHUTE_YES=1.
+  --yes, -y   confirm the destructive --fresh wipe (also via AGENTCHUTE_YES=1)
   --dry-run   print the plan and exit; no mutation
 
 env vars (flags override):
   AGENTCHUTE_VERSION, AGENTCHUTE_INSTALL_DIR, AGENTCHUTE_SHIM_DIR,
   AGENTCHUTE_PROFILE, AGENTCHUTE_NO_PATH_UPDATE=1,
   AGENTCHUTE_SETUP=0|1|auto, AGENTCHUTE_WAKE, AGENTCHUTE_WRAPPERS,
-  AGENTCHUTE_DRY_RUN=1
+  AGENTCHUTE_FRESH=1, AGENTCHUTE_YES=1, AGENTCHUTE_DRY_RUN=1
 EOF
 				return 0
 				;;
@@ -440,6 +458,34 @@ EOF
 		esac
 		shift
 	done
+
+	# Detect an interactive terminal once (used by the --fresh confirm gate and
+	# the setup invocation below).
+	have_tty=0
+	if ( : </dev/tty ) 2>/dev/null; then
+		have_tty=1
+	fi
+
+	# --fresh semantics: a DESTRUCTIVE clean reinstall. It implies --setup and
+	# defaults --wake to runner, and conflicts with --no-setup. In a
+	# non-interactive pipe it FAILS BEFORE any download unless the operator
+	# explicitly confirmed the wipe (--yes / AGENTCHUTE_YES=1) — --fresh alone is
+	# NOT enough in a pipe.
+	if [ "$fresh" = "1" ]; then
+		if [ "$do_setup" = "0" ]; then
+			err "--fresh conflicts with --no-setup: a fresh install must run setup to wipe state"
+		fi
+		do_setup=1
+		if [ -z "$setup_wake" ]; then
+			setup_wake="runner"
+		fi
+		if [ "$dry_run" != "1" ] && [ "$have_tty" != "1" ] && [ "$assume_yes" != "1" ]; then
+			err "--fresh performs a DESTRUCTIVE state wipe; refusing in a non-interactive pipe without explicit confirmation.
+  re-run with explicit confirmation, e.g.:
+    curl -fsSL https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/install.sh | AGENTCHUTE_FRESH=1 AGENTCHUTE_YES=1 sh
+    sh install.sh --fresh --yes"
+		fi
+	fi
 
 	probe_deps
 	sha_cmd=$(pick_sha256)
@@ -484,13 +530,23 @@ agentchute install
   setup:          $do_setup
   setup wake:     ${setup_wake:-prompt}
   setup wrappers: $setup_wrappers
+  fresh (wipe):   $fresh
 EOF
 
 	# --dry-run wins over setup (per codex). Still resolves version (network OK,
-	# just no mutation).
+	# just no mutation). For --fresh, also print the EXACT setup command that
+	# would run after the install — no install, no setup, no wipe in dry-run.
 	if [ "$dry_run" = "1" ]; then
 		info ""
 		info "(dry-run; no changes made)"
+		if [ "$fresh" = "1" ]; then
+			fresh_yes=""
+			[ "$assume_yes" = "1" ] && fresh_yes=" --yes"
+			info ""
+			info "--fresh would, after installing the new binary, run (DESTRUCTIVE):"
+			info "  agentchute setup --reset --wipe-state --shim-dir ${shim_dir:-${HOME:-}/.agentchute/bin} --wrappers $setup_wrappers --wake $setup_wake$fresh_yes"
+			info "  (wipes loop runtime state after stopping local processes; refuses a live bus)"
+		fi
 		return 0
 	fi
 
@@ -560,14 +616,26 @@ EOF
 	fi
 
 	if [ "$do_setup" = "1" ]; then
-		set -- setup --shim-dir "$shim_dir" --wrappers "$setup_wrappers"
-		if [ -n "$setup_wake" ]; then
-			set -- "$@" --wake "$setup_wake" --yes
+		if [ "$fresh" = "1" ]; then
+			# Fresh path: the NEW binary is already installed above; now drive the
+			# DESTRUCTIVE wipe THROUGH it. --wake is always set (defaulted to
+			# runner). Do NOT auto-pass setup --yes just because --wake is set —
+			# only pass it when the operator explicitly confirmed (--yes /
+			# AGENTCHUTE_YES=1); otherwise setup prints the wipe plan and prompts.
+			set -- setup --reset --wipe-state --shim-dir "$shim_dir" --wrappers "$setup_wrappers" --wake "$setup_wake"
+			if [ "$assume_yes" = "1" ]; then
+				set -- "$@" --yes
+			fi
+		else
+			set -- setup --shim-dir "$shim_dir" --wrappers "$setup_wrappers"
+			if [ -n "$setup_wake" ]; then
+				set -- "$@" --wake "$setup_wake" --yes
+			fi
 		fi
 		if [ "${AGENTCHUTE_NO_PATH_UPDATE:-0}" = "1" ]; then
 			set -- "$@" --no-profile
 		fi
-		if ! ( : </dev/tty ) 2>/dev/null && [ -z "$setup_wake" ]; then
+		if [ "$have_tty" != "1" ] && [ -z "$setup_wake" ]; then
 			info ""
 			warn "setup needs a tty when --wake is not provided; skipping setup"
 			warn "  run \`agentchute setup\` from your control repo"

--- a/internal/loop/lease.go
+++ b/internal/loop/lease.go
@@ -280,6 +280,31 @@ func VerifyFence(cfg *Config, id, token string) error {
 	return nil
 }
 
+// ReadServeClaim reads id's serve.claim (the serve-lease holder fact) without
+// taking the lease or any lock. An absent claim surfaces os.ErrNotExist; a
+// corrupt/invalid claim surfaces a parse error. Exported (read-only) for
+// cross-pool liveness checks such as `setup --wipe-state`, which must refuse to
+// wipe a bus that a FRESH claim on ANOTHER HOST still owns. The returned
+// ServeClaim's Host/LastSeen are the load-bearing fields for that check; pair
+// with ClaimIsStale to fold in the lease-timeout freshness rule.
+func ReadServeClaim(cfg *Config, id string) (*ServeClaim, error) {
+	if err := ValidateAgentID(id); err != nil {
+		return nil, err
+	}
+	return readClaim(claimPath(cfg, id))
+}
+
+// ClaimIsStale reports whether c is past the serve-lease timeout relative to
+// now (a future-dated last_seen reads as FRESH — failing closed is the safe
+// direction). Exported alongside ReadServeClaim so external liveness checks
+// apply the same freshness rule AcquireServeLease uses internally.
+func ClaimIsStale(c *ServeClaim, now time.Time) bool {
+	if c == nil {
+		return true
+	}
+	return claimIsStale(c, now)
+}
+
 // RenewLease is the heartbeat: under withAgentLock(id) it verifies our token
 // still owns the claim (ErrFenced if reclaimed) and bumps last_seen.
 func RenewLease(l *ServeLease) error {

--- a/setup.go
+++ b/setup.go
@@ -46,6 +46,8 @@ type setupOptions struct {
 	NoProfile   bool
 	Aliases     bool
 	InitNew     bool
+	Reset       bool
+	WipeState   bool
 }
 
 type setupGlobalState struct {
@@ -86,11 +88,18 @@ func cmdSetup(args []string) error {
 	fs.BoolVar(&opts.NoProfile, "no-profile", false, "do not edit shell profile; print PATH hint instead")
 	fs.BoolVar(&opts.Aliases, "aliases", false, "also install legacy same-name wrapper aliases")
 	fs.BoolVar(&opts.InitNew, "init", false, "allow setup to initialize a non-project directory")
+	fs.BoolVar(&opts.Reset, "reset", false, "explicitly run the runtime reset (always performed); required alongside --wipe-state")
+	fs.BoolVar(&opts.WipeState, "wipe-state", false, "DESTRUCTIVE: after reset, wipe loop runtime state (inbox/archive/malformed/live/scratch/state); requires --reset")
 	if err := fs.Parse(args); err != nil {
 		return setupUsage(err)
 	}
 	if fs.NArg() != 0 {
 		return setupUsage(fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")))
+	}
+	// --wipe-state is destructive; require the explicit --reset affirmation
+	// alongside it. Reject --wipe-state alone with a clear (non-help) error.
+	if opts.WipeState && !opts.Reset {
+		return fmt.Errorf("--wipe-state requires --reset: the destructive state wipe must be requested as `setup --reset --wipe-state`")
 	}
 
 	root, err := resolveSetupRoot(opts.ControlRepo)
@@ -141,6 +150,9 @@ func cmdSetup(args []string) error {
 
 	printSetupPlan(os.Stdout, root, opts, wrappers, detected)
 	if opts.DryRun {
+		if opts.WipeState {
+			printWipeStateDryRun(os.Stdout, root)
+		}
 		fmt.Println("\n(dry-run; no changes made)")
 		return nil
 	}
@@ -205,6 +217,15 @@ Flags:
   --no-profile           do not edit shell profile; print PATH hint instead
   --aliases              also install legacy same-name wrapper aliases
   --init                 allow initializing a non-project directory
+  --reset                explicitly run the runtime reset (always performed);
+                         required alongside --wipe-state
+  --wipe-state           DESTRUCTIVE: after reset, wipe loop runtime state
+                         (inbox/archive/malformed/live/scratch/state contents and
+                         live registrations) while preserving the committed
+                         scaffold and state/setup.json. Requires --reset; refuses
+                         a live bus. Use --dry-run to preview, --yes to skip the
+                         destructive confirm. Intended for the v0.7.0 -> v2
+                         transition.
   --dry-run              print plan without writing files
   --yes                  skip confirmation prompts
 `) + "\n"
@@ -489,7 +510,13 @@ func printSetupPlan(w io.Writer, root string, opts setupOptions, wrappers []stri
 		fmt.Fprintf(w, "  wrappers:     %s\n", strings.Join(wrappers, ", "))
 	}
 	fmt.Fprintf(w, "  init:         %s\n", filepath.Join(root, "AGENTCHUTE.md"))
-	fmt.Fprintln(w, "  reset:        stop local agentchute pollers/runners, clear live agents/*.md, release repo Herdr names")
+	if opts.WipeState {
+		fmt.Fprintln(w, "  reset:        DESTRUCTIVE wipe-state — stop local pollers/runners, then WIPE loop runtime")
+		fmt.Fprintln(w, "                state (inbox/archive/malformed/live/scratch/state) + live registrations;")
+		fmt.Fprintln(w, "                preserves scaffold + state/setup.json; refuses a live bus (prompts before deleting)")
+	} else {
+		fmt.Fprintln(w, "  reset:        stop local agentchute pollers/runners, clear live agents/*.md, release repo Herdr names")
+	}
 	if len(hookWrappers) > 0 {
 		fmt.Fprintln(w, "  hooks:        repo scope, force/idempotent")
 	}
@@ -755,10 +782,20 @@ func applySetup(root string, opts setupOptions, wrappers []string) error {
 		}
 
 		// Phase 3 — destructive runtime reset, LAST. By the time we reach here
-		// every recoverable write above has landed, so even if the reset (or a
-		// crash during it) fails partway, the bus retains its wake infrastructure
-		// (hooks/shims/enrollment) and a `setup` re-run recovers cleanly.
-		if err := setupRunRuntimeReset(root, cfg, wrappers); err != nil {
+		// every recoverable write above has landed (including state/setup.json), so
+		// even if the reset (or a crash during it) fails partway, the bus retains its
+		// wake infrastructure (hooks/shims/enrollment) and a `setup` re-run recovers
+		// cleanly. With --wipe-state the soft reset is REPLACED by the hard wipe: the
+		// wipe subsumes the soft reset (it stops local processes, clears live
+		// registrations and per-agent state) AND additionally clears inbox/archive/
+		// malformed/live contents, scratch dirs, and root runtime logs — while
+		// preserving state/setup.json and the committed scaffold, and failing closed
+		// on any live local process or fresh foreign-host presence.
+		if opts.WipeState {
+			if err := setupRunWipeState(root, cfg, wrappers, opts); err != nil {
+				return err
+			}
+		} else if err := setupRunRuntimeReset(root, cfg, wrappers); err != nil {
 			return err
 		}
 

--- a/setup_wipe.go
+++ b/setup_wipe.go
@@ -1,0 +1,838 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// setup_wipe.go — the DESTRUCTIVE `agentchute setup --reset --wipe-state` phase.
+//
+// This wipes ONLY the loop RUNTIME state (inbox/archive/malformed/live contents,
+// scratch dirs, root runtime logs, live agent registrations, and per-agent state)
+// after stopping local pool processes and proving the bus is not live. It is the
+// v0.7.0 -> v2 transition tool. Everything here is guarded HARD: it never
+// RemoveAll's the loop dir itself, never follows a symlink, never wipes a
+// non-canonical/overridden loop, and refuses outright if a live local process or
+// a fresh foreign-host presence/serve claim is detected.
+//
+// Scaffold preservation is by an explicit ALLOWLIST/NAME (README.md,
+// *.example.md, setup.json) — NOT by git-tracking, because an install may not be
+// in git.
+
+// wipeProcessWait is the bounded wait the wipe gives a SIGTERM'd local poller/
+// runner to exit before it re-verifies liveness. Longer than the soft reset's
+// 500ms because a destructive wipe must not race a still-shutting-down process.
+// Package var so tests can shrink it.
+var wipeProcessWait = 3 * time.Second
+
+// wipeRecreateDirs are the loop subdirectories that must exist (0700) after a
+// wipe. inbox/archive/malformed/live have their CONTENTS removed; agents/state
+// keep their allowlisted scaffold. All six are (re)created to guarantee a usable
+// post-wipe loop.
+var wipeRecreateDirs = []string{"inbox", "archive", "malformed", "live", "agents", "state"}
+
+// wipeLegacyNamespaceDotdirs is the EXPLICIT allowlist of pre-`.agentchute`
+// namespace dotdirs whose `<dotdir>/loop` may be removed by --wipe-state. Only
+// `.rehumanlabs` is concretely documented in this project's history (the original
+// brand namespace, removed in v0.2.2). Any OTHER dotdir that contains an
+// agentchute-loop sentinel is reported as "manual cleanup", never deleted.
+// Keep this list TIGHT: every entry is still subjected to the full per-candidate
+// guard (basename==loop, no symlink, sentinel present, under the control repo).
+var wipeLegacyNamespaceDotdirs = []string{
+	".rehumanlabs",
+}
+
+// wipeCategory is one grouped set of delete targets under a single parent
+// (e.g. all of inbox/). Preserved records the scaffold entries deliberately KEPT
+// in that parent, for the plan printout.
+type wipeCategory struct {
+	Name      string
+	Parent    string
+	Targets   []string
+	Preserved []string
+}
+
+// wipePlan is the fully-computed, pure (no-mutation) delete plan. Computing it
+// reads the tree; nothing is removed until executeWipePlan runs.
+type wipePlan struct {
+	LoopDir       string
+	ControlRepo   string
+	Categories    []wipeCategory
+	LegacyDirs    []string // verified legacy <dotdir>/loop dirs to RemoveAll
+	ManualCleanup []string // legacy-looking dotdirs reported, NOT deleted
+}
+
+// ---------- path guards ----------
+
+// validateWipePaths is the FIRST gate: it proves controlRepo + loopDir are safe
+// to operate on before any scan or deletion. Any violation is a HARD error.
+func validateWipePaths(controlRepo, loopDir string) error {
+	if strings.TrimSpace(controlRepo) == "" {
+		return fmt.Errorf("empty control repo")
+	}
+	if strings.TrimSpace(loopDir) == "" {
+		return fmt.Errorf("empty loop dir")
+	}
+	cr, err := filepath.Abs(filepath.Clean(controlRepo))
+	if err != nil {
+		return fmt.Errorf("resolve control repo %q: %w", controlRepo, err)
+	}
+	ld, err := filepath.Abs(filepath.Clean(loopDir))
+	if err != nil {
+		return fmt.Errorf("resolve loop dir %q: %w", loopDir, err)
+	}
+	switch ld {
+	case "", "/", ".":
+		return fmt.Errorf("refusing to wipe degenerate loop dir %q", ld)
+	}
+	if ld == cr {
+		return fmt.Errorf("refusing: loop dir %q equals the control repo", ld)
+	}
+	if ld == filepath.Dir(ld) {
+		return fmt.Errorf("refusing: loop dir %q is a filesystem root", ld)
+	}
+	// The loop parent (<repo>/.agentchute) must never itself be the wipe target.
+	canonical := filepath.Join(cr, fixedDotDirName, loopDirBaseName)
+	if ld == filepath.Dir(canonical) {
+		return fmt.Errorf("refusing: loop dir %q is the loop parent", ld)
+	}
+	// CANONICAL-ONLY: the loop MUST be exactly <controlRepo>/.agentchute/loop. An
+	// AGENTCHUTE_LOOP_DIR override pointing elsewhere fails closed — we never wipe
+	// an operator's bespoke loop location.
+	if ld != canonical {
+		return fmt.Errorf("loop dir %q is not the canonical %q; refusing to wipe a non-canonical or AGENTCHUTE_LOOP_DIR-overridden loop", ld, canonical)
+	}
+	// Reject symlinked control repo, .agentchute, and loop — a symlink anywhere in
+	// this chain could redirect deletion outside the project.
+	for _, p := range []string{cr, filepath.Join(cr, fixedDotDirName), ld} {
+		if err := rejectWipeSymlinkDir(p, true); err != nil {
+			return err
+		}
+	}
+	// Reject symlinked top-level runtime dirs. They are recreated/scanned, so a
+	// symlinked one would let us traverse out of the loop.
+	for _, sub := range wipeRecreateDirs {
+		if err := rejectWipeSymlinkDir(filepath.Join(ld, sub), false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// rejectWipeSymlinkDir lstat's p (never following) and fails if it is a symlink
+// or (when mustExist) absent / not a directory. When mustExist is false an
+// absent entry is fine (the runtime dir simply doesn't exist yet).
+func rejectWipeSymlinkDir(p string, mustExist bool) error {
+	info, err := os.Lstat(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if mustExist {
+				return fmt.Errorf("%s does not exist", p)
+			}
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", p, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink; refusing to wipe through it", p)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory; refusing", p)
+	}
+	return nil
+}
+
+const (
+	fixedDotDirName = ".agentchute"
+	loopDirBaseName = "loop"
+)
+
+// wipePathApproved is the per-target defense-in-depth check applied immediately
+// before each RemoveAll: the target must resolve under loopDir with no ".." and
+// its first path component must be an approved runtime dir or a recognized
+// loop-root leftover name. Legacy <dotdir>/loop dirs are NOT covered here (they
+// live outside loopDir and are guarded separately at plan time).
+func wipePathApproved(loopDir, target string) bool {
+	rel, err := filepath.Rel(loopDir, target)
+	if err != nil {
+		return false
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return false
+	}
+	parts := strings.Split(rel, string(os.PathSeparator))
+	switch parts[0] {
+	case "inbox", "archive", "malformed", "live", "agents", "state":
+		return true
+	}
+	if len(parts) == 1 && isWipeRootLeftoverName(parts[0]) {
+		return true
+	}
+	return false
+}
+
+// isWipeRootLeftoverName reports whether a loop-ROOT entry is a known runtime
+// leftover safe to delete: scratch dirs, the watchdog/poller/runner logs, and
+// stray sockets/pid files. Everything else at the loop root (README.md,
+// .gitignore, the runtime subdirs themselves) is preserved.
+func isWipeRootLeftoverName(name string) bool {
+	if strings.HasPrefix(name, "scratch-") {
+		return true
+	}
+	switch name {
+	case "watchdog.log", "poller.log", "runner.log":
+		return true
+	}
+	return strings.HasSuffix(name, ".sock") || strings.HasSuffix(name, ".pid")
+}
+
+// ---------- plan computation (pure) ----------
+
+// computeWipePlan scans the loop tree and builds the categorized delete plan.
+// It MUTATES NOTHING. A stat/permission error (other than not-exist) is a hard
+// failure here so the caller aborts BEFORE any deletion begins.
+func computeWipePlan(cfg *loop.Config, controlRepo string) (wipePlan, error) {
+	loopDir := cfg.LoopDir
+	plan := wipePlan{LoopDir: loopDir, ControlRepo: controlRepo}
+
+	// Full-contents categories: every entry under these dirs is runtime.
+	for _, name := range []string{"inbox", "archive", "malformed", "live"} {
+		cat, err := wipeContentsCategory(loopDir, name)
+		if err != nil {
+			return wipePlan{}, err
+		}
+		plan.Categories = append(plan.Categories, cat)
+	}
+	agentsCat, err := wipeAgentsCategory(loopDir)
+	if err != nil {
+		return wipePlan{}, err
+	}
+	plan.Categories = append(plan.Categories, agentsCat)
+
+	stateCat, err := wipeStateCategory(loopDir)
+	if err != nil {
+		return wipePlan{}, err
+	}
+	plan.Categories = append(plan.Categories, stateCat)
+
+	rootCat, err := wipeRootLeftoverCategory(loopDir)
+	if err != nil {
+		return wipePlan{}, err
+	}
+	plan.Categories = append(plan.Categories, rootCat)
+
+	legacy, manual, err := scanLegacyNamespaces(controlRepo)
+	if err != nil {
+		return wipePlan{}, err
+	}
+	plan.LegacyDirs = legacy
+	plan.ManualCleanup = manual
+	return plan, nil
+}
+
+func wipeReadDir(dir string) ([]os.DirEntry, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("scan %s: %w", dir, err)
+	}
+	return entries, nil
+}
+
+// wipeContentsCategory targets EVERY entry under <loop>/<name> (e.g. inbox/<id>
+// subdirs including their .claimed/). The parent dir is kept and recreated later.
+func wipeContentsCategory(loopDir, name string) (wipeCategory, error) {
+	dir := filepath.Join(loopDir, name)
+	entries, err := wipeReadDir(dir)
+	if err != nil {
+		return wipeCategory{}, err
+	}
+	cat := wipeCategory{Name: name, Parent: dir}
+	for _, e := range entries {
+		cat.Targets = append(cat.Targets, filepath.Join(dir, e.Name()))
+	}
+	sort.Strings(cat.Targets)
+	return cat, nil
+}
+
+// wipeAgentsCategory targets live registrations (agents/*.md) EXCEPT the
+// committed scaffold (README.md, *.example.md). Non-.md files and subdirs are
+// preserved.
+func wipeAgentsCategory(loopDir string) (wipeCategory, error) {
+	dir := filepath.Join(loopDir, "agents")
+	entries, err := wipeReadDir(dir)
+	if err != nil {
+		return wipeCategory{}, err
+	}
+	cat := wipeCategory{Name: "agents", Parent: dir}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			cat.Preserved = append(cat.Preserved, name+"/")
+			continue
+		}
+		if !strings.HasSuffix(name, ".md") || name == "README.md" || strings.HasSuffix(name, ".example.md") {
+			cat.Preserved = append(cat.Preserved, name)
+			continue
+		}
+		cat.Targets = append(cat.Targets, filepath.Join(dir, name))
+	}
+	sort.Strings(cat.Targets)
+	sort.Strings(cat.Preserved)
+	return cat, nil
+}
+
+// wipeStateCategory targets every state/ entry EXCEPT setup.json (the pool setup
+// state applySetup writes; deleting it would break future `agentchute update`/
+// resync).
+func wipeStateCategory(loopDir string) (wipeCategory, error) {
+	dir := filepath.Join(loopDir, "state")
+	entries, err := wipeReadDir(dir)
+	if err != nil {
+		return wipeCategory{}, err
+	}
+	cat := wipeCategory{Name: "state", Parent: dir}
+	for _, e := range entries {
+		name := e.Name()
+		if name == "setup.json" {
+			cat.Preserved = append(cat.Preserved, name)
+			continue
+		}
+		cat.Targets = append(cat.Targets, filepath.Join(dir, name))
+	}
+	sort.Strings(cat.Targets)
+	sort.Strings(cat.Preserved)
+	return cat, nil
+}
+
+// wipeRootLeftoverCategory targets scratch-* dirs and runtime logs/sockets at the
+// loop ROOT. It skips the runtime subdirs (handled by their own categories) and
+// the scaffold (README.md/.gitignore/AGENTCHUTE.md); any OTHER unrecognized
+// root entry is preserved (and reported), never deleted.
+func wipeRootLeftoverCategory(loopDir string) (wipeCategory, error) {
+	entries, err := wipeReadDir(loopDir)
+	if err != nil {
+		return wipeCategory{}, err
+	}
+	cat := wipeCategory{Name: "loop-root", Parent: loopDir}
+	for _, e := range entries {
+		name := e.Name()
+		switch name {
+		case "inbox", "archive", "malformed", "live", "agents", "state",
+			"README.md", ".gitignore", "AGENTCHUTE.md":
+			continue
+		}
+		if isWipeRootLeftoverName(name) {
+			cat.Targets = append(cat.Targets, filepath.Join(loopDir, name))
+		} else {
+			cat.Preserved = append(cat.Preserved, name)
+		}
+	}
+	sort.Strings(cat.Targets)
+	sort.Strings(cat.Preserved)
+	return cat, nil
+}
+
+// ---------- legacy namespace handling ----------
+
+// scanLegacyNamespaces inspects the control repo's dotdirs for pre-`.agentchute`
+// loops. An allowlisted dotdir (wipeLegacyNamespaceDotdirs) whose <dotdir>/loop
+// passes every per-candidate guard is returned for deletion; any OTHER dotdir
+// that merely LOOKS like an agentchute loop is returned as a manual-cleanup
+// report and never deleted.
+func scanLegacyNamespaces(controlRepo string) (legacy []string, manual []string, err error) {
+	entries, rerr := os.ReadDir(controlRepo)
+	if rerr != nil {
+		return nil, nil, fmt.Errorf("scan control repo %q: %w", controlRepo, rerr)
+	}
+	allow := map[string]bool{}
+	for _, d := range wipeLegacyNamespaceDotdirs {
+		allow[d] = true
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, ".") || name == fixedDotDirName {
+			continue
+		}
+		// DirEntry.IsDir() is false for a symlink-to-dir (no following), so a
+		// symlinked dotdir is naturally excluded from the dir scan below.
+		if !e.IsDir() {
+			continue
+		}
+		loopCandidate := filepath.Join(controlRepo, name, loopDirBaseName)
+		if !looksLikeAgentchuteLoop(loopCandidate) {
+			continue
+		}
+		if !allow[name] {
+			manual = append(manual, fmt.Sprintf("%s (unknown legacy namespace with an agentchute loop; manual cleanup)", filepath.Join(name, loopDirBaseName)))
+			continue
+		}
+		if reason := validateLegacyCandidate(controlRepo, loopCandidate); reason != "" {
+			manual = append(manual, fmt.Sprintf("%s (%s)", filepath.Join(name, loopDirBaseName), reason))
+			continue
+		}
+		legacy = append(legacy, loopCandidate)
+	}
+	sort.Strings(legacy)
+	sort.Strings(manual)
+	return legacy, manual, nil
+}
+
+// validateLegacyCandidate runs the full per-candidate guard. Returns "" when the
+// candidate is safe to RemoveAll, or a human reason when it must be skipped.
+func validateLegacyCandidate(controlRepo, loopCandidate string) string {
+	abs, err := filepath.Abs(filepath.Clean(loopCandidate))
+	if err != nil {
+		return "unresolvable path"
+	}
+	rel, err := filepath.Rel(controlRepo, abs)
+	if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+		return "not under the control repo"
+	}
+	if filepath.Base(abs) != loopDirBaseName {
+		return "basename is not \"loop\""
+	}
+	parentDot := filepath.Base(filepath.Dir(abs))
+	if parentDot == fixedDotDirName {
+		return "parent is the canonical .agentchute"
+	}
+	// No symlink on the dotdir or the loop dir itself.
+	if err := rejectWipeSymlinkDir(filepath.Dir(abs), true); err != nil {
+		return "namespace dir is a symlink or not a directory"
+	}
+	if err := rejectWipeSymlinkDir(abs, true); err != nil {
+		return "loop dir is a symlink or not a directory"
+	}
+	if !looksLikeAgentchuteLoop(abs) {
+		return "missing agentchute loop sentinel"
+	}
+	return ""
+}
+
+// looksLikeAgentchuteLoop is the legacy-loop sentinel: the dir must contain an
+// agents/ AND an inbox/ subdir AND a README.md whose text names agentchute. This
+// is deliberately strict so an unrelated `.something/loop` is never mistaken for
+// a coordination loop.
+func looksLikeAgentchuteLoop(dir string) bool {
+	if !isRealDir(filepath.Join(dir, "agents")) || !isRealDir(filepath.Join(dir, "inbox")) {
+		return false
+	}
+	data, err := readFileLimited(filepath.Join(dir, "README.md"), 64<<10)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(data)), "agentchute")
+}
+
+func isRealDir(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&os.ModeSymlink == 0 && info.IsDir()
+}
+
+func readFileLimited(path string, limit int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return io.ReadAll(io.LimitReader(f, limit))
+}
+
+// ---------- execution ----------
+
+// safeRemove deletes path WITHOUT ever following a symlink: a symlink or
+// non-directory entry is unlinked (os.Remove); a real directory is recursively
+// removed. An absent path is a no-op.
+func safeRemove(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return os.Remove(path)
+	}
+	return os.RemoveAll(path)
+}
+
+// executeWipePlan performs the deletions. Each runtime target is re-checked with
+// wipePathApproved (defense-in-depth) before removal. If deletion starts and
+// then fails, it collects the remaining/failed paths and returns a non-zero
+// error naming them.
+func executeWipePlan(plan wipePlan) error {
+	var failed []string
+	del := func(path string) {
+		if !wipePathApproved(plan.LoopDir, path) {
+			failed = append(failed, fmt.Sprintf("%s (rejected: not under an approved runtime dir)", path))
+			return
+		}
+		if err := safeRemove(path); err != nil {
+			failed = append(failed, fmt.Sprintf("%s (%v)", path, err))
+		}
+	}
+	for _, cat := range plan.Categories {
+		for _, t := range cat.Targets {
+			del(t)
+		}
+	}
+	for _, d := range plan.LegacyDirs {
+		// TOCTOU re-check: re-validate the legacy candidate right before removal.
+		if reason := validateLegacyCandidate(plan.ControlRepo, d); reason != "" {
+			failed = append(failed, fmt.Sprintf("%s (legacy re-check failed: %s)", d, reason))
+			continue
+		}
+		if err := os.RemoveAll(d); err != nil {
+			failed = append(failed, fmt.Sprintf("%s (%v)", d, err))
+		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("deletion failed for %d target(s); remaining: %s", len(failed), strings.Join(failed, "; "))
+	}
+	return nil
+}
+
+// recreateWipeDirs (re)creates the expected loop subdirs at 0700.
+func recreateWipeDirs(loopDir string) error {
+	for _, sub := range wipeRecreateDirs {
+		if err := loop.EnsurePrivateDir(filepath.Join(loopDir, sub)); err != nil {
+			return fmt.Errorf("recreate %s: %w", sub, err)
+		}
+	}
+	return nil
+}
+
+// rescanWipeLeftovers re-scans for runtime entries that REappeared after the
+// wipe — evidence that a process recreated state mid-wipe. Returns the offending
+// relative paths (empty == clean).
+func rescanWipeLeftovers(loopDir string) []string {
+	var leftovers []string
+	for _, name := range []string{"inbox", "archive", "malformed", "live"} {
+		entries, _ := os.ReadDir(filepath.Join(loopDir, name))
+		for _, e := range entries {
+			leftovers = append(leftovers, filepath.Join(name, e.Name()))
+		}
+	}
+	stateEntries, _ := os.ReadDir(filepath.Join(loopDir, "state"))
+	for _, e := range stateEntries {
+		if e.Name() == "setup.json" {
+			continue
+		}
+		leftovers = append(leftovers, filepath.Join("state", e.Name()))
+	}
+	sort.Strings(leftovers)
+	return leftovers
+}
+
+// ---------- live-bus refusal ----------
+
+// scanWipeLiveSignals is the READ-ONLY live-bus detector. It returns refusal
+// reasons (empty == safe to wipe) for: a still-alive local pool poller/runner,
+// an ambiguous local process recorded for this pool whose cmdline can't be
+// verified (FAIL CLOSED), an active local wrapper session, and any FRESH
+// presence (.live) or serve.claim owned by ANOTHER HOST.
+func scanWipeLiveSignals(cfg *loop.Config, agentIDs []string) []string {
+	var reasons []string
+	now := time.Now().UTC()
+	localHost := strings.TrimSpace(localHostname())
+
+	for _, id := range agentIDs {
+		if hb, err := loop.LoadPollerHeartbeat(cfg, id); err == nil {
+			if setupLocalHost(hb.Host) && hb.PID > 0 && setupProcessAlive(hb.PID) {
+				cmdline := setupProcessCommandLine(hb.PID)
+				if setupCommandMatches(cmdline, id, "poller run", cfg) {
+					reasons = append(reasons, fmt.Sprintf("live poller for %s (pid=%d) is still running; stop it before wiping", id, hb.PID))
+				} else {
+					reasons = append(reasons, fmt.Sprintf("ambiguous live process pid=%d recorded as poller for %s (cmdline did not match this pool); refusing (fail closed)", hb.PID, id))
+				}
+			}
+		}
+		if st, err := loop.LoadRunnerState(cfg, id); err == nil {
+			if setupLocalHost(st.Host) && st.RunnerPID > 0 && setupProcessAlive(st.RunnerPID) {
+				cmdline := setupProcessCommandLine(st.RunnerPID)
+				if setupCommandMatchesPool(cmdline, "run", cfg) && setupCommandHasAgentID(cmdline, id) {
+					reasons = append(reasons, fmt.Sprintf("live runner for %s (pid=%d) is still running; stop it before wiping", id, st.RunnerPID))
+				} else {
+					reasons = append(reasons, fmt.Sprintf("ambiguous live process pid=%d recorded as runner for %s (cmdline did not match this pool); refusing (fail closed)", st.RunnerPID, id))
+				}
+			}
+		}
+		if sess, err := loop.LoadActiveSession(cfg, id); err == nil {
+			if alive, reason := activeSessionAliveAtWithReason(sess, now); alive {
+				reasons = append(reasons, fmt.Sprintf("active wrapper session for %s (%s); close or restart it before wiping", id, reason))
+			}
+		}
+	}
+
+	reasons = append(reasons, scanWipeLivePresence(cfg, localHost, now)...)
+	reasons = append(reasons, scanForeignWipeServeClaims(cfg, localHost, now)...)
+	sort.Strings(reasons)
+	return reasons
+}
+
+// scanWipeLivePresence refuses on any FRESH .live presence fact that signals a
+// genuinely-live agent on this bus: a fresh fact owned by ANOTHER HOST (a shared
+// cross-host bus must not be wiped from one host), OR a fresh local fact whose
+// PID is still alive (a live agent — possibly outside the configured pool). A
+// fresh-but-dead local fact (e.g. a pool agent we just stopped, whose .live is
+// still inside the freshness window) does NOT block the wipe, because its PID is
+// no longer alive.
+func scanWipeLivePresence(cfg *loop.Config, localHost string, now time.Time) []string {
+	var out []string
+	entries, _ := os.ReadDir(filepath.Join(cfg.LoopDir, "live"))
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".live") {
+			continue
+		}
+		id := strings.TrimSuffix(name, ".live")
+		live, err := loop.ReadLive(cfg, id)
+		if err != nil {
+			continue
+		}
+		age := now.Sub(live.LastSeen.UTC())
+		if age < 0 {
+			age = 0
+		}
+		if age >= loop.LiveWindow() {
+			continue
+		}
+		h := strings.TrimSpace(live.Host)
+		if h != "" && localHost != "" && h != localHost {
+			out = append(out, fmt.Sprintf("fresh presence for %s on another host %q; refusing to wipe a shared live bus", id, h))
+			continue
+		}
+		if (h == "" || localHost == "" || h == localHost) && live.PID > 0 && setupProcessAlive(live.PID) {
+			out = append(out, fmt.Sprintf("fresh presence for %s from a live local agent (pid=%d); stop it before wiping", id, live.PID))
+		}
+	}
+	return out
+}
+
+// scanForeignWipeServeClaims refuses on any FRESH serve.claim held by another
+// host (the lease owner of an id lives elsewhere).
+func scanForeignWipeServeClaims(cfg *loop.Config, localHost string, now time.Time) []string {
+	var out []string
+	entries, _ := os.ReadDir(filepath.Join(cfg.LoopDir, "state"))
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		id := e.Name()
+		if loop.ValidateAgentID(id) != nil {
+			continue
+		}
+		claim, err := loop.ReadServeClaim(cfg, id)
+		if err != nil {
+			continue
+		}
+		if loop.ClaimIsStale(claim, now) {
+			continue
+		}
+		h := strings.TrimSpace(claim.Host)
+		if h != "" && localHost != "" && h != localHost {
+			out = append(out, fmt.Sprintf("fresh serve claim for %s held by another host %q; refusing to wipe a shared live bus", id, h))
+		}
+	}
+	return out
+}
+
+// wipeStopLocalProcesses SIGTERMs this pool's local pollers/runners (reusing the
+// soft-reset stop helpers, which only signal a cmdline-verified process) and
+// then waits up to wipeProcessWait for the recorded PIDs to exit. Returns the
+// ids stopped and any warnings, for the plan printout.
+func wipeStopLocalProcesses(cfg *loop.Config, agentIDs []string) (stopped, warnings []string) {
+	for _, id := range agentIDs {
+		if ok, warn := stopSetupPoller(cfg, id); warn != "" {
+			warnings = append(warnings, warn)
+		} else if ok {
+			stopped = append(stopped, id+" (poller)")
+		}
+		if ok, warn := stopSetupRunner(cfg, id); warn != "" {
+			warnings = append(warnings, warn)
+		} else if ok {
+			stopped = append(stopped, id+" (runner)")
+		}
+	}
+	deadline := time.Now().Add(wipeProcessWait)
+	for time.Now().Before(deadline) {
+		if wipeRecordedPIDsDead(cfg, agentIDs) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	sort.Strings(stopped)
+	sort.Strings(warnings)
+	return stopped, warnings
+}
+
+// wipeRecordedPIDsDead reports whether every local poller/runner PID recorded
+// for these ids is no longer alive.
+func wipeRecordedPIDsDead(cfg *loop.Config, agentIDs []string) bool {
+	for _, id := range agentIDs {
+		if hb, err := loop.LoadPollerHeartbeat(cfg, id); err == nil {
+			if setupLocalHost(hb.Host) && hb.PID > 0 && setupProcessAlive(hb.PID) {
+				return false
+			}
+		}
+		if st, err := loop.LoadRunnerState(cfg, id); err == nil {
+			if setupLocalHost(st.Host) && st.RunnerPID > 0 && setupProcessAlive(st.RunnerPID) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// ---------- plan printing ----------
+
+func printWipePlan(w io.Writer, plan wipePlan) {
+	fmt.Fprintln(w, "wipe-state plan (DESTRUCTIVE):")
+	fmt.Fprintf(w, "  control repo: %s\n", plan.ControlRepo)
+	fmt.Fprintf(w, "  loop dir:     %s\n", plan.LoopDir)
+	total := 0
+	for _, cat := range plan.Categories {
+		total += len(cat.Targets)
+		if len(cat.Targets) == 0 && len(cat.Preserved) == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "  %s/ (%s): delete %d entr%s\n", cat.Name, cat.Parent, len(cat.Targets), plural(len(cat.Targets)))
+		for _, t := range cat.Targets {
+			fmt.Fprintf(w, "      - %s\n", filepath.Base(t))
+		}
+		if len(cat.Preserved) > 0 {
+			fmt.Fprintf(w, "      preserved: %s\n", strings.Join(cat.Preserved, ", "))
+		}
+	}
+	if len(plan.LegacyDirs) > 0 {
+		fmt.Fprintf(w, "  legacy namespace loops (RemoveAll): %d\n", len(plan.LegacyDirs))
+		for _, d := range plan.LegacyDirs {
+			fmt.Fprintf(w, "      - %s\n", d)
+		}
+		total += len(plan.LegacyDirs)
+	}
+	if len(plan.ManualCleanup) > 0 {
+		fmt.Fprintln(w, "  manual cleanup (NOT deleted):")
+		for _, m := range plan.ManualCleanup {
+			fmt.Fprintf(w, "      - %s\n", m)
+		}
+	}
+	fmt.Fprintf(w, "  total delete targets: %d\n", total)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
+// ---------- orchestration ----------
+
+// setupRunWipeState is the destructive phase invoked LAST in applySetup when
+// --wipe-state is set. By this point every recoverable setup write (including
+// state/setup.json) has landed, so this only removes runtime state. It is a
+// package var so applySetup can call it and tests stay flexible.
+var setupRunWipeState = func(root string, cfg *loop.Config, wrappers []string, opts setupOptions) error {
+	if err := validateWipePaths(root, cfg.LoopDir); err != nil {
+		return fmt.Errorf("wipe-state: %w", err)
+	}
+
+	agentIDs, idWarnings := setupResetAgentIDs(root, cfg, wrappers)
+	for _, warn := range idWarnings {
+		fmt.Printf("warning: wipe-state: %s\n", warn)
+	}
+
+	stopped, stopWarnings := wipeStopLocalProcesses(cfg, agentIDs)
+	if len(stopped) > 0 {
+		fmt.Printf("stopped %d local process(es): %s\n", len(stopped), strings.Join(stopped, ", "))
+	}
+	for _, warn := range stopWarnings {
+		fmt.Printf("warning: wipe-state: %s\n", warn)
+	}
+
+	if reasons := scanWipeLiveSignals(cfg, agentIDs); len(reasons) > 0 {
+		return fmt.Errorf("wipe-state: refusing to wipe a live bus:\n  - %s", strings.Join(reasons, "\n  - "))
+	}
+
+	plan, err := computeWipePlan(cfg, root)
+	if err != nil {
+		return fmt.Errorf("wipe-state: %w", err)
+	}
+	printWipePlan(os.Stdout, plan)
+
+	if !opts.Yes {
+		ok, err := promptSetupConfirm("\nWipe the runtime state above? This is DESTRUCTIVE and cannot be undone. [y/N]: ")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("wipe-state: aborted by operator")
+		}
+	}
+
+	// RESCAN live signals after the confirm window, before any deletion.
+	if reasons := scanWipeLiveSignals(cfg, agentIDs); len(reasons) > 0 {
+		return fmt.Errorf("wipe-state: refusing to wipe; a live signal appeared during confirmation:\n  - %s", strings.Join(reasons, "\n  - "))
+	}
+
+	if err := executeWipePlan(plan); err != nil {
+		return fmt.Errorf("wipe-state: %w", err)
+	}
+	if err := recreateWipeDirs(cfg.LoopDir); err != nil {
+		return fmt.Errorf("wipe-state: %w", err)
+	}
+	if leftovers := rescanWipeLeftovers(cfg.LoopDir); len(leftovers) > 0 {
+		return fmt.Errorf("wipe-state: runtime files reappeared during the wipe (a live process may be writing): %s", strings.Join(leftovers, ", "))
+	}
+
+	fmt.Println("wipe-state: runtime state wiped; preserved scaffold (README.md, *.example.md) and state/setup.json.")
+	return nil
+}
+
+// printWipeStateDryRun prints the wipe plan for `setup --reset --wipe-state
+// --dry-run`. It MUTATES NOTHING: it discovers the loop (best-effort — a fresh
+// setup has no loop yet), validates the paths, prints the delete plan, and runs
+// the READ-ONLY live-bus detector (without stopping anything).
+func printWipeStateDryRun(w io.Writer, root string) {
+	cfg, err := loop.Discover(loop.DiscoverOpts{
+		ControlRepoFlag: root,
+		Cwd:             root,
+		EnvLoopDir:      os.Getenv("AGENTCHUTE_LOOP_DIR"),
+	})
+	if err != nil {
+		fmt.Fprintln(w, "\nwipe-state plan: no existing loop dir discovered yet; a fresh setup creates an empty loop, so there is nothing to wipe.")
+		return
+	}
+	if err := validateWipePaths(root, cfg.LoopDir); err != nil {
+		fmt.Fprintf(w, "\nwipe-state plan: cannot compute (%v)\n", err)
+		return
+	}
+	plan, err := computeWipePlan(cfg, root)
+	if err != nil {
+		fmt.Fprintf(w, "\nwipe-state plan: cannot compute (%v)\n", err)
+		return
+	}
+	fmt.Fprintln(w, "\n(the destructive wipe-state phase would run AFTER setup completes)")
+	printWipePlan(w, plan)
+
+	agentIDs, _ := setupResetAgentIDs(root, cfg, nil)
+	if reasons := scanWipeLiveSignals(cfg, agentIDs); len(reasons) > 0 {
+		fmt.Fprintln(w, "  live-bus check would REFUSE the wipe:")
+		for _, r := range reasons {
+			fmt.Fprintf(w, "      - %s\n", r)
+		}
+	} else {
+		fmt.Fprintln(w, "  live-bus check: no live local or foreign-host signals detected (re-verified at apply time).")
+	}
+}

--- a/setup_wipe_test.go
+++ b/setup_wipe_test.go
@@ -1,0 +1,396 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// newWipeTestRepo builds a control repo with a canonical .agentchute/loop and
+// returns the root + discovered config. Runtime dirs are created empty; callers
+// populate what they need.
+func newWipeTestRepo(t *testing.T) (string, *loop.Config) {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("AGENTCHUTE_CONTROL_REPO", "")
+	t.Setenv("AGENTCHUTE_LOOP_DIR", "")
+	mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
+	loopDir := filepath.Join(root, ".agentchute", "loop")
+	for _, sub := range []string{"agents", "inbox", "archive", "malformed", "live", "state"} {
+		mustMkdir(t, filepath.Join(loopDir, sub))
+	}
+	cfg, err := loop.Discover(loop.DiscoverOpts{ControlRepoFlag: root, Cwd: root})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	return root, cfg
+}
+
+func mustExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); err != nil {
+		t.Fatalf("expected %s to exist: %v", path, err)
+	}
+}
+
+func mustNotExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); err == nil {
+		t.Fatalf("expected %s to be gone", path)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("lstat %s: %v", path, err)
+	}
+}
+
+// ---------- path guards ----------
+
+func TestValidateWipePathsRejectsEmpty(t *testing.T) {
+	if err := validateWipePaths("", "/x/.agentchute/loop"); err == nil {
+		t.Fatal("empty control repo must be rejected")
+	}
+	if err := validateWipePaths("/x", ""); err == nil {
+		t.Fatal("empty loop dir must be rejected")
+	}
+}
+
+func TestValidateWipePathsRejectsRootAndDegenerate(t *testing.T) {
+	root, _ := newWipeTestRepo(t)
+	for _, ld := range []string{"/", ".", root} {
+		if err := validateWipePaths(root, ld); err == nil {
+			t.Fatalf("loop dir %q must be rejected", ld)
+		}
+	}
+}
+
+func TestValidateWipePathsRejectsNonCanonicalLoopOutsideRepo(t *testing.T) {
+	root, _ := newWipeTestRepo(t)
+	// A loop dir outside the control repo (a sibling tmp dir) is non-canonical.
+	other := t.TempDir()
+	outside := filepath.Join(other, ".agentchute", "loop")
+	mustMkdir(t, outside)
+	if err := validateWipePaths(root, outside); err == nil {
+		t.Fatal("loop dir outside the control repo must be rejected")
+	}
+	// A loop dir inside the repo but not at .agentchute/loop is non-canonical.
+	nonCanon := filepath.Join(root, ".other", "loop")
+	mustMkdir(t, nonCanon)
+	if err := validateWipePaths(root, nonCanon); err == nil {
+		t.Fatal("non-canonical in-repo loop dir must be rejected")
+	}
+}
+
+func TestValidateWipePathsRejectsSymlinkedLoop(t *testing.T) {
+	root, cfg := newWipeTestRepo(t)
+	// Replace the loop dir with a symlink to a real dir elsewhere.
+	if err := os.RemoveAll(cfg.LoopDir); err != nil {
+		t.Fatal(err)
+	}
+	target := t.TempDir()
+	if err := os.Symlink(target, cfg.LoopDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateWipePaths(root, cfg.LoopDir); err == nil {
+		t.Fatal("symlinked loop dir must be rejected")
+	}
+}
+
+func TestValidateWipePathsRejectsSymlinkedTopLevelRuntimeDir(t *testing.T) {
+	root, cfg := newWipeTestRepo(t)
+	inbox := filepath.Join(cfg.LoopDir, "inbox")
+	if err := os.RemoveAll(inbox); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(t.TempDir(), inbox); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateWipePaths(root, cfg.LoopDir); err == nil {
+		t.Fatal("symlinked top-level runtime dir must be rejected")
+	}
+}
+
+func TestValidateWipePathsAcceptsCanonical(t *testing.T) {
+	root, cfg := newWipeTestRepo(t)
+	if err := validateWipePaths(root, cfg.LoopDir); err != nil {
+		t.Fatalf("canonical loop must validate: %v", err)
+	}
+}
+
+// ---------- plan + execution ----------
+
+// populateRuntime fills the loop with runtime state + scaffold and returns the
+// scaffold paths that must survive a wipe.
+func populateRuntime(t *testing.T, cfg *loop.Config) (survive, gone []string) {
+	t.Helper()
+	ld := cfg.LoopDir
+	// scaffold (must survive)
+	survive = []string{
+		filepath.Join(ld, "README.md"),
+		filepath.Join(ld, "agents", "README.md"),
+		filepath.Join(ld, "agents", "claude-code.example.md"),
+		filepath.Join(ld, "state", "setup.json"),
+	}
+	for _, p := range survive {
+		mustWrite(t, p, []byte("scaffold"))
+	}
+	// runtime (must be gone)
+	gone = []string{
+		filepath.Join(ld, "agents", "claude-code.md"),
+		filepath.Join(ld, "inbox", "claude-code", "msg.md"),
+		filepath.Join(ld, "inbox", "claude-code", ".claimed", "c.md"),
+		filepath.Join(ld, "archive", "old.md"),
+		filepath.Join(ld, "malformed", "bad.md"),
+		filepath.Join(ld, "live", "claude-code.live"),
+		filepath.Join(ld, "state", "claude-code", "poller.json"),
+		filepath.Join(ld, "watchdog.log"),
+		filepath.Join(ld, "poller.log"),
+		filepath.Join(ld, "scratch-abc", "x"),
+	}
+	for _, p := range gone {
+		mustWrite(t, p, []byte("runtime"))
+	}
+	return survive, gone
+}
+
+func TestComputeAndExecuteWipePreservesScaffold(t *testing.T) {
+	root, cfg := newWipeTestRepo(t)
+	survive, gone := populateRuntime(t, cfg)
+
+	plan, err := computeWipePlan(cfg, root)
+	if err != nil {
+		t.Fatalf("computeWipePlan: %v", err)
+	}
+	if err := executeWipePlan(plan); err != nil {
+		t.Fatalf("executeWipePlan: %v", err)
+	}
+	if err := recreateWipeDirs(cfg.LoopDir); err != nil {
+		t.Fatalf("recreateWipeDirs: %v", err)
+	}
+
+	for _, p := range survive {
+		mustExist(t, p)
+	}
+	for _, p := range gone {
+		mustNotExist(t, p)
+	}
+	// scratch-abc directory itself must be gone (not just its child).
+	mustNotExist(t, filepath.Join(cfg.LoopDir, "scratch-abc"))
+	// runtime dirs recreated.
+	for _, sub := range []string{"inbox", "archive", "malformed", "live", "agents", "state"} {
+		mustExist(t, filepath.Join(cfg.LoopDir, sub))
+	}
+	if leftovers := rescanWipeLeftovers(cfg.LoopDir); len(leftovers) != 0 {
+		t.Fatalf("post-wipe leftovers: %v", leftovers)
+	}
+}
+
+func TestWipeStatePreservesSetupJSON(t *testing.T) {
+	root, cfg := newWipeTestRepo(t)
+	setupJSON := filepath.Join(cfg.LoopDir, "state", "setup.json")
+	mustWrite(t, setupJSON, []byte(`{"version":1}`))
+	// other per-agent state must be removed.
+	other := filepath.Join(cfg.LoopDir, "state", "claude-code", "pending-replies.json")
+	mustWrite(t, other, []byte("x"))
+
+	plan, err := computeWipePlan(cfg, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := executeWipePlan(plan); err != nil {
+		t.Fatal(err)
+	}
+	mustExist(t, setupJSON)
+	mustNotExist(t, filepath.Join(cfg.LoopDir, "state", "claude-code"))
+}
+
+// ---------- legacy namespace allowlist ----------
+
+func writeLegacyLoop(t *testing.T, root, dotdir string, sentinel bool) string {
+	t.Helper()
+	loopDir := filepath.Join(root, dotdir, "loop")
+	mustMkdir(t, filepath.Join(loopDir, "agents"))
+	mustMkdir(t, filepath.Join(loopDir, "inbox"))
+	if sentinel {
+		mustWrite(t, filepath.Join(loopDir, "README.md"), []byte("# agentchute loop"))
+	}
+	return loopDir
+}
+
+func TestScanLegacyNamespacesAllowlist(t *testing.T) {
+	root, _ := newWipeTestRepo(t)
+	allowed := writeLegacyLoop(t, root, ".rehumanlabs", true) // allowlisted + sentinel -> delete
+	unknown := writeLegacyLoop(t, root, ".somevendor", true)  // not allowlisted + sentinel -> manual
+	noSentinel := writeLegacyLoop(t, root, ".bare", false)    // looks like a loop dir but no agentchute marker -> skipped
+
+	legacy, manual, err := scanLegacyNamespaces(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(legacy) != 1 || legacy[0] != allowed {
+		t.Fatalf("expected legacy=[%s], got %v", allowed, legacy)
+	}
+	if len(manual) != 1 || !strings.Contains(manual[0], ".somevendor") {
+		t.Fatalf("expected one manual report for .somevendor, got %v", manual)
+	}
+	// the no-sentinel dir must appear in neither set.
+	for _, m := range manual {
+		if strings.Contains(m, ".bare") {
+			t.Fatalf("no-sentinel dir must not be reported: %v", manual)
+		}
+	}
+	_ = unknown
+	_ = noSentinel
+}
+
+func TestExecuteWipeRemovesAllowlistedLegacyLoop(t *testing.T) {
+	root, cfg := newWipeTestRepo(t)
+	legacyLoop := writeLegacyLoop(t, root, ".rehumanlabs", true)
+	plan, err := computeWipePlan(cfg, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := executeWipePlan(plan); err != nil {
+		t.Fatal(err)
+	}
+	mustNotExist(t, legacyLoop)
+	// the canonical loop survives (its contents wiped, dir intact handled elsewhere).
+	mustExist(t, cfg.LoopDir)
+}
+
+// ---------- live-bus refusal ----------
+
+func TestScanWipeLiveSignalsRefusesLiveRunner(t *testing.T) {
+	_, cfg := newWipeTestRepo(t)
+	const id = "claude-code"
+
+	if err := loop.SaveRunnerState(cfg, loop.RunnerState{
+		AgentID:   id,
+		Host:      localHostname(),
+		RunnerPID: 4242,
+		Status:    "running",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	oldAlive := setupProcessAlive
+	oldCmd := setupProcessCommandLine
+	setupProcessAlive = func(pid int) bool { return pid == 4242 }
+	setupProcessCommandLine = func(pid int) string {
+		return "/usr/local/bin/agentchute run " + id + " --as " + id + " --control-repo " + cfg.LoopDir
+	}
+	t.Cleanup(func() { setupProcessAlive = oldAlive; setupProcessCommandLine = oldCmd })
+
+	reasons := scanWipeLiveSignals(cfg, []string{id})
+	if len(reasons) == 0 {
+		t.Fatal("expected a refusal reason for a live runner")
+	}
+	joined := strings.Join(reasons, "\n")
+	if !strings.Contains(joined, "live runner") {
+		t.Fatalf("expected a live-runner reason, got: %s", joined)
+	}
+}
+
+func TestScanWipeLiveSignalsRefusesForeignHostPresence(t *testing.T) {
+	_, cfg := newWipeTestRepo(t)
+	const id = "codex"
+	mustWriteLiveAt(t, cfg, id, time.Now()) // mustWriteLiveAt stamps Host="test-host"
+	reasons := scanWipeLiveSignals(cfg, nil)
+	if len(reasons) == 0 || !strings.Contains(strings.Join(reasons, "\n"), "another host") {
+		t.Fatalf("expected a foreign-host presence refusal, got %v", reasons)
+	}
+}
+
+func TestSetupRunWipeStateRefusesLiveRunner(t *testing.T) {
+	root, cfg := newWipeTestRepo(t)
+	populateRuntime(t, cfg)
+	const id = "claude-code"
+	if err := loop.SaveRunnerState(cfg, loop.RunnerState{
+		AgentID:   id,
+		Host:      localHostname(),
+		RunnerPID: 4243,
+		Status:    "running",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	oldAlive := setupProcessAlive
+	oldCmd := setupProcessCommandLine
+	oldSig := setupSignalProcess
+	oldWait := wipeProcessWait
+	setupProcessAlive = func(pid int) bool { return pid == 4243 }
+	setupProcessCommandLine = func(pid int) string {
+		return "/usr/local/bin/agentchute run " + id + " --as " + id + " " + cfg.LoopDir
+	}
+	setupSignalProcess = func(pid int, sig os.Signal) error { return nil } // no-op: never signal a real pid
+	wipeProcessWait = time.Millisecond
+	t.Cleanup(func() {
+		setupProcessAlive = oldAlive
+		setupProcessCommandLine = oldCmd
+		setupSignalProcess = oldSig
+		wipeProcessWait = oldWait
+	})
+
+	err := setupRunWipeState(root, cfg, []string{id}, setupOptions{Yes: true})
+	if err == nil {
+		t.Fatal("setupRunWipeState must refuse when a live runner is present")
+	}
+	// nothing should have been deleted (refusal happens before execute).
+	mustExist(t, filepath.Join(cfg.LoopDir, "archive", "old.md"))
+}
+
+func TestSetupRunWipeStateHappyPath(t *testing.T) {
+	root, cfg := newWipeTestRepo(t)
+	survive, gone := populateRuntime(t, cfg)
+	oldWait := wipeProcessWait
+	wipeProcessWait = time.Millisecond
+	t.Cleanup(func() { wipeProcessWait = oldWait })
+
+	if err := setupRunWipeState(root, cfg, []string{"claude-code"}, setupOptions{Yes: true}); err != nil {
+		t.Fatalf("setupRunWipeState happy path: %v", err)
+	}
+	for _, p := range survive {
+		mustExist(t, p)
+	}
+	for _, p := range gone {
+		mustNotExist(t, p)
+	}
+}
+
+// ---------- cmdSetup flag wiring ----------
+
+func TestSetupWipeStateWithoutResetRejected(t *testing.T) {
+	err := cmdSetup([]string{"--wipe-state", "--wake", "runner", "--wrappers", "none"})
+	if err == nil || !strings.Contains(err.Error(), "requires --reset") {
+		t.Fatalf("expected --wipe-state-without-reset rejection, got %v", err)
+	}
+}
+
+func TestSetupWipeStateDryRunMutatesNothing(t *testing.T) {
+	root, cfg := newWipeTestRepo(t)
+	survive, gone := populateRuntime(t, cfg)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("AGENTCHUTE_LOOP_DIR", "")
+
+	withCwd(t, root, func() {
+		if err := cmdSetup([]string{
+			"--reset", "--wipe-state", "--dry-run",
+			"--control-repo", root,
+			"--wake", "runner",
+			"--wrappers", "none",
+			"--no-profile",
+		}); err != nil {
+			t.Fatalf("dry-run cmdSetup: %v", err)
+		}
+	})
+
+	// dry-run must not delete anything.
+	for _, p := range append(append([]string{}, survive...), gone...) {
+		mustExist(t, p)
+	}
+}


### PR DESCRIPTION
## Clean wipe-and-reinstall for the v0.7.0 → v2 transition

Follow-up to #5. Adds a **destructive, safety-gated** clean-slate path so an install can drop all old (push-era) protocol state and come up fresh on pull-only v2 — instead of carrying old-format data through the dual-read drain.

**Stacked on #5** (base `feat/simple-again-v2`; retarget to `main` after #5 merges). **Designed and reviewed by codex** (shell-safety + destructive-delete lane) — safety/shell review passed clean.

### `agentchute setup --reset --wipe-state`
Requires `--reset --wipe-state` together; destructive phase runs last in setup. Wipes loop **runtime only** — `inbox/*` (incl `.claimed/`), `archive/*`, `malformed/*`, `live/*`, `scratch-*`, root runtime logs/sock/pid, `agents/*.md` (except `README.md` + `*.example.md`), `state/*` (except **`setup.json`**, preserved so `update`/resync still works) — then recreates the dirs at 0700.

Safety guards before any `RemoveAll`: `--yes` or interactive confirm (`--dry-run` is read-only); abs/clean paths; **require the canonical `<repo>/.agentchute/loop`** (fails on an `AGENTCHUTE_LOOP_DIR` override); reject symlinked `.agentchute`/`loop`/runtime dirs; per-target `filepath.Rel` no `..`; **never `RemoveAll(loopDir)`**; hard-fail + remaining-paths on mid-wipe error; post-wipe rescan. Scaffold preserved by allowlist (not git). Legacy-namespace cleanup is allowlist + sentinel gated (`.rehumanlabs` only; unknown dotdirs reported, never deleted). **Live-bus refusal:** hard-fail on a live local runner/poller/wrapper for the pool (3s stop + verify dead), fail-closed on an ambiguous PID, refuse a foreign-host `.live`/`serve.claim` (don't wipe a shared bus).

### `install.sh --fresh`
Installs the new binary **first**, then runs `setup --reset --wipe-state`. Non-TTY / `curl|sh` **fails before download** unless `--yes`/`AGENTCHUTE_YES=1` (prints the exact safe command); `--dry-run` installs nothing. POSIX `set -eu`, no `eval`, no new `rm -rf`.

### Tests / checks
16 wipe tests (path/symlink/canonical guards, scaffold + `setup.json` preservation, legacy allowlist, live-runner + foreign-host refusal, dry-run no-op, `--wipe-state`-without-`--reset` rejected). `go build/vet/test` + `-race` + conformance + `shellcheck install.sh` + `tests/install_test.sh` all green.

**Stop before merge** — release is the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
