### PR TITLE
docs(compat): schedule deferred compat debt (COMPAT markers + AGENTCHUTE.md inventory)

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -178,7 +178,7 @@ Reply obligations are **owned by the asker**, not the recipient:
 - When the asker later consumes a reply whose `in_reply_to` references that `(to,from,seq)`, the obligation is cleared (idempotent).
 - The asker's gate surfaces **outstanding** and **expired** obligations as **non-blocking warnings**. An expired obligation is the asker-side dead-recipient signal: a dead recipient shows up twice over — the asker's expired `.owed` AND the recipient's stale `.live` — so the gate never deadlocks on a corpse.
 
-> **One-release compatibility (legacy recipient ledger still blocks).** The recipient-side `pending-replies.json` ledger is **legacy compat**: any entries *already on it* still block the recipient's finish gate for one release (until replied or deferred). But `check` no longer records a recipient-side obligation on consume — consuming a `reply_required` message records nothing on the recipient and merely **prints the reply-ref command** (`reply_required` is advisory on the wire; the binding obligation is the asker's `.owed`, §6.4/§6.6 above). So NEW `reply_required` consumes create no recipient-side blocker; only pre-existing ledger entries do. Making `.owed` the sole authority (and dropping the legacy recipient ledger) is a deferred follow-up.
+> **One-release compatibility (legacy recipient ledger still blocks).** The recipient-side `pending-replies.json` ledger is **legacy compat**: any entries *already on it* still block the recipient's finish gate for one release (until replied or deferred). But `check` no longer records a recipient-side obligation on consume — consuming a `reply_required` message records nothing on the recipient and merely **prints the reply-ref command** (`reply_required` is advisory on the wire; the binding obligation is the asker's `.owed`, §6.4/§6.6 above). So NEW `reply_required` consumes create no recipient-side blocker; only pre-existing ledger entries do. Making `.owed` the sole authority (and dropping the recipient ledger entirely) is a **future redesign item, not a scheduled removal** — it interacts with the recipient-side finish-gate block and needs a design pass to settle what must be preserved rather than a straight delete (see §13.1).
 
 ## 7. Coordination defaults
 
