### PR TITLE
fix(conformance): free dedup key at consume-commit so post-consume resend re-lands [stacked on #5]

### DIFF
--- a/conformance/inbox_binding.go
+++ b/conformance/inbox_binding.go
@@ -119,6 +119,16 @@ func (b *inboxBinding) Consume(id string, handler func(Msg) error) (int, error) 
 		if len(b.inbox[id]) > 0 {
 			b.inbox[id] = b.inbox[id][1:]
 		}
+		// Post-consume the delivery slot is freed, so drop the EEXIST dedup key:
+		// a later resend of the SAME (to,from,seq) must RE-LAND, matching the real
+		// FS where EEXIST-as-no-op holds only pre-consume/pre-archive (once the file
+		// is archived, a re-landed copy relies on receiver-side Key/Deduper to
+		// collapse the duplicate effect — NOT on delivery dedup). Done at COMMIT
+		// only (after handler success + the crash check), so a crash before commit
+		// keeps the slot present and EEXIST remains a no-op (C1 at-least-once holds).
+		if msgs[i].Seq > 0 {
+			delete(b.delivered, fmt.Sprintf("%s|%s|%d", id, msgs[i].From, msgs[i].Seq))
+		}
 		b.seen[id] = time.Now() // a consume is also a liveness signal
 		b.mu.Unlock()
 		n++

--- a/conformance/inbox_postconsume_test.go
+++ b/conformance/inbox_postconsume_test.go
@@ -1,0 +1,55 @@
+package conformance
+
+import "testing"
+
+// TestInbox_PostConsumeResendRelandsThenKeyDedup pins the corrected post-consume
+// semantics for the INBOX binding: once a message is consumed+committed the inbox
+// slot is freed, so a later resend of the SAME (to,from,seq) must RE-LAND — it is
+// NOT suppressed by delivery (EEXIST) dedup forever. This matches the real FS,
+// where EEXIST-as-no-op holds only PRE-consume/pre-archive; after the file is
+// archived a re-landed copy relies on the RECEIVER's Key/Deduper to collapse the
+// duplicate EFFECT. (Before the fix the in-memory `delivered` map deduped forever,
+// over-optimistically green-lighting a post-consume dedup the FS does not provide.)
+//
+// Inbox-only on purpose: the shared-log binding legitimately retains a committed
+// delivery identity forever (the record stays in the append-only log), so this is
+// not run via eachBinding.
+func TestInbox_PostConsumeResendRelandsThenKeyDedup(t *testing.T) {
+	b := newInbox()
+	must(t, b.Register("bob"))
+
+	// Deliver seq=1 (Key k1), then consume + commit it.
+	must(t, b.Deliver("bob", Msg{From: "alice", Seq: 1, Key: "k1", Body: "do-it"}))
+	var acts []Msg
+	n, err := b.Consume("bob", func(m Msg) error { acts = append(acts, m); return nil })
+	must(t, err)
+	if n != 1 || len(acts) != 1 {
+		t.Fatalf("first consume must deliver exactly 1; n=%d acts=%d", n, len(acts))
+	}
+	if got, _ := b.Poll("bob"); len(got) != 0 {
+		t.Fatalf("inbox must be empty after consume+commit; saw %d", len(got))
+	}
+
+	// POST-CONSUME resend of the SAME (to,from,seq) must RE-LAND (the regression:
+	// pre-fix it was silently EEXIST-deduped and never re-landed).
+	if err := b.Deliver("bob", Msg{From: "alice", Seq: 1, Key: "k1", Body: "do-it"}); err != nil {
+		t.Fatalf("post-consume resend must re-land, got err: %v", err)
+	}
+	if got, _ := b.Poll("bob"); len(got) != 1 {
+		t.Fatalf("post-consume resend must be visible again (re-land); saw %d — delivery dedup wrongly suppressed it", len(got))
+	}
+
+	// The RECEIVER's Key/Deduper is what collapses the duplicate EFFECT across the
+	// original consume and the re-landed resend (both Key k1) -> exactly one effect.
+	d := NewDeduper()
+	effects := 0
+	apply := func(m Msg) error {
+		return d.Once(m, func(Msg) error { effects++; return nil })
+	}
+	must(t, apply(acts[0])) // the original, already consumed above
+	_, cerr := b.Consume("bob", apply)
+	must(t, cerr) // the re-landed resend
+	if effects != 1 {
+		t.Fatalf("receiver Key dedup must collapse original + post-consume resend to ONE effect; got %d", effects)
+	}
+}


### PR DESCRIPTION
## conformance harness: free the dedup key at consume-commit (post-consume resend re-lands)

Follow-up to #5. Found by the RFC writer reviewing the diff; fix spec'd and reviewed by codex. **Conformance-suite-only; no product code or protocol change.** Stacked on #5 (base `feat/simple-again-v2`; retarget to `main` after #5 merges).

### The bug (in the regression authority, not the product)
The in-tree conformance harness's **inbox binding** deduped delivery by `(to,from,seq)` **forever — including post-consume.** That over-tests reality: on the real FS, `EEXIST`-as-no-op holds only **pre-consume/pre-archive**; once a message is archived a re-landed resend **re-lands**, and the **receiver's `Key`/Deduper** is what collapses the duplicate effect. Left unfixed, the harness would green-light a post-consume delivery dedup the FS does not provide.

### Fix (`conformance/inbox_binding.go`)
At consume **COMMIT** (after handler success **and** after the crash-simulation point), if the consumed message has `Seq > 0`, delete its `(to,from,seq)` key from `delivered`. The delete is at COMMIT **only**, so a crash-before-commit keeps the slot present and `EEXIST` remains a no-op — **C1 at-least-once is unaffected**.

### Test (`conformance/inbox_postconsume_test.go`, inbox-only)
deliver `seq=1`/`Key k1` → consume+commit → resend the same `(to,from,seq)` **re-lands** (visible again) → a single receiver `Deduper` collapses original+resend to **one** effect. Not run via `eachBinding`: the shared-log binding legitimately retains a committed identity forever (the record stays in the append-only log).

### Checks
`cd conformance && go test ./...` green — all 7 invariants + `C1_AtLeastOnceIdempotent` + `C1_SenderCrashResume` + `D1_FsyncOrdering` + the new test; gofmt clean. codex (mandatory) **LGTM**.

**Stop before merge** — release is the owner's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
