### PR TITLE
ci(release): drop shellcheck examples/*.sh from release preflight

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,9 +46,6 @@ jobs:
         run: shellcheck -s sh install.sh
       - name: shellcheck tests/install_test.sh
         run: shellcheck -s sh tests/install_test.sh
-      - name: shellcheck examples/*.sh
-        # examples carry bash shebangs; let shellcheck honor them (no -s sh).
-        run: shellcheck examples/*.sh
       - name: run install_test.sh
         run: sh tests/install_test.sh
       - name: install GoReleaser


### PR DESCRIPTION
The example shell scripts were removed in the v0.8 cleanup, so `shellcheck examples/*.sh` hits an empty glob and exits 2 — which failed the v0.8.0 release preflight before goreleaser ran. This mirrors the same fix already applied to ci.yaml. After merge, the v0.8.0 tag moves to this commit and the release re-fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)