@@ -247,6 +247,21 @@ A well-formed canonical seq file is never quarantined (the dual-read lister reco
 - Coordinator/router agents.
 - Opt-in transcript export / shared-log audit profile (the `log` binding in [`conformance/`](conformance/) is the first-class opt-in profile).
 - Handshake / version negotiation beyond the registration `v:` field.
+
+### 13.1 Compatibility & deprecations (scheduled removals)
+
+One-release compatibility carried from v0.8.0. Each has an in-code `// COMPAT(remove-in: vX.Y[, gate: name]): …` marker so removal is a grep-delete, not a judgment call. **Re-listing is not retiring:** if a gated item's gate is unmet at its target branch-cut, escalate — do not silently re-defer.
+
+| Item | Location | Target | Gate |
+|------|----------|--------|------|
+| `message_id` frontmatter emission (wire identity is `(to,from,seq)`) | `internal/loop/message.go` (`ComposeMessage`) | v0.8.9 | migrate ALL readers off `message_id` first: reply threading (`--reply-to` + the recipient pending-reply ledger) AND the display-only readers (`boot`/`pending`/`self_poll`/`watch`/`sendResult`) → `(to,from,seq)` |
+| Legacy-nonce inbox reader + writer (dual-read/write of `<ts>_from-<s>_msg-<nonce>.md`) | `internal/loop/inbox.go` — READ: `inboxFilenameRE`/`inboxFilenameShapeRE`, `InferSenderFromFilename` legacy branch, `LegacyNonce` classifier, `ParseInboxFilename` legacy path, `CountLegacyNonce`; WRITE (test-only callers): `WriteInboxMessage`/`generateNonce`/`formatInboxFilename` (remove together — `WriteInboxMessage` calls `ParseInboxFilename`; migrate ~30 test fixtures) | v0.8.9 | **legacy-gauge-zero pool-wide, INCLUDING `.claimed/` residue** — extend `CountLegacyNonce` to scan `inbox/<id>/.claimed/` (`ListClaimedMessages`) first; it reads inbox listings only today, so a legacy message parked in `.claimed/` would make "zero" a false negative |
+| `run` verb → `serve` | `run.go` | `serve` ships v0.8.9 with `run` as a deprecated alias; alias removed the release after | `serve` shipped + one release elapsed |
+| `renderShimScript` (legacy shim generator) | `shims.go` | v0.8.9 | **none** — zero production callers; migrate its 3 test-fixture callers to inline legacy content |
+| `selectShimSpecs`/`shimInstallNames` selectors → static legacy-name list | `shims.go`, `setup.go` | v0.8.9 | **none** — behavior-preserving swap; the cleanup only needs the legacy `ac-*` name set, not generation logic |
+| `shims install --wrapper`/`--aliases` + `setup --aliases` no-op flags | `shims.go`, `setup.go` | after cutover | live pool confirmed running the `ac` dispatcher (v0.8.8+), not merely "dispatcher code exists" — old scripts/muscle-memory may still pass them |
+
+**Redesign-required — NOT a scheduled removal:** unifying the asker-owned `.owed` ledger with the recipient-side pending-reply ledger. `.owed` is asker-local and non-blocking; the recipient finish-gate block must stay recipient-local (peers never read each other's state dir). Making `.owed` the sole authority by *dropping* the recipient block would break the "never a silent hang" guarantee — any unification must **relocate** the block, not delete it. If trimming real duplication, target `PendingReplyEntry.message_id`. See the design note in `internal/loop/owed.go`.
 
 ## 14. Namespace
 State lives under the fixed `.agentchute/loop` directory. `AGENTCHUTE.md` is shared; reference-implementation notes live in `.agentchute/loop/README.md`. (Earlier drafts used a vendor-namespaced `.<vendor>/loop/` dotdir and a `.rehumanlabs/` legacy namespace; both are gone — the namespace is now fixed. `reHuman Labs` remains the maker's credit in `README.md`; that's brand, not a namespace.)

--- a/internal/loop/inbox.go
+++ b/internal/loop/inbox.go
@@ -57,6 +57,27 @@ var agentIDPattern = `[a-z0-9][a-z0-9-]*`
 // Timestamp: `YYYY-MM-DDTHH-MM-SS-uuuuuuZ` (`-` instead of `:` for fs portability;
 // microseconds zero-padded to 6 digits).
 // Nonce: 4 lowercase hex characters.
+//
+// COMPAT(remove-in: v0.8.9, gate: legacy-gauge-zero): this is the root of the
+// one-release legacy-nonce dual-read. Removable ONLY after every live inbox
+// reports zero legacy-named messages pool-wide — and the gauge must cover BOTH
+// inbox/<id>/ AND inbox/<id>/.claimed/ residue: CountLegacyNonce is fed only from
+// inbox listings today (gate.go/doctor.go), but a legacy message parked in
+// .claimed/ (post-claim crash or a blocked ack) would make "zero" a false
+// negative. Extend the gauge to .claimed (ListClaimedMessages/parseAnyInboxName)
+// before it can serve as this gate.
+//
+//	READ set:  inboxFilenameRE + inboxFilenameShapeRE, the legacy branch of
+//	           InferSenderFromFilename, the LegacyNonce:true classifier,
+//	           ParseInboxFilename's legacy path, CountLegacyNonce.
+//	WRITE set: WriteInboxMessage, generateNonce, formatInboxFilename — ZERO
+//	           production callers (prod send writes seq via seq.go); only ~30 test
+//	           fixtures use them. WriteInboxMessage calls ParseInboxFilename, so
+//	           READ+WRITE must be removed together (and the ~30 test sites migrated
+//	           to the seq writer or a test-only legacy fixture) or the build breaks.
+//
+// If the gauge is nonzero at branch-cut, DO NOT silently re-defer — escalate.
+// See AGENTCHUTE.md "Compatibility & Deprecations".
 var inboxFilenameRE = regexp.MustCompile(
 	`^(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{6}Z)_from-(` + agentIDPattern + `)_msg-([0-9a-f]{4})\.md$`,
 )

--- a/internal/loop/message.go
+++ b/internal/loop/message.go
@@ -27,6 +27,13 @@ func ComposeMessage(now time.Time, from, to, task, status, replyTo, body string)
 	_ = status // workflow vocabulary → body convention; not emitted (compat param).
 	var b strings.Builder
 	b.WriteString("---\n")
+	// COMPAT(remove-in: v0.8.9): message_id is compat-only frontmatter — the wire
+	// identity is (to, from, seq). Before removing, migrate every reader off it:
+	// (1) reply threading — --reply-to and the recipient pending-reply ledger key
+	// on message_id (FirstPendingByMessageID, defer.go); (2) display-only readers
+	// that print the id (boot.go, pending.go, self_poll.go, watch.go, and
+	// sendResult/reply_message_id) — swap them to the (to,from,seq) triple rather
+	// than blanking it. See AGENTCHUTE.md "Compatibility & Deprecations".
 	fmt.Fprintf(&b, "message_id: %s\n", FormatMessageID(now))
 	fmt.Fprintf(&b, "from: %s\n", from)
 	if replyTo != "" {

--- a/internal/loop/owed.go
+++ b/internal/loop/owed.go
@@ -24,6 +24,16 @@ import (
 // GATE 2: PURELY ADDITIVE. record-on-ask / clear-on-reply / expiry are wired
 // into send/check/gate in Gate 5; nothing here is wired yet.
 //
+// DESIGN NOTE — `.owed` is NOT a drop-in replacement for the recipient-side
+// pending-reply ledger's finish-gate block (ledger.go). Do NOT "make `.owed` the
+// sole reply-obligation authority" by dropping that block: `.owed` is
+// asker-owned and non-blocking, while the recipient's finish gate MUST block on
+// recipient-LOCAL state (peers never read each other's state dir) — so the block
+// cannot move to the asker's `.owed`. Removing it breaks the "never a silent
+// hang" guarantee. Any unification is a REDESIGN that relocates the block, not a
+// deletion; if trimming real duplication, target PendingReplyEntry.message_id.
+// See AGENTCHUTE.md "Compatibility & Deprecations".
+//
 // KEY: the primary key is the trusted committed identity MsgID{To,From,Seq} —
 // exactly as ledger.go keys on the trusted OriginalFilename rather than a
 // sender-asserted id. From == the asker (== the ledger owner); To == the


### PR DESCRIPTION
P1 from the post-v0.8.8 review. Pure additive (comments + spec); no behavior change.

- **AGENTCHUTE.md §13.1** — 'Compatibility & deprecations (scheduled removals)' table: each carried-over deferral + target version + gate, with a 're-listing is not retiring / escalate don't re-defer' rule.
- **`// COMPAT(remove-in: v0.8.9)`** at the `message_id` emission site (`message.go`), gated on migrating reply-threading off `message_id`.
- **`// COMPAT(remove-in: v0.8.9, gate: legacy-gauge-zero)`** at the legacy-nonce reader root (`inbox.go`), enumerating the full removable set.
- **owed.go design note** — `.owed` is NOT a drop-in for the recipient pending-reply finish-gate block (would break 'never a silent hang'); redesign that relocates the block, not a deletion. (sonnet's catch.)

Shims-generation cruft removal is listed in the table for **after** the live dispatcher cutover — separate PR (task #62), not batched here (codex's guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)