### PR TITLE
v0.9.0: rename launch verb run -> serve (run = deprecated alias 1 release; generic [agentchute] cue)

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -14,7 +14,7 @@
 
 A small convention for two or more agents (humans, AI assistants, or both) to coordinate through **shared inboxes**. Designed for explicit handoffs: agent X writes a message into agent Y's inbox; Y picks it up on its own cadence.
 
-Coordination is **pull-only**. A sender's sole responsibility is durable delivery — write the file. A sender NEVER pokes or wakes a recipient. Each recipient discovers its own mail by polling, and a wrapper that has no native polling loop is launched under the reference CLI's **runner** (`agentchute run`), a per-agent PTY supervisor that polls the agent's own inbox and injects a `check inbox` cue into the child when new mail arrives. This is a correctness choice, not a simplicity one: parent-child supervision is ground truth, whereas a published wake target (a socket, a tmux pane, a reachability cache) goes stale and lies. The previous push apparatus (watchdog, sender-side wake, wake adapters, reachability cache) is **deleted**.
+Coordination is **pull-only**. A sender's sole responsibility is durable delivery — write the file. A sender NEVER pokes or wakes a recipient. Each recipient discovers its own mail by polling, and a wrapper that has no native polling loop is launched under the reference CLI's **runner** (`agentchute serve`), a per-agent PTY supervisor that polls the agent's own inbox and injects a `check inbox` cue into the child when new mail arrives. This is a correctness choice, not a simplicity one: parent-child supervision is ground truth, whereas a published wake target (a socket, a tmux pane, a reachability cache) goes stale and lies. The previous push apparatus (watchdog, sender-side wake, wake adapters, reachability cache) is **deleted**.
 
 ### Protocol primitives (implementation-agnostic)
 
@@ -33,7 +33,7 @@ The protocol is a small set of implementation-agnostic primitives. Conforming im
 The reference CLI maps these primitives onto local filesystem choices on a shared filesystem:
 - **Inbox medium**: `.md` files under a fixed loop directory (`.agentchute/loop/inbox/<id>/`).
 - **Transport**: unique-temp + atomic `link()`-no-clobber (NFS-safe; `EEXIST` = already-delivered).
-- **Wake**: none on the wire. A loopless wrapper is supervised by `agentchute run`, which injects `[agentchute:run] check inbox` into the child's PTY when its OWN inbox poll sees new mail. The runner is local to the agent it supervises; it is not a sender-reachable endpoint.
+- **Wake**: none on the wire. A loopless wrapper is supervised by `agentchute serve`, which injects `[agentchute] check inbox` into the child's PTY when its OWN inbox poll sees new mail. The runner is local to the agent it supervises; it is not a sender-reachable endpoint.
 
 These are reference choices, not protocol requirements. Conforming implementations can swap the inbox medium and transport (see [`EXTENSIONS.md`](EXTENSIONS.md) and the alternate `log` binding in [`conformance/`](conformance/)) as long as no-overwrite per-recipient delivery and the seven invariants hold.
 
@@ -41,7 +41,7 @@ These are reference choices, not protocol requirements. Conforming implementatio
 
 ### In scope (v1)
 - **Pull-only inbox coordination** through per-recipient inboxes (§6).
-- **Per-agent supervision.** A loopless wrapper runs under `agentchute run` (PTY supervisor) for inbox polling and `check inbox` injection. No sender-side wake.
+- **Per-agent supervision.** A loopless wrapper runs under `agentchute serve` (PTY supervisor) for inbox polling and `check inbox` injection. No sender-side wake.
 - **Small shared-FS pool.** 2 to ~10 agents sharing one filesystem (single host, or multi-host over a shared/network mount). Beyond that, routing/role-election is required (v2).
 - **Substrate-defined pool locator.** _Reference CLI: a repo containing `AGENTCHUTE.md` and a `.agentchute/loop` directory._
 - **Free-form messages with optional structured envelope** (§6.4).
@@ -204,7 +204,7 @@ Identity is pool-scoped: `(pool_locator, agent_id)`. A physical process particip
 There is **no wake on the wire** and no sender-side poke. Discovery is recipient-side polling; the only question is what drives a given wrapper's poll.
 
 - **Native-loop wrappers** poll their own inbox on their own cadence (or at lifecycle boundaries via hooks).
-- **Loopless wrappers** run under the **runner** — `agentchute run -- <wrapper>` — a per-agent PTY supervisor. It launches the child under a PTY, acquires the serve lease (§5.4), polls the agent's OWN inbox each tick, writes `.live`, and injects `[agentchute:run] check inbox` into the child's PTY when new mail appears (respecting an idle/injection window so it doesn't interrupt mid-turn). It uses per-vendor submit bytes (e.g. bracketed-paste + enhanced-enter for codex) so the cue actually submits.
+- **Loopless wrappers** run under the **runner** — `agentchute serve -- <wrapper>` — a per-agent PTY supervisor. It launches the child under a PTY, acquires the serve lease (§5.4), polls the agent's OWN inbox each tick, writes `.live`, and injects `[agentchute] check inbox` into the child's PTY when new mail appears (respecting an idle/injection window so it doesn't interrupt mid-turn). It uses per-vendor submit bytes (e.g. bracketed-paste + enhanced-enter for codex) so the cue actually submits.
 
 The leading bracket in the injected cue is machine metadata; the model-facing instruction is `check inbox`. `setup --wake` installs the runner path only; the former tmux/herdr wake adapters and the runner receive-socket were removed in the pull-only redesign.
 
@@ -252,7 +252,7 @@ One-release compatibility carried from v0.8.0. Each has an in-code `// COMPAT(re
 
 | Item | Location | Target | Gate |
 |------|----------|--------|------|
-| `run` verb → `serve` | `run.go` | `serve` ships v0.8.9 with `run` as a deprecated alias; alias removed the release after | `serve` shipped + one release elapsed |
+| `run` verb → `serve` alias removal | `dispatch.go` (`commandHandlers["run"]`), `run.go` | v0.10.0 — `serve` shipped in v0.9.0 with `run` as a deprecated working alias (no stderr/stdout deprecation spam; the docs/help carry it); delete the `"run": cmdServe` alias entry and its `COMPAT` marker | one release elapsed since v0.9.0 (v0.10.0 branch-cut) |
 | `renderShimScript` (legacy shim generator) | `shims.go` | v0.8.9 | **none** — zero production callers; migrate its 3 test-fixture callers to inline legacy content |
 | `selectShimSpecs`/`shimInstallNames` selectors → static legacy-name list | `shims.go`, `setup.go` | v0.8.9 | **none** — behavior-preserving swap; the cleanup only needs the legacy `ac-*` name set, not generation logic |
 | `shims install --wrapper`/`--aliases` + `setup --aliases` no-op flags | `shims.go`, `setup.go` | after cutover | live pool confirmed running the `ac` dispatcher (v0.8.8+), not merely "dispatcher code exists" — old scripts/muscle-memory may still pass them |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file follows the [AGENTS.md](https://agents.md) convention. Any AI agent �
 
 ---
 
-<!-- agentchute-enrollment v18 begin -->
+<!-- agentchute-enrollment v19 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 **1. Setup / Startup Path**
@@ -14,16 +14,16 @@ Run `agentchute setup` once per control repo. `runner` is the only supported wak
 agentchute setup --wake runner --wrappers all --yes
 ```
 
-> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher (`ac run <wrapper>`).
+> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher (`ac serve <wrapper>`; `run` is a deprecated alias for `serve`, removed in v0.10.0).
 
-Start sessions with `ac run <wrapper>` from a control repo. The dispatcher routes through `agentchute run`, which registers you, acquires a serve lease (id-uniqueness + fencing token), refreshes `last_seen` and your `.live` presence, polls your OWN inbox, exports your resolved id as `AGENTCHUTE_AGENT_ID` into the wrapper, and injects `[agentchute:run] check inbox` when mail arrives. The runner publishes no wake target — peers never poke it (pull-only). Hookless wrappers such as Grok still need the dispatcher for startup because they have no lifecycle hook that can run `boot`; `ac run <wrapper>` enrolls them. Treat the bracketed prefix as machine metadata: the injection is only a CUE — you must actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"` to claim mail (then `ack` to commit); the runner does NOT consume it for you.
+Start sessions with `ac serve <wrapper>` from a control repo (`run` is a deprecated alias for `serve`, removed in v0.10.0). The dispatcher routes through `agentchute serve`, which registers you, acquires a serve lease (id-uniqueness + fencing token), refreshes `last_seen` and your `.live` presence, polls your OWN inbox, exports your resolved id as `AGENTCHUTE_AGENT_ID` into the wrapper, and injects `[agentchute] check inbox` when mail arrives. The runner publishes no wake target — peers never poke it (pull-only). Hookless wrappers such as Grok still need the dispatcher for startup because they have no lifecycle hook that can run `boot`; `ac serve <wrapper>` enrolls them. Treat the bracketed prefix as machine metadata: the injection is only a CUE — you must actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"` to claim mail (then `ack` to commit); the runner does NOT consume it for you.
 
 **The project is the communication boundary**: agents by default only see and talk to peers in the same discovered project pool. Unrelated projects on one host or tmux server are isolated because each project has its own pool and, when identity is not explicit, the CLI derives project-scoped IDs from the folder name (for example, `codex-agentchute`).
 
 If a session starts and you do not see agentchute boot/enrolled context, run the wrapper with its vendor so the CLI can derive the contextual identity:
 
 ```sh
-agentchute run --vendor <vendor> -- <wrapper>
+agentchute serve --vendor <vendor> -- <wrapper>
 ```
 
 As a manual fallback, pin your identity ONCE and then enroll under it before doing any work:
@@ -65,11 +65,11 @@ agentchute doctor --as <your-id>
 ```
 
 **2. Lifecycle Hooks (Required for Context and Gates)**
-`agentchute setup` installs lifecycle hooks for hook-capable wrappers. If you are not using setup, run `agentchute hooks install` once per control repo. Hooks surface inbox context per turn and block finish while unread mail remains. Hookless wrappers rely on the `ac` dispatcher (`ac run <wrapper>`) for startup enrollment.
+`agentchute setup` installs lifecycle hooks for hook-capable wrappers. If you are not using setup, run `agentchute hooks install` once per control repo. Hooks surface inbox context per turn and block finish while unread mail remains. Hookless wrappers rely on the `ac` dispatcher (`ac serve <wrapper>`) for startup enrollment.
 
 **3. Recipient Polling Fallback**
-Senders only deliver to your inbox (pull-only; nobody pokes you). If you are not launched through `agentchute run`, keep recipient polling alive so your `.live` presence stays fresh:
-- **Runner default**: `agentchute run --vendor <vendor> -- <wrapper>` polls your own inbox, keeps `.live` fresh, and injects the `check inbox` cue.
+Senders only deliver to your inbox (pull-only; nobody pokes you). If you are not launched through `agentchute serve`, keep recipient polling alive so your `.live` presence stays fresh:
+- **Runner default**: `agentchute serve --vendor <vendor> -- <wrapper>` polls your own inbox, keeps `.live` fresh, and injects the `check inbox` cue.
 - **Hook-managed fallback**: `agentchute poller ensure --as <id> --vendor <vendor>` starts/verifies heartbeat-only `poller run` and writes `state/<agent_id>/poller.json` + `.live`; it does not launch wrappers or consume mail unless explicitly run with `--launch`.
 - **Native loops**: if your wrapper has a recurring task feature, it may replace `poller run` only if it keeps a fresh heartbeat.
 
@@ -85,13 +85,13 @@ agentchute gate --before finish --as <your-id>
 The gate (read-only) blocks `finish` on unread direct mail or an unregistered self; it does NOT check `.live` at `finish`/`continue` (a stale/absent `.live` blocks only the `commit`/`release` gates). Reply obligations are asker-owned only: outstanding/expired `.owed` obligations surface as non-blocking warnings, and a `reply_required` message never blocks the recipient. Clear the gate by consuming mail with `agentchute check --as <your-id>` (then `ack`); reply to any message that needs one with `agentchute send --reply-to <ref>`.
 
 Hand-protocol path (no binary): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v18 end -->
+<!-- agentchute-enrollment v19 end -->
 
 ---
 
 ## What this is
 
-**agentchute** is a tiny **pull-only** coordination protocol for AI agents: per-recipient inboxes where senders only ever write files and never poke a recipient. A loopless wrapper is supervised by the runner (`agentchute run`), a per-agent PTY supervisor that polls the agent's own inbox and injects a `check inbox` cue. The reference implementation stores those inboxes as markdown files on a shared filesystem; alternate transports (queues, object stores, HTTP) are protocol-compatible but don't ship in the reference CLI (see [`EXTENSIONS.md`](EXTENSIONS.md)). Small Go codebase, mostly stdlib, with one PTY dependency for the runner. Ships via `go install` and pre-built binaries on GitHub Releases. MIT.
+**agentchute** is a tiny **pull-only** coordination protocol for AI agents: per-recipient inboxes where senders only ever write files and never poke a recipient. A loopless wrapper is supervised by the runner (`agentchute serve`), a per-agent PTY supervisor that polls the agent's own inbox and injects a `check inbox` cue. The reference implementation stores those inboxes as markdown files on a shared filesystem; alternate transports (queues, object stores, HTTP) are protocol-compatible but don't ship in the reference CLI (see [`EXTENSIONS.md`](EXTENSIONS.md)). Small Go codebase, mostly stdlib, with one PTY dependency for the runner. Ships via `go install` and pre-built binaries on GitHub Releases. MIT.
 
 The pitch is intentionally narrow: agents sharing one inbox medium (typically running side-by-side in tmux panes on the reference CLI's shared filesystem; optionally on different machines via a network mount) get a markdown-based mailbox so they stop copy-pasting handoffs by hand. That's the entire scope.
 
@@ -102,7 +102,7 @@ The pitch is intentionally narrow: agents sharing one inbox medium (typically ru
 3. `AGENTCHUTE.md` — the protocol spec. Source of truth for any reimplementation.
 4. `EXTENSIONS.md` — community-extension space (cross-folder enrollment, alternate substrates/transports, cross-pool agents); informs which changes belong in the core spec vs. an extension.
 5. `CONTRIBUTING.md` — PR process, style details, scope criteria, bug-report template.
-6. `examples/` — start at [`examples/README.md`](examples/README.md) (the index) and `examples/hooks/` (the per-wrapper lifecycle hook templates the installer wires). The tmux/wake/watchdog-era walkthrough scripts were removed in the pull-only redesign; the runner (`ac run <wrapper>`) flow lives in the root README quickstart.
+6. `examples/` — start at [`examples/README.md`](examples/README.md) (the index) and `examples/hooks/` (the per-wrapper lifecycle hook templates the installer wires). The tmux/wake/watchdog-era walkthrough scripts were removed in the pull-only redesign; the runner (`ac serve <wrapper>`) flow lives in the root README quickstart.
 
 ## Working rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,13 @@
 # CLAUDE.md
 
-<!-- agentchute-enrollment v18 begin -->
+<!-- agentchute-enrollment v19 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 Canonical enrollment spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
 
 **1. Pin your identity — once.** Base `agent_id=claude-code`, `vendor=anthropic`. Resolve your lane id ONCE at startup and reuse the SAME id on every call:
 
-- Launched via the `ac` dispatcher (`ac run <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
+- Launched via the `ac` dispatcher (`ac serve <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
 - Otherwise set it yourself, before `boot`:
 
 ```sh
@@ -31,9 +31,9 @@ agentchute setup --wake runner --wrappers claude-code --yes
 
 `--wrappers claude-code` is single-agent scope (just this wrapper); a shared multi-vendor pool uses `--wrappers all` (see [`AGENTS.md`](AGENTS.md)). `runner` is the only supported wake path: coordination is pull-only, so senders write your inbox and never poke you; the runner polls your own inbox and injects the cue. (The old tmux/herdr wake adapters were removed.)
 
-> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher. Start runner-mode sessions with `ac run <wrapper>`.
+> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher. Start runner-mode sessions with `ac serve <wrapper>` (`run` is a deprecated alias for `serve`, removed in v0.10.0).
 
-**Wake events** arrive as `[agentchute:run] check inbox`, injected by your own runner when it sees new mail in your inbox. The bracketed prefix is machine metadata; the instruction is `check inbox` — so actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"`. The runner injects the cue but does NOT auto-consume mail; `check` is what CLAIMS and displays your mail, and `ack` commits it.
+**Wake events** arrive as `[agentchute] check inbox`, injected by your own runner when it sees new mail in your inbox. The bracketed prefix is machine metadata; the instruction is `check inbox` — so actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"`. The runner injects the cue but does NOT auto-consume mail; `check` is what CLAIMS and displays your mail, and `ack` commits it.
 
 **If startup enrollment doesn't run** (rare; indicates a setup gap):
 
@@ -51,7 +51,7 @@ agentchute gate --before finish --as "$AGENTCHUTE_AGENT_ID"
 Consume unread mail with `agentchute check --as "$AGENTCHUTE_AGENT_ID"` (CLAIMS + displays — at-least-once; a crash before `ack` re-delivers), then `ack` to commit — that clears the finish gate (which blocks only on unread/malformed mail). Reply to any message that needs one with `agentchute send --reply-to <ref>`; reply obligations are asker-owned (`.owed`) and never block the recipient. The Stop hook runs `ack` then the gate for you.
 
 Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v18 end -->
+<!-- agentchute-enrollment v19 end -->
 
 ---
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,13 +1,13 @@
 # CODEX.md
 
-<!-- agentchute-enrollment v18 begin -->
+<!-- agentchute-enrollment v19 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 Canonical enrollment spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
 
 **1. Pin your identity — once.** Base `agent_id=codex`, `vendor=openai`. Resolve your lane id ONCE at startup and reuse the SAME id on every call:
 
-- Launched via the `ac` dispatcher (`ac run <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
+- Launched via the `ac` dispatcher (`ac serve <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
 - Otherwise set it yourself, before `boot`:
 
 ```sh
@@ -31,9 +31,9 @@ agentchute setup --wake runner --wrappers codex --yes
 
 `--wrappers codex` is single-agent scope (just this wrapper); a shared multi-vendor pool uses `--wrappers all` (see [`AGENTS.md`](AGENTS.md)). `runner` is the only supported wake path: coordination is pull-only, so senders write your inbox and never poke you; the runner polls your own inbox and injects the cue. (The old tmux/herdr wake adapters were removed.)
 
-> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher. Start runner-mode sessions with `ac run <wrapper>`.
+> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher. Start runner-mode sessions with `ac serve <wrapper>` (`run` is a deprecated alias for `serve`, removed in v0.10.0).
 
-**Wake events** arrive as `[agentchute:run] check inbox`, injected by your own runner when it sees new mail in your inbox. The bracketed prefix is machine metadata; the instruction is `check inbox` — so actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"`. The runner injects the cue but does NOT auto-consume mail; `check` is what CLAIMS and displays your mail, and `ack` commits it.
+**Wake events** arrive as `[agentchute] check inbox`, injected by your own runner when it sees new mail in your inbox. The bracketed prefix is machine metadata; the instruction is `check inbox` — so actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"`. The runner injects the cue but does NOT auto-consume mail; `check` is what CLAIMS and displays your mail, and `ack` commits it.
 
 **If startup enrollment doesn't run** (rare; indicates a setup gap):
 
@@ -51,7 +51,7 @@ agentchute gate --before finish --as "$AGENTCHUTE_AGENT_ID"
 Consume unread mail with `agentchute check --as "$AGENTCHUTE_AGENT_ID"` (CLAIMS + displays — at-least-once; a crash before `ack` re-delivers), then `ack` to commit — that clears the finish gate (which blocks only on unread/malformed mail). Reply to any message that needs one with `agentchute send --reply-to <ref>`; reply obligations are asker-owned (`.owed`) and never block the recipient. The Stop hook runs `ack` then the gate for you.
 
 Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v18 end -->
+<!-- agentchute-enrollment v19 end -->
 
 ---
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,13 +1,13 @@
 # GEMINI.md
 
-<!-- agentchute-enrollment v18 begin -->
+<!-- agentchute-enrollment v19 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 Canonical enrollment spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
 
 **1. Pin your identity — once.** Base `agent_id=gemini-cli`, `vendor=google`. Resolve your lane id ONCE at startup and reuse the SAME id on every call:
 
-- Launched via the `ac` dispatcher (`ac run <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
+- Launched via the `ac` dispatcher (`ac serve <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
 - Otherwise set it yourself, before `boot`:
 
 ```sh
@@ -31,9 +31,9 @@ agentchute setup --wake runner --wrappers gemini-cli --yes
 
 `--wrappers gemini-cli` is single-agent scope (just this wrapper); a shared multi-vendor pool uses `--wrappers all` (see [`AGENTS.md`](AGENTS.md)). `runner` is the only supported wake path: coordination is pull-only, so senders write your inbox and never poke you; the runner polls your own inbox and injects the cue. (The old tmux/herdr wake adapters were removed.)
 
-> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher. Start runner-mode sessions with `ac run <wrapper>`.
+> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher. Start runner-mode sessions with `ac serve <wrapper>` (`run` is a deprecated alias for `serve`, removed in v0.10.0).
 
-**Wake events** arrive as `[agentchute:run] check inbox`, injected by your own runner when it sees new mail in your inbox. The bracketed prefix is machine metadata; the instruction is `check inbox` — so actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"`. The runner injects the cue but does NOT auto-consume mail; `check` is what CLAIMS and displays your mail, and `ack` commits it.
+**Wake events** arrive as `[agentchute] check inbox`, injected by your own runner when it sees new mail in your inbox. The bracketed prefix is machine metadata; the instruction is `check inbox` — so actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"`. The runner injects the cue but does NOT auto-consume mail; `check` is what CLAIMS and displays your mail, and `ack` commits it.
 
 **If startup enrollment doesn't run** (rare; indicates a setup gap):
 
@@ -51,7 +51,7 @@ agentchute gate --before finish --as "$AGENTCHUTE_AGENT_ID"
 Consume unread mail with `agentchute check --as "$AGENTCHUTE_AGENT_ID"` (CLAIMS + displays — at-least-once; a crash before `ack` re-delivers), then `ack` to commit — that clears the finish gate (which blocks only on unread/malformed mail). Reply to any message that needs one with `agentchute send --reply-to <ref>`; reply obligations are asker-owned (`.owed`) and never block the recipient. The Stop hook runs `ack` then the gate for you.
 
 Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v18 end -->
+<!-- agentchute-enrollment v19 end -->
 
 ---
 

--- a/GROK.md
+++ b/GROK.md
@@ -1,13 +1,13 @@
 # GROK.md
 
-<!-- agentchute-enrollment v18 begin -->
+<!-- agentchute-enrollment v19 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 Canonical enrollment spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
 
 **1. Pin your identity — once.** Base `agent_id=grok`, `vendor=xai`. Resolve your lane id ONCE at startup and reuse the SAME id on every call:
 
-- Launched via the `ac` dispatcher (`ac run <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
+- Launched via the `ac` dispatcher (`ac serve <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
 - Otherwise set it yourself, before `boot`:
 
 ```sh
@@ -31,9 +31,9 @@ agentchute setup --wake runner --wrappers grok --yes
 
 `--wrappers grok` is single-agent scope (just this wrapper); a shared multi-vendor pool uses `--wrappers all` (see [`AGENTS.md`](AGENTS.md)). `runner` is the only supported wake path: coordination is pull-only, so senders write your inbox and never poke you; the runner polls your own inbox and injects the cue. (The old tmux/herdr wake adapters were removed.)
 
-> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher. Start runner-mode sessions with `ac run <wrapper>`.
+> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher. Start runner-mode sessions with `ac serve <wrapper>` (`run` is a deprecated alias for `serve`, removed in v0.10.0).
 
-**Wake events** arrive as `[agentchute:run] check inbox`, injected by your own runner when it sees new mail in your inbox. The bracketed prefix is machine metadata; the instruction is `check inbox` — so actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"`. The runner injects the cue but does NOT auto-consume mail; `check` is what CLAIMS and displays your mail, and `ack` commits it.
+**Wake events** arrive as `[agentchute] check inbox`, injected by your own runner when it sees new mail in your inbox. The bracketed prefix is machine metadata; the instruction is `check inbox` — so actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"`. The runner injects the cue but does NOT auto-consume mail; `check` is what CLAIMS and displays your mail, and `ack` commits it.
 
 **If startup enrollment doesn't run** (rare; indicates a setup gap):
 
@@ -51,13 +51,13 @@ agentchute gate --before finish --as "$AGENTCHUTE_AGENT_ID"
 Consume unread mail with `agentchute check --as "$AGENTCHUTE_AGENT_ID"` (CLAIMS + displays — at-least-once; a crash before `ack` re-delivers), then `ack` to commit — that clears the finish gate (which blocks only on unread/malformed mail). Reply to any message that needs one with `agentchute send --reply-to <ref>`; reply obligations are asker-owned (`.owed`) and never block the recipient. The Stop hook runs `ack` then the gate for you.
 
 Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v18 end -->
+<!-- agentchute-enrollment v19 end -->
 
 ---
 
 ## Grok-Specific Notes
 
-- **Startup/enrollment runs through the `ac` dispatcher, not lifecycle hooks.** The grok CLI has no repo hook system (no `settings.json`/`hooks.json`, no SessionStart/UserPromptSubmit/Stop events), so `agentchute setup --wrappers grok` installs the `ac` dispatcher and `ac run grok` routes through `agentchute run` to enroll you — there is no hook install. setup still installs the `ac` dispatcher for grok precisely because no lifecycle hook can run startup enrollment. `agentchute hooks install` has no grok target by design.
+- **Startup/enrollment runs through the `ac` dispatcher, not lifecycle hooks.** The grok CLI has no repo hook system (no `settings.json`/`hooks.json`, no SessionStart/UserPromptSubmit/Stop events), so `agentchute setup --wrappers grok` installs the `ac` dispatcher and `ac serve grok` routes through `agentchute serve` to enroll you — there is no hook install. setup still installs the `ac` dispatcher for grok precisely because no lifecycle hook can run startup enrollment. `agentchute hooks install` has no grok target by design.
 - Treat `AGENTCHUTE.md` as the wire-contract source of truth. If code behavior and spec text disagree, surface the mismatch before patching.
 - Standard pre-commit ritual from `AGENTS.md`: `gofmt -w .`, `go vet ./...`, `go test ./...`, `go build ./...`.
 - Use `.agentchute/loop/` for coordination. Check your inbox at turn start, archive consumed messages, and reply through agentchute or the documented file protocol.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ curl -fsSL https://raw.githubusercontent.com/agentchute/agentchute/main/install.
 > curl -fsSL https://raw.githubusercontent.com/agentchute/agentchute/main/install.sh | sh -s -- --fresh --yes --wake runner --wrappers all
 > ```
 >
-> Open a new shell (or `hash -r`) so the new `ac` dispatcher resolves (it installs at `~/.agentchute/bin/ac` and must precede the system `/usr/sbin/ac` on PATH). Verify with `ac doctor`, then restart each agent: `ac run claude`, `ac run codex`, … See [CHANGELOG](CHANGELOG.md).
+> Open a new shell (or `hash -r`) so the new `ac` dispatcher resolves (it installs at `~/.agentchute/bin/ac` and must precede the system `/usr/sbin/ac` on PATH). Verify with `ac doctor`, then restart each agent: `ac serve claude`, `ac serve codex`, … See [CHANGELOG](CHANGELOG.md).
 
 That's the reference CLI. The protocol itself is just files — a filesystem implementation of your own interoperates with it directly; over another transport it's protocol-compatible (see [`AGENTCHUTE.md`](AGENTCHUTE.md)).
 
@@ -32,7 +32,7 @@ That's the reference CLI. The protocol itself is just files — a filesystem imp
 
 ## The idea
 
-Every agent has an inbox — a directory. A message is a Markdown file dropped in it. The recipient reads its own inbox, on its own schedule. Delivery is best-effort; the message just waits until it's read. That's the whole protocol, and it works with **any terminal-based agent** — Claude Code, Codex, Gemini CLI, Grok, or your own — because the protocol depends on no vendor behavior. (The reference runner installs a single `ac` dispatcher — launch any of those four with `ac run <wrapper>`; any other terminal agent runs under the same runner or its own polling loop.)
+Every agent has an inbox — a directory. A message is a Markdown file dropped in it. The recipient reads its own inbox, on its own schedule. Delivery is best-effort; the message just waits until it's read. That's the whole protocol, and it works with **any terminal-based agent** — Claude Code, Codex, Gemini CLI, Grok, or your own — because the protocol depends on no vendor behavior. (The reference runner installs a single `ac` dispatcher — launch any of those four with `ac serve <wrapper>`; any other terminal agent runs under the same runner or its own polling loop.)
 
 ## What's in the protocol
 
@@ -73,10 +73,12 @@ curl -fsSL https://raw.githubusercontent.com/agentchute/agentchute/main/install.
 agentchute setup --wake runner --wrappers all --yes
 
 # 2. start each agent in its own terminal, with a pinned id so peers can address it
-AGENTCHUTE_AGENT_ID=claude-code ac run claude   # one terminal
-AGENTCHUTE_AGENT_ID=codex       ac run codex    # another terminal
-agentchute doctor --as codex                    # sanity-check (any terminal)
+AGENTCHUTE_AGENT_ID=claude-code ac serve claude   # one terminal
+AGENTCHUTE_AGENT_ID=codex       ac serve codex    # another terminal
+agentchute doctor --as codex                      # sanity-check (any terminal)
 ```
+
+`ac serve <wrapper>` is the launch verb; `ac run <wrapper>` still works as a deprecated alias (removed in v0.10.0).
 
 That's it — both agents are enrolled and polling their own inboxes. Coordination happens between them; you won't normally run `send`/`check`/`ack` yourself.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Concretely, on a shared `.agentchute/loop/`:
 
 - **Messages are unsigned plaintext.** There is no authentication, no signing, no encryption, and no sandbox. A message's `from` field is a self-asserted string.
 - **Any process with read/write access to the loop directory (or the repo) can read, delete, replay, or spoof messages** for any agent, and can read every agent's inbox, archive, and ledgers. Delivery is a filesystem `link()`; presence is a plaintext `.live` file.
-- **The runner launches operator-chosen argv.** `agentchute run` (and the `ac` dispatcher) launch the wrapper command the operator configured and inject `[agentchute:run] check inbox` cues into that wrapper's local PTY. There is no remote wake and no sender-reachable endpoint (coordination is pull-only), but a process that can write your inbox can cause you to be cued to read attacker-controlled content.
+- **The runner launches operator-chosen argv.** `agentchute serve` (and the `ac` dispatcher) launch the wrapper command the operator configured and inject `[agentchute] check inbox` cues into that wrapper's local PTY. There is no remote wake and no sender-reachable endpoint (coordination is pull-only), but a process that can write your inbox can cause you to be cued to read attacker-controlled content.
 - **Not suitable for hostile or multi-tenant hosts.** If untrusted code shares the machine, the user account, the repo, or the loop directory, it can fully compromise the pool.
 
 ### The rule

--- a/dispatch.go
+++ b/dispatch.go
@@ -22,17 +22,21 @@ var commandHandlers = map[string]func([]string) error{
 	"check":        cmdCheck,
 	"ack":          cmdAck,
 	"pending":      cmdPending,
-	"run":          cmdRun,
-	"setup":        cmdSetup,
-	"update":       cmdUpdate,
-	"self-check":   cmdSelfCheck,
-	"poller":       cmdPoller,
-	"default-id":   cmdIdentity,
-	"identity":     cmdIdentity,
-	"shims":        cmdShims,
-	"status":       cmdStatus,
-	"doctor":       cmdDoctor,
-	"hooks":        cmdHooks,
+	"serve":        cmdServe,
+	// COMPAT(remove-in: v0.10.0): "run" is a deprecated alias for "serve" (v0.9.0
+	// rename). Kept working for one release; no deprecation warning is printed so a
+	// supervised wrapper's PTY is never polluted. Delete this entry with the alias.
+	"run":        cmdServe,
+	"setup":      cmdSetup,
+	"update":     cmdUpdate,
+	"self-check": cmdSelfCheck,
+	"poller":     cmdPoller,
+	"default-id": cmdIdentity,
+	"identity":   cmdIdentity,
+	"shims":      cmdShims,
+	"status":     cmdStatus,
+	"doctor":     cmdDoctor,
+	"hooks":      cmdHooks,
 }
 
 // globalValueFlags are the leading flags the `ac` dispatcher accepts BEFORE the
@@ -51,7 +55,7 @@ type dispatchKind int
 
 const (
 	dispatchCommand dispatchKind = iota // route to an agentchute subcommand
-	dispatchRun                         // launch a wrapper under `run`
+	dispatchRun                         // launch a wrapper under `serve` (`run` is a deprecated alias)
 	dispatchHelp
 )
 
@@ -94,10 +98,10 @@ func splitLeadingGlobalFlags(args []string) (global, rest []string) {
 }
 
 // parseDispatch is the bounded, canonical-only `ac` parser (v0.8.8):
-//   - known command          -> route to it
-//   - run <wrapper> [args]    -> launch that wrapper
-//   - bare known wrapper      -> ERROR "use ac run <wrapper>"
-//   - unknown                 -> ERROR with suggestions
+//   - known command            -> route to it
+//   - serve <wrapper> [args]    -> launch that wrapper (`run` is a deprecated alias)
+//   - bare known wrapper        -> ERROR "use ac serve <wrapper>"
+//   - unknown                   -> ERROR with suggestions
 //
 // It performs NO arbitrary-PATH-executable inference; a command name always
 // wins over a same-named wrapper.
@@ -105,7 +109,7 @@ func parseDispatch(args []string) (dispatchPlan, error) {
 	global, rest := splitLeadingGlobalFlags(args)
 	if len(rest) == 0 {
 		if len(global) > 0 {
-			return dispatchPlan{}, fmt.Errorf("ac: expected a command or `run <wrapper>` after %s", strings.Join(global, " "))
+			return dispatchPlan{}, fmt.Errorf("ac: expected a command or `serve <wrapper>` after %s", strings.Join(global, " "))
 		}
 		return dispatchPlan{Kind: dispatchHelp}, nil
 	}
@@ -115,14 +119,16 @@ func parseDispatch(args []string) (dispatchPlan, error) {
 	switch sub {
 	case "-h", "--help", "help":
 		return dispatchPlan{Kind: dispatchHelp}, nil
-	case "run":
+	case "serve", "run":
+		// `serve` is the launch verb; `run` is a deprecated alias (removed in
+		// v0.10.0). Both dispatch a wrapper launch identically.
 		if len(subArgs) == 0 {
-			return dispatchPlan{}, fmt.Errorf("ac run <wrapper> — known wrappers: %s", strings.Join(knownWrapperTokens(), ", "))
+			return dispatchPlan{}, fmt.Errorf("ac serve <wrapper> — known wrappers: %s", strings.Join(knownWrapperTokens(), ", "))
 		}
 		token := subArgs[0]
 		spec, ok := wrapperForToken(token)
 		if !ok {
-			return dispatchPlan{}, fmt.Errorf("ac run: unknown wrapper %q — known: %s", token, strings.Join(knownWrapperTokens(), ", "))
+			return dispatchPlan{}, fmt.Errorf("ac serve: unknown wrapper %q — known: %s", token, strings.Join(knownWrapperTokens(), ", "))
 		}
 		return dispatchPlan{Kind: dispatchRun, Global: global, Wrapper: spec, WrapperArgs: subArgs[1:]}, nil
 	}
@@ -133,12 +139,12 @@ func parseDispatch(args []string) (dispatchPlan, error) {
 		return dispatchPlan{Kind: dispatchCommand, Global: global, Command: sub, CommandArgs: cmdArgs}, nil
 	}
 
-	// A bare wrapper token is canonical-only: require `ac run <wrapper>`.
+	// A bare wrapper token is canonical-only: require `ac serve <wrapper>`.
 	if _, ok := wrapperForToken(sub); ok {
-		return dispatchPlan{}, fmt.Errorf("`ac %s` launches a wrapper — use `ac run %s`", sub, sub)
+		return dispatchPlan{}, fmt.Errorf("`ac %s` launches a wrapper — use `ac serve %s`", sub, sub)
 	}
 
-	return dispatchPlan{}, fmt.Errorf("ac: unknown subcommand %q\n  commands: %s\n  wrappers: use `ac run <wrapper>` (%s)",
+	return dispatchPlan{}, fmt.Errorf("ac: unknown subcommand %q\n  commands: %s\n  wrappers: use `ac serve <wrapper>` (%s)",
 		sub, strings.Join(commandNamesSorted(), ", "), strings.Join(knownWrapperTokens(), ", "))
 }
 
@@ -186,7 +192,7 @@ func cmdDispatch(args []string) error {
 	return fmt.Errorf("ac: internal dispatch error")
 }
 
-// dispatchExecRun resolves the real wrapper binary and re-execs `agentchute run`
+// dispatchExecRun resolves the real wrapper binary and re-execs `agentchute serve`
 // for it, mirroring the generated-shim exec path (without an ac-* shim name).
 // shimDir (peeled from the dispatcher script's --shim-dir) is excluded from the
 // PATH search so a stale same-name alias shim there is never picked as the real
@@ -231,10 +237,10 @@ func dispatchExecRun(plan dispatchPlan, shimDir string) error {
 	return execReplace(agentchuteBin, runArgs, os.Environ())
 }
 
-// buildDispatchRunArgs assembles the `agentchute run` argv for a dispatcher
+// buildDispatchRunArgs assembles the `agentchute serve` argv for a dispatcher
 // launch, emitting exactly one authoritative --vendor/--control-repo/--loop-dir.
 func buildDispatchRunArgs(agentchuteBin, vendor string, forwardGlobal []string, controlRepo, loopDir string, wrapperArgs []string) []string {
-	runArgs := []string{agentchuteBin, "run", "--vendor", vendor}
+	runArgs := []string{agentchuteBin, "serve", "--vendor", vendor}
 	runArgs = append(runArgs, forwardGlobal...)
 	runArgs = append(runArgs,
 		"--control-repo", controlRepo,
@@ -283,9 +289,10 @@ func dispatchHelpText() string {
 	return fmt.Sprintf(`ac — the agentchute launcher/dispatcher
 
 Usage:
-  ac run <wrapper> [args...]   launch a wrapper under the runner (%s)
-  ac <command> [args...]       any agentchute command (%s)
+  ac serve <wrapper> [args...]   launch a wrapper under the runner (%s)
+  ac <command> [args...]         any agentchute command (%s)
 
-Global flags may precede the subcommand: ac --as <id> run codex
+Global flags may precede the subcommand: ac --as <id> serve codex
+(run is a deprecated alias for serve, removed in v0.10.0.)
 `, strings.Join(knownWrapperTokens(), ", "), strings.Join(commandNamesSorted(), ", "))
 }

--- a/dispatch_test.go
+++ b/dispatch_test.go
@@ -55,11 +55,15 @@ func TestParseDispatch_Run(t *testing.T) {
 		wantGlobal []string
 		wantWArgs  []string
 	}{
-		{"run by key", []string{"run", "codex"}, "codex", nil, []string{}},
-		{"run by alias agy", []string{"run", "agy"}, "gemini", nil, []string{}},
-		{"run with global flag (spaced)", []string{"--as", "x", "run", "codex"}, "codex", []string{"--as", "x"}, []string{}},
-		{"run with global flag (=)", []string{"--as=x", "run", "gemini", "--flag"}, "gemini", []string{"--as=x"}, []string{"--flag"}},
-		{"run with control-repo + loop-dir globals", []string{"--control-repo", "R", "--loop-dir", "D", "run", "codex"}, "codex", []string{"--control-repo", "R", "--loop-dir", "D"}, []string{}},
+		{"serve by key", []string{"serve", "codex"}, "codex", nil, []string{}},
+		{"serve by alias agy", []string{"serve", "agy"}, "gemini", nil, []string{}},
+		{"serve with global flag (spaced)", []string{"--as", "x", "serve", "codex"}, "codex", []string{"--as", "x"}, []string{}},
+		{"serve with global flag (=)", []string{"--as=x", "serve", "gemini", "--flag"}, "gemini", []string{"--as=x"}, []string{"--flag"}},
+		{"serve with control-repo + loop-dir globals", []string{"--control-repo", "R", "--loop-dir", "D", "serve", "codex"}, "codex", []string{"--control-repo", "R", "--loop-dir", "D"}, []string{}},
+		// `run` is the deprecated alias — it must launch identically to `serve`.
+		{"run alias by key", []string{"run", "codex"}, "codex", nil, []string{}},
+		{"run alias by wrapper alias agy", []string{"run", "agy"}, "gemini", nil, []string{}},
+		{"run alias with global flag", []string{"--as", "x", "run", "codex"}, "codex", []string{"--as", "x"}, []string{}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -89,13 +93,14 @@ func TestParseDispatch_Errors(t *testing.T) {
 		args    []string
 		wantSub string
 	}{
-		{"bare wrapper requires run", []string{"claude"}, "use `ac run claude`"},
-		{"bare wrapper alias requires run", []string{"agy"}, "use `ac run agy`"},
+		{"bare wrapper requires serve", []string{"claude"}, "use `ac serve claude`"},
+		{"bare wrapper alias requires serve", []string{"agy"}, "use `ac serve agy`"},
 		{"unknown subcommand", []string{"frobnicate"}, "unknown subcommand"},
-		{"run without wrapper", []string{"run"}, "ac run <wrapper>"},
-		{"run unknown wrapper", []string{"run", "nope"}, "unknown wrapper"},
+		{"serve without wrapper", []string{"serve"}, "ac serve <wrapper>"},
+		{"serve unknown wrapper", []string{"serve", "nope"}, "unknown wrapper"},
+		{"run alias without wrapper", []string{"run"}, "ac serve <wrapper>"},
+		{"run alias unknown wrapper", []string{"run", "nope"}, "unknown wrapper"},
 		{"global flag then nothing", []string{"--as", "x"}, "expected a command"},
-		{"serve is deferred, not a launch keyword", []string{"serve", "claude"}, "unknown subcommand"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -111,14 +116,17 @@ func TestParseDispatch_Errors(t *testing.T) {
 }
 
 func TestParseDispatch_CommandWinsOverWrapperName(t *testing.T) {
-	// "run" is both an agentchute command and the dispatcher launch keyword;
-	// the dispatcher must treat `ac run <wrapper>` as a launch, not cmdRun.
-	plan, err := parseDispatch([]string{"run", "grok"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if plan.Kind != dispatchRun || plan.Wrapper.Key != "grok" {
-		t.Fatalf("ac run grok => kind=%v key=%q; want launch of grok", plan.Kind, plan.Wrapper.Key)
+	// "serve" (and its deprecated alias "run") are both agentchute commands and the
+	// dispatcher launch keyword; the dispatcher must treat `ac serve <wrapper>` /
+	// `ac run <wrapper>` as a launch, not as cmdServe routed through the command path.
+	for _, verb := range []string{"serve", "run"} {
+		plan, err := parseDispatch([]string{verb, "grok"})
+		if err != nil {
+			t.Fatalf("ac %s grok: %v", verb, err)
+		}
+		if plan.Kind != dispatchRun || plan.Wrapper.Key != "grok" {
+			t.Fatalf("ac %s grok => kind=%v key=%q; want launch of grok", verb, plan.Kind, plan.Wrapper.Key)
+		}
 	}
 }
 
@@ -137,7 +145,7 @@ func TestParseDispatch_Help(t *testing.T) {
 func TestCommandHandlersCoverExpected(t *testing.T) {
 	// Guard against accidental removal: the dispatcher's known-command set must
 	// include the core operational commands.
-	for _, name := range []string{"check", "send", "ack", "doctor", "setup", "run", "status", "gate", "boot"} {
+	for _, name := range []string{"check", "send", "ack", "doctor", "setup", "serve", "run", "status", "gate", "boot"} {
 		if commandHandlers[name] == nil {
 			t.Errorf("commandHandlers missing %q", name)
 		}
@@ -221,7 +229,7 @@ func TestBuildDispatchRunArgs_SingleAuthoritativePair(t *testing.T) {
 	got := buildDispatchRunArgs("/bin/agentchute", "openai", []string{"--as", "reviewer"},
 		"/repo", "/repo/.agentchute/loop", []string{"/usr/bin/codex", "resume"})
 	want := []string{
-		"/bin/agentchute", "run", "--vendor", "openai", "--as", "reviewer",
+		"/bin/agentchute", "serve", "--vendor", "openai", "--as", "reviewer",
 		"--control-repo", "/repo", "--loop-dir", "/repo/.agentchute/loop", "--shim-name", "ac", "--",
 		"/usr/bin/codex", "resume",
 	}

--- a/docs/internal/HANDOFF.md
+++ b/docs/internal/HANDOFF.md
@@ -8,7 +8,7 @@ Read this after `AGENTS.md` and before touching anything. This file stays short 
 
 Latest release: **`v0.8.0`** — the "simple again" / protocol-v2 redesign.
 
-Coordination is **pull-only**: senders only ever write files and never poke a recipient. A loopless wrapper runs under the runner (`agentchute run`, launched via `ac run <wrapper>`) — a per-agent PTY supervisor that polls the agent's own inbox and injects a `check inbox` cue. There is no watchdog, no reachability cache, and no tmux/herdr wake adapters; those were removed. Message identity is the durable `(to, from, seq)` tuple; consumption is two-phase (`check` claims, `ack` commits — at-least-once, so handlers must be idempotent). Presence is the `.live` fact. Reply obligations are asker-owned (`.owed`). Id-uniqueness rides a serve lease + fencing token. The protocol's invariants ship as an executable suite in [`conformance/`](conformance/).
+Coordination is **pull-only**: senders only ever write files and never poke a recipient. A loopless wrapper runs under the runner (`agentchute serve`, launched via `ac serve <wrapper>`) — a per-agent PTY supervisor that polls the agent's own inbox and injects a `check inbox` cue. There is no watchdog, no reachability cache, and no tmux/herdr wake adapters; those were removed. Message identity is the durable `(to, from, seq)` tuple; consumption is two-phase (`check` claims, `ack` commits — at-least-once, so handlers must be idempotent). Presence is the `.live` fact. Reply obligations are asker-owned (`.owed`). Id-uniqueness rides a serve lease + fencing token. The protocol's invariants ship as an executable suite in [`conformance/`](conformance/).
 
 ## Source of truth
 

--- a/doctor.go
+++ b/doctor.go
@@ -373,13 +373,13 @@ func checkUnenrolledPresence(cfg *loop.Config) doctorCheck {
 	return doctorCheck{
 		Name:     "unenrolled_presence",
 		Severity: severityWarn,
-		Message:  fmt.Sprintf("%d wrapper(s) present in this pool but not enrolled: %s — enroll via the `ac` dispatcher (`ac run <wrapper>`) or `agentchute boot --as <id>`", len(found), strings.Join(parts, ", ")),
+		Message:  fmt.Sprintf("%d wrapper(s) present in this pool but not enrolled: %s — enroll via the `ac` dispatcher (`ac serve <wrapper>`) or `agentchute boot --as <id>`", len(found), strings.Join(parts, ", ")),
 	}
 }
 
 // checkLaunchProvenance is the WI-E3 detect-and-warn launch-bypass check. When
 // the runner wake path IS configured (setup installed the ac-* launchers and the
-// expected launch is `ac run <wrapper>` -> runner), it WARNS — never BLOCKS — if a
+// expected launch is `ac serve <wrapper>` -> runner), it WARNS — never BLOCKS — if a
 // wrapper is running raw:
 //
 //   - the agent's registration records launched_by=manual or has no provenance
@@ -389,7 +389,7 @@ func checkUnenrolledPresence(cfg *loop.Config) doctorCheck {
 //
 // This is ADVISORY by design (codex guardrail): it NEVER returns a BLOCKER, it
 // does NOT flip the runner default (runner stays opt-in), and it installs no
-// same-name shadowing — it only points the operator at `ac run <wrapper>`. Managed
+// same-name shadowing — it only points the operator at `ac serve <wrapper>`. Managed
 // enrollments (runner/hook/poller) and non-runner setups do not warn.
 func checkLaunchProvenance(cfg *loop.Config, agentID string, opts doctorOptions) doctorCheck {
 	const name = "launch_provenance"
@@ -411,7 +411,7 @@ func checkLaunchProvenance(cfg *loop.Config, agentID string, opts doctorOptions)
 	// Provenance: the agent enrolled raw (manual / no provenance) rather than via
 	// the runner. Managed provenance (runner/hook/poller) is fine. The old
 	// per-wrapper-shim shadow check is obsolete under the `ac` dispatcher — launch
-	// is `ac run <wrapper>`, and `ac`'s own PATH precedence is the ac_dispatcher check.
+	// is `ac serve <wrapper>`, and `ac`'s own PATH precedence is the ac_dispatcher check.
 	if agentID != "" {
 		if reg, err := loop.ReadRegistration(cfg.AgentRegistrationPath(agentID)); err == nil {
 			switch strings.TrimSpace(reg.LaunchedBy) {
@@ -429,22 +429,22 @@ func checkLaunchProvenance(cfg *loop.Config, agentID string, opts doctorOptions)
 	return doctorCheck{
 		Name:     name,
 		Severity: severityWarn,
-		Message:  fmt.Sprintf("%s — relaunch via `%s` to route through the runner (advisory only; the runner stays opt-in and is never auto-activated)", strings.Join(reasons, "; "), acRunHintForAgent(agentID)),
+		Message:  fmt.Sprintf("%s — relaunch via `%s` to route through the runner (advisory only; the runner stays opt-in and is never auto-activated)", strings.Join(reasons, "; "), acServeHintForAgent(agentID)),
 	}
 }
 
-// acRunHintForAgent renders the canonical launch command for an agent id, e.g.
-// "ac run codex". Falls back to a generic hint for an unrecognized id.
-func acRunHintForAgent(agentID string) string {
+// acServeHintForAgent renders the canonical launch command for an agent id, e.g.
+// "ac serve codex". Falls back to a generic hint for an unrecognized id.
+func acServeHintForAgent(agentID string) string {
 	agentID = strings.TrimSpace(agentID)
 	for _, spec := range wrapperSpecs {
 		// Match contextual ids (codex-agentchute) to their canonical wrapper,
 		// not just exact base ids — mirrors shimNamesForAgent.
 		if registrationMatchesCanonical(agentID, spec.AgentID) {
-			return "ac run " + spec.Key
+			return "ac serve " + spec.Key
 		}
 	}
-	return "ac run <wrapper>"
+	return "ac serve <wrapper>"
 }
 
 func shimNamesForAgent(agentID string) []string {

--- a/doctor_test.go
+++ b/doctor_test.go
@@ -449,8 +449,8 @@ func TestDoctor_WarnsOnRawWrapperBypass(t *testing.T) {
 		if got.Severity == severityBlocker {
 			t.Fatalf("launch-bypass check must never be a BLOCKER; got %q", got.Severity)
 		}
-		if !strings.Contains(got.Message, "ac run gemini") {
-			t.Fatalf("warn message should name the fix `ac run gemini`: %q", got.Message)
+		if !strings.Contains(got.Message, "ac serve gemini") {
+			t.Fatalf("warn message should name the fix `ac serve gemini`: %q", got.Message)
 		}
 	})
 
@@ -669,18 +669,18 @@ func TestCmdDoctorDiscoveryFailureBlocks(t *testing.T) {
 	})
 }
 
-func TestAcRunHintForAgent_ContextualIDs(t *testing.T) {
+func TestAcServeHintForAgent_ContextualIDs(t *testing.T) {
 	cases := map[string]string{
-		"codex":                 "ac run codex",
-		"codex-agentchute":      "ac run codex",  // contextual id
-		"gemini-cli-agentchute": "ac run gemini", // contextual id, aliased wrapper
-		"claude-code":           "ac run claude",
-		"grok-agentchute":       "ac run grok",
-		"totally-unknown":       "ac run <wrapper>",
+		"codex":                 "ac serve codex",
+		"codex-agentchute":      "ac serve codex",  // contextual id
+		"gemini-cli-agentchute": "ac serve gemini", // contextual id, aliased wrapper
+		"claude-code":           "ac serve claude",
+		"grok-agentchute":       "ac serve grok",
+		"totally-unknown":       "ac serve <wrapper>",
 	}
 	for id, want := range cases {
-		if got := acRunHintForAgent(id); got != want {
-			t.Errorf("acRunHintForAgent(%q) = %q, want %q", id, got, want)
+		if got := acServeHintForAgent(id); got != want {
+			t.Errorf("acServeHintForAgent(%q) = %q, want %q", id, got, want)
 		}
 	}
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,14 +14,14 @@ points so you don't call them by hand:
 | Claude Code | [`hooks/claude-code/.claude/settings.json`](hooks/claude-code/.claude/settings.json) |
 | codex CLI | [`hooks/codex/.codex/hooks.json`](hooks/codex/.codex/hooks.json) |
 | Gemini CLI | [`hooks/gemini/.gemini/settings.json`](hooks/gemini/.gemini/settings.json) |
-| Grok CLI | hookless — uses `ac run grok` / `agentchute run` for startup + wake |
+| Grok CLI | hookless — uses `ac serve grok` / `agentchute serve` for startup + wake |
 
 ## Running a pool (pull-only)
 
 Coordination is **pull-only**: senders write to an inbox and never poke a recipient. Each
-agent runs under the `ac` dispatcher (`ac run <wrapper>` → `agentchute run`), a per-agent supervisor that polls
+agent runs under the `ac` dispatcher (`ac serve <wrapper>` → `agentchute serve`), a per-agent supervisor that polls
 the agent's own inbox and injects `check inbox`. There is no tmux/herdr wake and no
-watchdog — those were removed in 0.8.
+watchdog — those were removed in 0.8. (`run` is a deprecated alias for `serve`, removed in v0.10.0.)
 
 ```sh
 # install + wire the repo once
@@ -29,8 +29,8 @@ curl -fsSL https://raw.githubusercontent.com/agentchute/agentchute/main/install.
 agentchute setup --wake runner --wrappers all --yes
 
 # start each agent in its own terminal, with a pinned id
-AGENTCHUTE_AGENT_ID=claude-code ac run claude
-AGENTCHUTE_AGENT_ID=codex       ac run codex
+AGENTCHUTE_AGENT_ID=claude-code ac serve claude
+AGENTCHUTE_AGENT_ID=codex       ac serve codex
 agentchute doctor --as codex            # sanity-check
 ```
 

--- a/grok_parity_test.go
+++ b/grok_parity_test.go
@@ -8,7 +8,7 @@ import (
 
 // Grok parity, runner/shim surface. The grok CLI has no repo hook system
 // (no settings.json/hooks.json, no SessionStart lifecycle), so its first-class
-// wake path is the launcher shim that routes through `agentchute run`. These
+// wake path is the launcher shim that routes through `agentchute serve`. These
 // tests pin grok as a known setup wrapper and a shimmable wrapper, while
 // asserting it is correctly treated as hookless.
 
@@ -17,7 +17,7 @@ func TestShimsInstallGrok(t *testing.T) {
 	withCwd(t, root, func() {
 		if _, err := captureStdout(t, func() error {
 			// --wrapper grok is now a no-op; the wrapper-agnostic `ac` dispatcher
-			// routes grok via `ac run grok`.
+			// routes grok via `ac serve grok`.
 			return cmdShims([]string{"install", "--dir", filepath.Join(root, "bin"), "--wrapper", "grok"})
 		}); err != nil {
 			t.Fatalf("shims install grok: %v", err)

--- a/init.go
+++ b/init.go
@@ -30,7 +30,7 @@ var enrollmentMarkerRE = regexp.MustCompile(`<!-- agentchute-enrollment v(\d+) (
 var embeddedSpecContent string
 
 const (
-	enrollmentVersion       = 18
+	enrollmentVersion       = 19
 	gitignoreVersion        = 2
 	gitignoreBeginV1        = "# agentchute-gitignore v2 begin"
 	gitignoreEndV1          = "# agentchute-gitignore v2 end"

--- a/init_test.go
+++ b/init_test.go
@@ -18,11 +18,11 @@ func TestInitFreshEmpty(t *testing.T) {
 	}
 
 	expectAction(t, plan, "AGENTCHUTE.md", "write")
-	expectAction(t, plan, "CLAUDE.md", "create v18")
-	expectAction(t, plan, "CODEX.md", "create v18")
-	expectAction(t, plan, "GEMINI.md", "create v18")
-	expectAction(t, plan, "GROK.md", "create v18")
-	expectAction(t, plan, "AGENTS.md", "create v18")
+	expectAction(t, plan, "CLAUDE.md", "create v19")
+	expectAction(t, plan, "CODEX.md", "create v19")
+	expectAction(t, plan, "GEMINI.md", "create v19")
+	expectAction(t, plan, "GROK.md", "create v19")
+	expectAction(t, plan, "AGENTS.md", "create v19")
 	expectAction(t, plan, ".gitignore", "skip") // not in git
 	expectAction(t, plan, ".agentchute/loop/agents", "mkdir 0700")
 	expectAction(t, plan, ".agentchute/loop/inbox", "mkdir 0700")
@@ -81,14 +81,14 @@ func TestInitPrependsBlockWhenNoMarker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectAction(t, plan, "CLAUDE.md", "prepend v18")
+	expectAction(t, plan, "CLAUDE.md", "prepend v19")
 	applyAll(t, plan)
 
 	got, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(got), "agentchute-enrollment v18 begin") {
+	if !strings.Contains(string(got), "agentchute-enrollment v19 begin") {
 		t.Errorf("CLAUDE.md missing marker after prepend:\n%s", got)
 	}
 	if !strings.HasSuffix(string(got), originalContent) {
@@ -143,7 +143,7 @@ func TestInitReplacesDriftedV1Content(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectAction(t, plan, "CLAUDE.md", "replace v1→v18")
+	expectAction(t, plan, "CLAUDE.md", "replace v1→v19")
 	applyAll(t, plan)
 
 	got, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
@@ -167,7 +167,7 @@ func TestInitUpgradesV11EnrollmentBlockToV13(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectAction(t, plan, "CODEX.md", "replace v11→v18")
+	expectAction(t, plan, "CODEX.md", "replace v11→v19")
 	applyAll(t, plan)
 
 	got, err := os.ReadFile(filepath.Join(root, "CODEX.md"))
@@ -189,7 +189,7 @@ func TestInitUpgradesV11EnrollmentBlockToV13(t *testing.T) {
 // Existing file with a future version marker → leave alone with warning.
 func TestInitLeavesNewerVersionAlone(t *testing.T) {
 	root := t.TempDir()
-	future := "<!-- agentchute-enrollment v19 begin -->\nfuture\n<!-- agentchute-enrollment v19 end -->\n"
+	future := "<!-- agentchute-enrollment v20 begin -->\nfuture\n<!-- agentchute-enrollment v20 end -->\n"
 	mustWrite(t, filepath.Join(root, "CLAUDE.md"), []byte(future))
 
 	plan, err := computeInitPlan(root, "agentchute", false)

--- a/internal/loop/registration.go
+++ b/internal/loop/registration.go
@@ -86,7 +86,7 @@ type Registration struct {
 
 // WI-E3 launch-provenance values for Registration.LaunchedBy. Advisory only.
 const (
-	LaunchedByRunner = "runner" // started under `agentchute run` (the runner owns the lane).
+	LaunchedByRunner = "runner" // started under `agentchute serve` (the runner owns the lane).
 	LaunchedByHook   = "hook"   // a SessionStart-class lifecycle hook ran boot/self-check.
 	LaunchedByManual = "manual" // a hand-run `agentchute register` (or raw/passthrough enroll).
 	LaunchedByPoller = "poller" // enrolled/refreshed by a recipient-side poller.

--- a/internal/loop/runner.go
+++ b/internal/loop/runner.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// RunnerState is local diagnostic/recovery state for `agentchute run`.
+// RunnerState is local diagnostic/recovery state for `agentchute serve`.
 // Registration last_seen remains the liveness source of truth.
 //
 // Pull-only (simple-again Gate 6c): the runner no longer owns a receive socket

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 // agentchute — pull-only, inbox-based agent coordination via markdown files.
 // Senders only write a recipient's inbox; nobody pokes a recipient. A loopless
-// wrapper is supervised by the runner (`agentchute run`), a per-agent PTY
+// wrapper is supervised by the runner (`agentchute serve`), a per-agent PTY
 // supervisor that polls the agent's own inbox and injects a `check inbox` cue
 // (see AGENTCHUTE.md §8).
 //
@@ -34,7 +34,7 @@ Commands:
   ack            commit messages claimed by check (archive the .claimed residue)
   pending        peek unread messages (read-only; safe for lifecycle hooks)
   default-id     print the contextual default agent id for a wrapper/vendor
-  run            launch a wrapper under the PTY runner (serve lease + inbox polling + check-inbox injection; pull-only, no wake socket)
+  serve          launch a wrapper under the PTY runner (serve lease + inbox polling + check-inbox injection; pull-only, no wake socket). "run" is a deprecated alias (removed in v0.10.0)
   setup          one-command control-repo setup; installs the runner wake path (the only supported path)
   update         self-update the binary to a release, then re-sync this repo's setup
   self-check     refresh own registration/last_seen and .live presence (pull-only: no wake target to reconcile)

--- a/prepare_pool_test.go
+++ b/prepare_pool_test.go
@@ -46,8 +46,8 @@ func TestPreparePoolPlanFreshTarget(t *testing.T) {
 		t.Fatalf("WrapperActions count = %d, want 5", len(tp.WrapperActions))
 	}
 	for _, w := range tp.WrapperActions {
-		if w.Action != "create v18" {
-			t.Errorf("wrapper %s action = %q, want 'create v18'", filepath.Base(w.Target), w.Action)
+		if w.Action != "create v19" {
+			t.Errorf("wrapper %s action = %q, want 'create v19'", filepath.Base(w.Target), w.Action)
 		}
 	}
 	if tp.GitignoreAction != nil {

--- a/presence_scan.go
+++ b/presence_scan.go
@@ -71,9 +71,9 @@ const processAncestryDepthLimit = 32
 
 // processAncestryHasEnrolledRunner reports whether any ANCESTOR (walking ppid
 // from pid's parent upward) is an enrolled runner for this pool — defined as a
-// LIVE, SAME-USER process whose cmdline is an `agentchute run` for THIS pool.
+// LIVE, SAME-USER process whose cmdline is an `agentchute serve` for THIS pool.
 // (Recorded runner.json pids are deliberately NOT trusted on their own: a stale
-// pid can be reused.) A vendor wrapper launched by the runner (agentchute run ->
+// pid can be reused.) A vendor wrapper launched by the runner (agentchute serve ->
 // codex -> node -> vendor codex) is therefore NOT a raw, unenrolled bypass — it
 // is the runner's child. Best-effort + cheap: bounded depth, cycle-guarded, and
 // only invoked for an in-pool wrapper process.
@@ -92,7 +92,7 @@ func processAncestryHasEnrolledRunner(pid int, cfg *loop.Config) bool {
 		// Revalidate the ancestor DIRECTLY — never trust a recorded runner.json
 		// pid (it can be stale or reused as an unrelated process). The ancestor
 		// counts only if it is a LIVE, SAME-USER process whose cmdline is an
-		// `agentchute run` for THIS pool.
+		// `agentchute serve` for THIS pool.
 		if setupProcessAlive(parent) && processSameUser(parent) &&
 			setupCommandMatchesRunnerPool(setupProcessCommandLine(parent), cfg) {
 			return true
@@ -216,7 +216,7 @@ func scanUnenrolledWrappers(cfg *loop.Config) ([]UnenrolledProcess, error) {
 			Kind:       "herdr",
 			Hint:       name,
 			Cwd:        p.Cwd,
-			Suggestion: fmt.Sprintf("herdr agent %q is in this pool but not enrolled; relaunch via the `ac` dispatcher (`ac run <wrapper>`) or run `agentchute boot --as %s`", name, name),
+			Suggestion: fmt.Sprintf("herdr agent %q is in this pool but not enrolled; relaunch via the `ac` dispatcher (`ac serve <wrapper>`) or run `agentchute boot --as %s`", name, name),
 		})
 	}
 
@@ -235,7 +235,7 @@ func scanUnenrolledWrappers(cfg *loop.Config) ([]UnenrolledProcess, error) {
 			Kind:       "tmux",
 			Hint:       pane,
 			Cwd:        p.Cwd,
-			Suggestion: fmt.Sprintf("tmux pane %s is in this pool but not enrolled; relaunch via the `ac` dispatcher (`ac run <wrapper>`) or run `agentchute boot --as <id>`", pane),
+			Suggestion: fmt.Sprintf("tmux pane %s is in this pool but not enrolled; relaunch via the `ac` dispatcher (`ac serve <wrapper>`) or run `agentchute boot --as <id>`", pane),
 		})
 	}
 
@@ -271,7 +271,7 @@ func scanUnenrolledWrappers(cfg *loop.Config) ([]UnenrolledProcess, error) {
 			continue
 		}
 		// Suppress runner children: a wrapper whose ancestry includes an enrolled
-		// runner for this pool was launched BY the runner (agentchute run -> wrapper
+		// runner for this pool was launched BY the runner (agentchute serve -> wrapper
 		// -> ... -> vendor binary); it is not a raw, unenrolled launch. Checked last
 		// so the ppid walk only runs for an in-pool wrapper process (cheapest).
 		if pr.PID > 0 && processAncestryHasEnrolledRunner(pr.PID, cfg) {
@@ -281,7 +281,7 @@ func scanUnenrolledWrappers(cfg *loop.Config) ([]UnenrolledProcess, error) {
 			Kind:       "process",
 			Hint:       fmt.Sprintf("pid %d (%s)", pr.PID, filepath.Base(strings.TrimSpace(pr.Command))),
 			Cwd:        pr.Cwd,
-			Suggestion: "wrapper running raw with no agentchute enrollment; relaunch via the `ac` dispatcher (`ac run <wrapper>`) or run `agentchute boot --as <id>`",
+			Suggestion: "wrapper running raw with no agentchute enrollment; relaunch via the `ac` dispatcher (`ac serve <wrapper>`) or run `agentchute boot --as <id>`",
 		})
 	}
 

--- a/presence_scan_test.go
+++ b/presence_scan_test.go
@@ -252,7 +252,7 @@ func snapshotDir(t *testing.T, dir string) map[string]string {
 }
 
 // Task 3: a wrapper process whose ancestry includes an enrolled runner (the
-// runner launched it: agentchute run -> wrapper -> ... -> vendor binary) must NOT
+// runner launched it: agentchute serve -> wrapper -> ... -> vendor binary) must NOT
 // be reported as unenrolled, while a truly raw wrapper still is.
 func TestScanUnenrolledWrappers_SuppressesRunnerChildren(t *testing.T) {
 	cfg, root := presencePoolCfg(t)
@@ -299,11 +299,11 @@ func TestScanUnenrolledWrappers_SuppressesRunnerChildren(t *testing.T) {
 			return 1
 		}
 	}
-	// The ancestor 5000 is revalidated DIRECTLY: a live, same-user `agentchute run`
+	// The ancestor 5000 is revalidated DIRECTLY: a live, same-user `agentchute serve`
 	// for THIS pool. A recorded runner.json pid is never trusted on its own.
 	setupProcessCommandLine = func(pid int) string {
 		if pid == 5000 {
-			return "/usr/local/bin/agentchute run --vendor openai --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir + " --shim-name ac -- /usr/bin/codex"
+			return "/usr/local/bin/agentchute serve --vendor openai --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir + " --shim-name ac -- /usr/bin/codex"
 		}
 		return ""
 	}
@@ -329,7 +329,7 @@ func TestScanUnenrolledWrappers_SuppressesRunnerChildren(t *testing.T) {
 }
 
 // Security (codex Gate-3 review): a STALE/reused runner.json pid must NOT suppress
-// a raw wrapper. The ancestor pid is recorded but is no longer an agentchute run,
+// a raw wrapper. The ancestor pid is recorded but is no longer an agentchute serve,
 // so it must not count — the raw child is reported.
 func TestScanUnenrolledWrappers_StalePIDDoesNotSuppress(t *testing.T) {
 	cfg, root := presencePoolCfg(t)
@@ -371,7 +371,7 @@ func TestScanUnenrolledWrappers_StalePIDDoesNotSuppress(t *testing.T) {
 	}
 }
 
-// Security (codex Gate-3 review): an ancestor whose cmdline IS an agentchute run
+// Security (codex Gate-3 review): an ancestor whose cmdline IS an agentchute serve
 // for this pool but owned by ANOTHER user must NOT suppress (no cross-user trust).
 func TestScanUnenrolledWrappers_CrossUserAncestorDoesNotSuppress(t *testing.T) {
 	cfg, root := presencePoolCfg(t)
@@ -389,7 +389,7 @@ func TestScanUnenrolledWrappers_CrossUserAncestorDoesNotSuppress(t *testing.T) {
 	}
 	setupProcessCommandLine = func(pid int) string {
 		if pid == 9100 {
-			return "/usr/local/bin/agentchute run --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir
+			return "/usr/local/bin/agentchute serve --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir
 		}
 		return ""
 	}
@@ -410,7 +410,7 @@ func TestScanUnenrolledWrappers_CrossUserAncestorDoesNotSuppress(t *testing.T) {
 	}
 }
 
-// Task 3 fallback: an ancestor that is an `agentchute run` for this pool (matched
+// Task 3 fallback: an ancestor that is an `agentchute serve` for this pool (matched
 // by cmdline) also suppresses the child, even without a runner.json pid binding.
 func TestScanUnenrolledWrappers_SuppressesViaRunnerCmdlineAncestor(t *testing.T) {
 	cfg, root := presencePoolCfg(t)
@@ -429,7 +429,7 @@ func TestScanUnenrolledWrappers_SuppressesViaRunnerCmdlineAncestor(t *testing.T)
 	}
 	setupProcessCommandLine = func(pid int) string {
 		if pid == 9100 {
-			return "/usr/local/bin/agentchute run --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir
+			return "/usr/local/bin/agentchute serve --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir
 		}
 		return ""
 	}
@@ -447,7 +447,7 @@ func TestScanUnenrolledWrappers_SuppressesViaRunnerCmdlineAncestor(t *testing.T)
 		t.Fatalf("scanUnenrolledWrappers: %v", err)
 	}
 	if len(got) != 0 {
-		t.Fatalf("a child of an `agentchute run` ancestor must be suppressed, got %+v", got)
+		t.Fatalf("a child of an `agentchute serve` ancestor must be suppressed, got %+v", got)
 	}
 }
 

--- a/run.go
+++ b/run.go
@@ -23,7 +23,7 @@ const (
 	defaultRunnerIntervalSeconds = 5
 	defaultRunnerIdleGrace       = 2 * time.Second
 	defaultRunnerBusyGrace       = 30 * time.Second
-	defaultRunnerPrompt          = "[agentchute:run] check inbox"
+	defaultRunnerPrompt          = "[agentchute] check inbox"
 
 	bracketedPasteStart = "\x1b[200~"
 	bracketedPasteEnd   = "\x1b[201~"
@@ -54,8 +54,8 @@ type runnerOptions struct {
 	ShimName        string // ac-* launcher shim that started this lane (provenance).
 }
 
-func cmdRun(args []string) error {
-	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+func cmdServe(args []string) error {
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 
 	var opts runnerOptions
@@ -180,7 +180,7 @@ func runHelpErr() error {
 
 func runHelp() string {
 	return strings.TrimSpace(`
-Usage: agentchute run --vendor <vendor> [--as <id>] [flags] -- <wrapper> [args...]
+Usage: agentchute serve --vendor <vendor> [--as <id>] [flags] -- <wrapper> [args...]
 
 Launch an interactive wrapper under agentchute's PTY runner. The runner owns
 registration, last_seen heartbeat updates, the serve lease (id-uniqueness +
@@ -191,7 +191,7 @@ Flags:
   --vendor <vendor>          vendor or origin (anthropic, openai, google, xai)
   --interval <seconds>       inbox poll interval (minimum 5; default 5)
   --interrupt-policy <mode>  after-idle|after-grace|always (default after-idle; idle is heuristic)
-  --prompt <text>            prompt injected on wake (default "[agentchute:run] check inbox")
+  --prompt <text>            prompt injected on wake (default "[agentchute] check inbox")
   --idle-grace <duration>    quiet period before prompt injection (default 2s)
   --busy-grace <duration>    grace before Ctrl-C in after-grace mode (default 30s)
   --control-repo <p>         control repo path (or $AGENTCHUTE_CONTROL_REPO)
@@ -276,7 +276,7 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 	if rawEnabled {
 		defer func() {
 			if err := restoreTerminal(); err != nil {
-				fmt.Fprintf(os.Stderr, "agentchute run: restore terminal: %v\n", err)
+				fmt.Fprintf(os.Stderr, "agentchute serve: restore terminal: %v\n", err)
 			}
 		}()
 	}
@@ -299,7 +299,7 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 	rt.lastOutputUnixNano.Store(nowUnix)
 	rt.lastInputUnixNano.Store(nowUnix)
 	if err := rt.saveState(); err != nil {
-		fmt.Fprintf(os.Stderr, "agentchute run: write runner state: %v\n", err)
+		fmt.Fprintf(os.Stderr, "agentchute serve: write runner state: %v\n", err)
 	}
 
 	defer func() {
@@ -315,7 +315,7 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 		// (another serve owns the id); releasing would be a no-op and must not
 		// delete the new owner's claim, so it is not an error to report.
 		if err := loop.ReleaseLease(rt.lease); err != nil && !errors.Is(err, loop.ErrFenced) {
-			fmt.Fprintf(os.Stderr, "agentchute run: release serve lease: %v\n", err)
+			fmt.Fprintf(os.Stderr, "agentchute serve: release serve lease: %v\n", err)
 		}
 	}()
 
@@ -442,15 +442,15 @@ func (r *runnerRuntime) pollOnce(enqueueNew bool) {
 	if r.lease != nil {
 		if err := loop.RenewLease(r.lease); err != nil {
 			if errors.Is(err, loop.ErrFenced) {
-				fmt.Fprintf(os.Stderr, "agentchute run: serve lease reclaimed (fenced); shutting down\n")
+				fmt.Fprintf(os.Stderr, "agentchute serve: serve lease reclaimed (fenced); shutting down\n")
 				r.requestShutdown(syscall.SIGTERM)
 				return
 			}
-			fmt.Fprintf(os.Stderr, "agentchute run: renew serve lease: %v\n", err)
+			fmt.Fprintf(os.Stderr, "agentchute serve: renew serve lease: %v\n", err)
 		}
 	}
 	if err := loop.UpdateLastSeen(r.cfg, r.opts.AgentID, now); err != nil {
-		fmt.Fprintf(os.Stderr, "agentchute run: update last_seen: %v\n", err)
+		fmt.Fprintf(os.Stderr, "agentchute serve: update last_seen: %v\n", err)
 	}
 	// Track a SEEN-filename snapshot across BOTH parsed messages and skipped
 	// (malformed/unparseable) files. Lexicographic-newest tracking misses two
@@ -461,7 +461,7 @@ func (r *runnerRuntime) pollOnce(enqueueNew bool) {
 	// filename not already in the set is unseen mail and must enqueue a wake.
 	msgs, skipped, err := loop.ListInboxMessagesWithSkipped(r.cfg.AgentInboxDir(r.opts.AgentID))
 	if err != nil && !errors.Is(err, loop.ErrInboxMissing) {
-		fmt.Fprintf(os.Stderr, "agentchute run: list inbox: %v\n", err)
+		fmt.Fprintf(os.Stderr, "agentchute serve: list inbox: %v\n", err)
 	}
 	r.mu.Lock()
 	if r.seenInboxFiles == nil {
@@ -488,7 +488,7 @@ func (r *runnerRuntime) pollOnce(enqueueNew bool) {
 	r.lastPoll = now
 	r.mu.Unlock()
 	if err := r.saveState(); err != nil {
-		fmt.Fprintf(os.Stderr, "agentchute run: write runner state: %v\n", err)
+		fmt.Fprintf(os.Stderr, "agentchute serve: write runner state: %v\n", err)
 	}
 }
 
@@ -562,7 +562,7 @@ func (r *runnerRuntime) isIdle() bool {
 
 func (r *runnerRuntime) injectPrompt() {
 	if err := r.writePTY(promptInjectionBytes(r.opts)); err != nil {
-		fmt.Fprintf(os.Stderr, "agentchute run: inject prompt: %v\n", err)
+		fmt.Fprintf(os.Stderr, "agentchute serve: inject prompt: %v\n", err)
 		return
 	}
 	now := time.Now().UTC()
@@ -603,7 +603,7 @@ func (r *runnerRuntime) copyPTYOutput() {
 		if n > 0 {
 			r.lastOutputUnixNano.Store(time.Now().UnixNano())
 			if _, werr := os.Stdout.Write(buf[:n]); werr != nil {
-				fmt.Fprintf(os.Stderr, "agentchute run: write stdout: %v\n", werr)
+				fmt.Fprintf(os.Stderr, "agentchute serve: write stdout: %v\n", werr)
 				return
 			}
 		}

--- a/run_test.go
+++ b/run_test.go
@@ -211,7 +211,7 @@ func TestRunExportsRunnerPIDToWrapper(t *testing.T) {
 	}
 
 	withCwd(t, root, func() {
-		if err := cmdRun([]string{
+		if err := cmdServe([]string{
 			"--as", "codex",
 			"--vendor", "openai",
 			"--control-repo", root,
@@ -220,7 +220,7 @@ func TestRunExportsRunnerPIDToWrapper(t *testing.T) {
 			"--idle-grace", "100ms",
 			"--", script,
 		}); err != nil {
-			t.Fatalf("cmdRun err = %v", err)
+			t.Fatalf("cmdServe err = %v", err)
 		}
 	})
 

--- a/send.go
+++ b/send.go
@@ -164,7 +164,7 @@ func cmdSend(args []string) error {
 	// sender crash between the durable seq commit and the link loses the
 	// allocated seq as a legal gap (at-most-once for this message). Acceptable
 	// for the transition. serveToken rides AGENTCHUTE_SERVE_TOKEN (Gate 6b): a
-	// send from a child launched under `agentchute run` carries the runner's
+	// send from a child launched under `agentchute serve` carries the runner's
 	// active serve-lease fence, so a write from a fenced (reclaimed) agent fails
 	// closed (AllocateSeq VerifyFence -> ErrFenced). Empty env (no serve lease) =>
 	// unfenced, the transitional off-bus mode (unchanged behavior).

--- a/setup.go
+++ b/setup.go
@@ -202,11 +202,11 @@ Usage:
 Scaffolds the control repo with agentchute init, stops local agentchute
 pollers/runners, clears stale live registrations and repo Herdr names so agents
 re-enroll, installs lifecycle hooks for the selected wrappers, and installs the
-single ac dispatcher (launch a wrapper with: ac run <wrapper>).
+single ac dispatcher (launch a wrapper with: ac serve <wrapper>).
 
 runner is the only supported wake path: the tmux/herdr wake adapters were
 removed in the pull-only redesign. Agents wake by being launched through the
-ac dispatcher (e.g. ac run codex); peers deliver by writing the inbox and never poke.
+ac dispatcher (e.g. ac serve codex); peers deliver by writing the inbox and never poke.
 
 Flags:
   --wake runner          install the runner wake path (the only supported value;
@@ -393,7 +393,7 @@ func setupPromptInput() (io.Reader, func(), error) {
 
 // setupWrapper describes a wrapper that `agentchute setup` knows about. The
 // set is broader than hookWrappers: a wrapper is enrollable through the runner
-// shim (which routes any vendor through `agentchute run`) even when its CLI has
+// shim (which routes any vendor through `agentchute serve`) even when its CLI has
 // no repo hook system. Hookable wrappers additionally have a hookWrappers entry
 // whose lifecycle hooks setup installs; hookless wrappers (e.g. grok, whose CLI
 // exposes no settings.json/hooks.json) rely on the shim wake path alone.
@@ -574,7 +574,7 @@ func setupShimWrappers(wake string, wrappers []string) []string {
 // a single instruction.
 func printSetupCompletionGuidance(w io.Writer, wake string) {
 	_ = wake // runner is the only installable wake path; retained for call-site stability.
-	fmt.Fprintln(w, "Open one new shell (or `hash -r`), restart selected wrappers via `ac run <wrapper>` (e.g. `ac run codex`), then run `agentchute doctor --as <id>`.")
+	fmt.Fprintln(w, "Open one new shell (or `hash -r`), restart selected wrappers via `ac serve <wrapper>` (e.g. `ac serve codex`), then run `agentchute doctor --as <id>`.")
 }
 
 func setupHookableWrappers(wrappers []string) []string {

--- a/setup_clean.go
+++ b/setup_clean.go
@@ -76,7 +76,7 @@ func (p cleanPlan) RemoveItems() []cleanItem {
 	return out
 }
 
-// cleanProcess is a live `agentchute run`/`agentchute poller run` process for
+// cleanProcess is a live `agentchute serve`/`agentchute poller run` process for
 // THIS pool, already cmdline-matched by the FIXED matcher (Task 1).
 type cleanProcess struct {
 	PID  int
@@ -416,7 +416,7 @@ func resolveCleanInputs(cfg *loop.Config, controlRepo string, agentIDs []string)
 // printWipeStateDryRun so the clean-all shares the wipe's single destructive
 // confirm and post-confirm live-bus rescan.)
 
-// listPoolAgentchuteProcesses enumerates live `agentchute run`/`poller run`
+// listPoolAgentchuteProcesses enumerates live `agentchute serve`/`poller run`
 // processes whose cmdline matches THIS pool (the FIXED matcher from Task 1).
 // Package var so the wipe orchestration stays testable without shelling out.
 var listPoolAgentchuteProcesses = defaultListPoolAgentchuteProcesses

--- a/setup_reset.go
+++ b/setup_reset.go
@@ -251,7 +251,7 @@ func stopSetupRunner(cfg *loop.Config, agentID string) (bool, string) {
 	}
 	cmdline := setupProcessCommandLine(st.RunnerPID)
 	// Runner attribution = the runner.json pid->id binding (loaded above) +
-	// setupProcessAlive (checked above) + this being an `agentchute run` for THIS
+	// setupProcessAlive (checked above) + this being an `agentchute serve` for THIS
 	// pool. A runner is launched WITHOUT --as (contextual id), so its cmdline never
 	// carries the agent id; requiring it here was a false-negative that left every
 	// live runner un-stopped. The state file binds pid->id; the cmdline only proves
@@ -290,14 +290,14 @@ func setupCommandMatches(cmdline, agentID, subcommand string, cfg *loop.Config) 
 // cmdline), a runner is launched with the CONTEXTUAL id — it has NO --as — so its
 // cmdline never contains the agent id. The pid->id binding therefore comes from
 // the runner.json state file (state/<id>/runner.json recorded this pid for <id>),
-// and the cmdline only needs to prove the process is an `agentchute run` for THIS
+// and the cmdline only needs to prove the process is an `agentchute serve` for THIS
 // pool (its --control-repo/--loop-dir resolves to this pool). Requiring the agent
 // id in a runner cmdline is the false-negative this fixes: every live runner was
 // reported "ambiguous ... cmdline did not match this pool; refusing (fail closed)".
 // A foreign pool or non-agentchute process still fails this check (still ambiguous,
 // still fail-closed).
 func setupCommandMatchesRunnerPool(cmdline string, cfg *loop.Config) bool {
-	return setupCommandMatchesPool(cmdline, "run", cfg)
+	return setupCommandMatchesPool(cmdline, "serve", cfg)
 }
 
 func setupCommandMatchesPool(cmdline, subcommand string, cfg *loop.Config) bool {
@@ -312,8 +312,13 @@ func setupCommandMatchesPool(cmdline, subcommand string, cfg *loop.Config) bool 
 		if !strings.Contains(normalized, " agentchute poller run ") && !strings.Contains(normalized, "/agentchute poller run ") {
 			return false
 		}
-	case "run":
-		if !strings.Contains(normalized, " agentchute run ") && !strings.Contains(normalized, "/agentchute run ") {
+	case "serve":
+		// The `ac` dispatcher and the legacy ac-* shim both exec `agentchute serve`.
+		// `agentchute run` remains a working deprecated alias (removed v0.10.0), so a
+		// directly-`run`-launched supervisor must still be attributed identically.
+		serveMatch := strings.Contains(normalized, " agentchute serve ") || strings.Contains(normalized, "/agentchute serve ")
+		runAliasMatch := strings.Contains(normalized, " agentchute run ") || strings.Contains(normalized, "/agentchute run ")
+		if !serveMatch && !runAliasMatch {
 			return false
 		}
 	default:

--- a/setup_test.go
+++ b/setup_test.go
@@ -506,8 +506,8 @@ func TestSetupRefreshesExistingEnrollmentBlocks(t *testing.T) {
 	if strings.Contains(text, "stale identity instructions") {
 		t.Fatalf("setup did not replace stale enrollment block:\n%s", text)
 	}
-	if !strings.Contains(text, "agentchute-enrollment v18 begin") || !strings.Contains(text, "AGENTCHUTE_AGENT_ID") {
-		t.Fatalf("setup did not refresh CODEX.md to v18 env identity guidance:\n%s", text)
+	if !strings.Contains(text, "agentchute-enrollment v19 begin") || !strings.Contains(text, "AGENTCHUTE_AGENT_ID") {
+		t.Fatalf("setup did not refresh CODEX.md to v19 env identity guidance:\n%s", text)
 	}
 	if !strings.Contains(text, "Local notes.") {
 		t.Fatalf("setup lost non-enrollment content:\n%s", text)

--- a/setup_wipe.go
+++ b/setup_wipe.go
@@ -561,7 +561,7 @@ func scanWipeLiveSignals(cfg *loop.Config, agentIDs []string) []string {
 			if setupLocalHost(st.Host) && st.RunnerPID > 0 && setupProcessAlive(st.RunnerPID) {
 				cmdline := setupProcessCommandLine(st.RunnerPID)
 				// Runner attribution: runner.json binds this pid to <id>, the pid is
-				// alive, and the cmdline is an `agentchute run` for THIS pool. A runner
+				// alive, and the cmdline is an `agentchute serve` for THIS pool. A runner
 				// has NO --as (contextual id), so we must NOT require the agent id in the
 				// cmdline — doing so reported every live runner as ambiguous. The poller
 				// case below keeps the agent-id check (pollers DO carry --as).

--- a/setup_wipe_test.go
+++ b/setup_wipe_test.go
@@ -281,7 +281,7 @@ func TestScanWipeLiveSignalsRefusesLiveRunner(t *testing.T) {
 	// Realistic runner cmdline: NO --as (runners use the contextual id), so the
 	// pool proof is the exact --control-repo/--loop-dir value match.
 	setupProcessCommandLine = func(pid int) string {
-		return "/usr/local/bin/agentchute run --vendor openai --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir + " --shim-name ac -- /usr/bin/codex"
+		return "/usr/local/bin/agentchute serve --vendor openai --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir + " --shim-name ac -- /usr/bin/codex"
 	}
 	t.Cleanup(func() { setupProcessAlive = oldAlive; setupProcessCommandLine = oldCmd })
 
@@ -323,7 +323,7 @@ func TestSetupRunWipeStateRefusesLiveRunner(t *testing.T) {
 	oldWait := wipeProcessWait
 	setupProcessAlive = func(pid int) bool { return pid == 4243 }
 	setupProcessCommandLine = func(pid int) string {
-		return "/usr/local/bin/agentchute run " + id + " --as " + id + " " + cfg.LoopDir
+		return "/usr/local/bin/agentchute serve " + id + " --as " + id + " " + cfg.LoopDir
 	}
 	setupSignalProcess = func(pid int, sig os.Signal) error { return nil } // no-op: never signal a real pid
 	wipeProcessWait = time.Millisecond
@@ -371,9 +371,17 @@ func TestSetupCommandMatchesRunnerPool(t *testing.T) {
 
 	// A runner is launched WITHOUT --as (contextual id), but DOES carry the pool
 	// path. It must match — this is the false-negative the fix repairs.
-	runnerNoAs := "/usr/local/bin/agentchute run --control-repo " + root + " --loop-dir " + cfg.LoopDir
+	runnerNoAs := "/usr/local/bin/agentchute serve --control-repo " + root + " --loop-dir " + cfg.LoopDir
 	if !setupCommandMatchesRunnerPool(runnerNoAs, cfg) {
 		t.Fatalf("runner cmdline without --as but with the pool path must match: %q", runnerNoAs)
+	}
+
+	// The deprecated `run` alias (removed v0.10.0) must be attributed IDENTICALLY to
+	// `serve` — a supervisor launched via `agentchute run` is still a live runner for
+	// this pool.
+	runAlias := "/usr/local/bin/agentchute run --control-repo " + root + " --loop-dir " + cfg.LoopDir
+	if !setupCommandMatchesRunnerPool(runAlias, cfg) {
+		t.Fatalf("deprecated `agentchute run` alias supervisor must still match this pool: %q", runAlias)
 	}
 
 	// A poller carries --as <id>; the poller matcher still requires it.
@@ -384,7 +392,7 @@ func TestSetupCommandMatchesRunnerPool(t *testing.T) {
 
 	// A foreign pool / non-agentchute process must NOT match (still ambiguous ->
 	// fail closed).
-	foreignPool := "/usr/local/bin/agentchute run --control-repo /some/other/repo"
+	foreignPool := "/usr/local/bin/agentchute serve --control-repo /some/other/repo"
 	if setupCommandMatchesRunnerPool(foreignPool, cfg) {
 		t.Fatalf("a runner for a DIFFERENT pool must not match: %q", foreignPool)
 	}
@@ -412,7 +420,7 @@ func TestScanWipeLiveSignalsRunnerWithoutAsIsLiveNotAmbiguous(t *testing.T) {
 	setupProcessAlive = func(pid int) bool { return pid == 4711 }
 	setupProcessCommandLine = func(pid int) string {
 		// NO --as: runners launch with the contextual id.
-		return "/usr/local/bin/agentchute run --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir
+		return "/usr/local/bin/agentchute serve --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir
 	}
 	t.Cleanup(func() { setupProcessAlive = oldAlive; setupProcessCommandLine = oldCmd })
 
@@ -468,11 +476,11 @@ func TestSetupWipeStateDryRunMutatesNothing(t *testing.T) {
 // gates a SIGTERM for runners that carry no agent id).
 func TestSetupCommandMatchesRunnerPool_SiblingPrefixRejected(t *testing.T) {
 	cfg := &loop.Config{ControlRepo: "/tmp/repo", LoopDir: "/tmp/repo/.agentchute/loop"}
-	foreign := "/usr/local/bin/agentchute run --control-repo /tmp/repo2 --loop-dir /tmp/repo2/.agentchute/loop"
+	foreign := "/usr/local/bin/agentchute serve --control-repo /tmp/repo2 --loop-dir /tmp/repo2/.agentchute/loop"
 	if setupCommandMatchesRunnerPool(foreign, cfg) {
 		t.Fatal("sibling-prefix /tmp/repo2 must NOT match pool /tmp/repo")
 	}
-	ours := "/usr/local/bin/agentchute run --vendor openai --control-repo /tmp/repo --loop-dir /tmp/repo/.agentchute/loop --shim-name ac -- /usr/bin/codex"
+	ours := "/usr/local/bin/agentchute serve --vendor openai --control-repo /tmp/repo --loop-dir /tmp/repo/.agentchute/loop --shim-name ac -- /usr/bin/codex"
 	if !setupCommandMatchesRunnerPool(ours, cfg) {
 		t.Fatal("this pool's runner (no --as) must match by exact path value")
 	}
@@ -488,7 +496,7 @@ func TestSetupCommandMatchesRunnerPool_IgnoresWrapperArgsAfterDashDash(t *testin
 	cfg := &loop.Config{ControlRepo: "/tmp/pool", LoopDir: "/tmp/pool/.agentchute/loop"}
 	// Foreign runner for /tmp/other; its launched wrapper happens to take a
 	// --control-repo /tmp/pool of its own — that is AFTER `--` and must be ignored.
-	foreign := "/usr/local/bin/agentchute run --vendor openai --control-repo /tmp/other --loop-dir /tmp/other/.agentchute/loop -- /usr/bin/codex --control-repo /tmp/pool --loop-dir /tmp/pool/.agentchute/loop"
+	foreign := "/usr/local/bin/agentchute serve --vendor openai --control-repo /tmp/other --loop-dir /tmp/other/.agentchute/loop -- /usr/bin/codex --control-repo /tmp/pool --loop-dir /tmp/pool/.agentchute/loop"
 	if setupCommandMatchesRunnerPool(foreign, cfg) {
 		t.Fatal("--control-repo/--loop-dir in wrapper argv (after --) must NOT attribute to this pool")
 	}

--- a/shims.go
+++ b/shims.go
@@ -13,7 +13,7 @@ import (
 
 type wrapperSpec struct {
 	// Key is the canonical wrapper name used by the `ac` dispatcher
-	// (`ac run <Key>`). Name is the legacy generated-shim filename (ac-*),
+	// (`ac serve <Key>`). Name is the legacy generated-shim filename (ac-*),
 	// retained only until the dispatcher fully replaces generated shims.
 	Key        string
 	Name       string
@@ -30,7 +30,7 @@ var wrapperSpecs = []wrapperSpec{
 	{Key: "grok", Name: "ac-grok", Aliases: []string{"grok"}, AgentID: "grok", Vendor: "xai", Candidates: []string{"grok"}},
 }
 
-// wrapperForToken resolves a dispatcher wrapper token (`ac run <token>`) by
+// wrapperForToken resolves a dispatcher wrapper token (`ac serve <token>`) by
 // canonical Key or alias. It deliberately does NOT match the legacy ac-* Name —
 // the dispatcher addresses wrappers, not generated shim filenames.
 func wrapperForToken(token string) (wrapperSpec, bool) {
@@ -212,7 +212,7 @@ exec "$AGENTCHUTE_BIN" shims exec --name %s --shim-dir %s -- "$@"
 
 // renderDispatcherScript renders the single `ac` dispatcher that setup /
 // `shims install` writes. It is wrapper-agnostic: it execs `agentchute dispatch`,
-// which routes `ac <command>` and `ac run <wrapper>` (parsed in dispatch.go). The
+// which routes `ac <command>` and `ac serve <wrapper>` (parsed in dispatch.go). The
 // --shim-dir argument lets dispatch exclude a stale same-name alias shim inside
 // the shim dir during the transition. Mirrors renderShimScript's AGENTCHUTE_BIN
 // override + shellQuote discipline.
@@ -348,7 +348,7 @@ func cmdShimsExec(args []string) error {
 	}
 	runArgs := []string{
 		agentchuteBin,
-		"run",
+		"serve",
 		"--vendor", spec.Vendor,
 		"--control-repo", cfg.ControlRepo,
 		"--loop-dir", cfg.LoopDir,
@@ -523,7 +523,7 @@ Usage:
 ` + "`shims install`" + ` installs the single ` + "`ac`" + ` dispatcher (default
 $HOME/.agentchute/bin/ac) and removes any legacy per-wrapper ac-* launchers it
 supersedes. The dispatcher routes ` + "`ac <command>`" + ` to agentchute and
-` + "`ac run <wrapper>`" + ` to the runner. --wrapper/--aliases are accepted for
+` + "`ac serve <wrapper>`" + ` to the runner. --wrapper/--aliases are accepted for
 back-compat but no longer generate per-wrapper files.
 `)
 }

--- a/templates/enrollment/agents.md
+++ b/templates/enrollment/agents.md
@@ -1,4 +1,4 @@
-<!-- agentchute-enrollment v18 begin -->
+<!-- agentchute-enrollment v19 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 **1. Setup / Startup Path**
@@ -8,16 +8,16 @@ Run `agentchute setup` once per control repo. `runner` is the only supported wak
 agentchute setup --wake runner --wrappers all --yes
 ```
 
-> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher (`ac run <wrapper>`).
+> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher (`ac serve <wrapper>`; `run` is a deprecated alias for `serve`, removed in v0.10.0).
 
-Start sessions with `ac run <wrapper>` from a control repo. The dispatcher routes through `agentchute run`, which registers you, acquires a serve lease (id-uniqueness + fencing token), refreshes `last_seen` and your `.live` presence, polls your OWN inbox, exports your resolved id as `AGENTCHUTE_AGENT_ID` into the wrapper, and injects `[agentchute:run] check inbox` when mail arrives. The runner publishes no wake target — peers never poke it (pull-only). Hookless wrappers such as Grok still need the dispatcher for startup because they have no lifecycle hook that can run `boot`; `ac run <wrapper>` enrolls them. Treat the bracketed prefix as machine metadata: the injection is only a CUE — you must actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"` to claim mail (then `ack` to commit); the runner does NOT consume it for you.
+Start sessions with `ac serve <wrapper>` from a control repo (`run` is a deprecated alias for `serve`, removed in v0.10.0). The dispatcher routes through `agentchute serve`, which registers you, acquires a serve lease (id-uniqueness + fencing token), refreshes `last_seen` and your `.live` presence, polls your OWN inbox, exports your resolved id as `AGENTCHUTE_AGENT_ID` into the wrapper, and injects `[agentchute] check inbox` when mail arrives. The runner publishes no wake target — peers never poke it (pull-only). Hookless wrappers such as Grok still need the dispatcher for startup because they have no lifecycle hook that can run `boot`; `ac serve <wrapper>` enrolls them. Treat the bracketed prefix as machine metadata: the injection is only a CUE — you must actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"` to claim mail (then `ack` to commit); the runner does NOT consume it for you.
 
 **The project is the communication boundary**: agents by default only see and talk to peers in the same discovered project pool. Unrelated projects on one host or tmux server are isolated because each project has its own pool and, when identity is not explicit, the CLI derives project-scoped IDs from the folder name (for example, `codex-agentchute`).
 
 If a session starts and you do not see agentchute boot/enrolled context, run the wrapper with its vendor so the CLI can derive the contextual identity:
 
 ```sh
-agentchute run --vendor <vendor> -- <wrapper>
+agentchute serve --vendor <vendor> -- <wrapper>
 ```
 
 As a manual fallback, pin your identity ONCE and then enroll under it before doing any work:
@@ -59,11 +59,11 @@ agentchute doctor --as <your-id>
 ```
 
 **2. Lifecycle Hooks (Required for Context and Gates)**
-`agentchute setup` installs lifecycle hooks for hook-capable wrappers. If you are not using setup, run `agentchute hooks install` once per control repo. Hooks surface inbox context per turn and block finish while unread mail remains. Hookless wrappers rely on the `ac` dispatcher (`ac run <wrapper>`) for startup enrollment.
+`agentchute setup` installs lifecycle hooks for hook-capable wrappers. If you are not using setup, run `agentchute hooks install` once per control repo. Hooks surface inbox context per turn and block finish while unread mail remains. Hookless wrappers rely on the `ac` dispatcher (`ac serve <wrapper>`) for startup enrollment.
 
 **3. Recipient Polling Fallback**
-Senders only deliver to your inbox (pull-only; nobody pokes you). If you are not launched through `agentchute run`, keep recipient polling alive so your `.live` presence stays fresh:
-- **Runner default**: `agentchute run --vendor <vendor> -- <wrapper>` polls your own inbox, keeps `.live` fresh, and injects the `check inbox` cue.
+Senders only deliver to your inbox (pull-only; nobody pokes you). If you are not launched through `agentchute serve`, keep recipient polling alive so your `.live` presence stays fresh:
+- **Runner default**: `agentchute serve --vendor <vendor> -- <wrapper>` polls your own inbox, keeps `.live` fresh, and injects the `check inbox` cue.
 - **Hook-managed fallback**: `agentchute poller ensure --as <id> --vendor <vendor>` starts/verifies heartbeat-only `poller run` and writes `state/<agent_id>/poller.json` + `.live`; it does not launch wrappers or consume mail unless explicitly run with `--launch`.
 - **Native loops**: if your wrapper has a recurring task feature, it may replace `poller run` only if it keeps a fresh heartbeat.
 
@@ -79,4 +79,4 @@ agentchute gate --before finish --as <your-id>
 The gate (read-only) blocks `finish` on unread direct mail or an unregistered self; it does NOT check `.live` at `finish`/`continue` (a stale/absent `.live` blocks only the `commit`/`release` gates). Reply obligations are asker-owned only: outstanding/expired `.owed` obligations surface as non-blocking warnings, and a `reply_required` message never blocks the recipient. Clear the gate by consuming mail with `agentchute check --as <your-id>` (then `ack`); reply to any message that needs one with `agentchute send --reply-to <ref>`.
 
 Hand-protocol path (no binary): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v18 end -->
+<!-- agentchute-enrollment v19 end -->

--- a/templates/enrollment/wrapper.md
+++ b/templates/enrollment/wrapper.md
@@ -1,11 +1,11 @@
-<!-- agentchute-enrollment v18 begin -->
+<!-- agentchute-enrollment v19 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 Canonical enrollment spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
 
 **1. Pin your identity — once.** Base `agent_id={{AGENT_ID}}`, `vendor={{VENDOR}}`. Resolve your lane id ONCE at startup and reuse the SAME id on every call:
 
-- Launched via the `ac` dispatcher (`ac run <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
+- Launched via the `ac` dispatcher (`ac serve <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
 - Otherwise set it yourself, before `boot`:
 
 ```sh
@@ -29,9 +29,9 @@ agentchute setup --wake runner --wrappers {{AGENT_ID}} --yes
 
 `--wrappers {{AGENT_ID}}` is single-agent scope (just this wrapper); a shared multi-vendor pool uses `--wrappers all` (see [`AGENTS.md`](AGENTS.md)). `runner` is the only supported wake path: coordination is pull-only, so senders write your inbox and never poke you; the runner polls your own inbox and injects the cue. (The old tmux/herdr wake adapters were removed.)
 
-> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher. Start runner-mode sessions with `ac run <wrapper>`.
+> **Note**: A new shell session (or manually sourcing your profile) is required for the PATH changes to take effect. Setup adds the shim directory to PATH and installs the single `ac` dispatcher. Start runner-mode sessions with `ac serve <wrapper>` (`run` is a deprecated alias for `serve`, removed in v0.10.0).
 
-**Wake events** arrive as `[agentchute:run] check inbox`, injected by your own runner when it sees new mail in your inbox. The bracketed prefix is machine metadata; the instruction is `check inbox` — so actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"`. The runner injects the cue but does NOT auto-consume mail; `check` is what CLAIMS and displays your mail, and `ack` commits it.
+**Wake events** arrive as `[agentchute] check inbox`, injected by your own runner when it sees new mail in your inbox. The bracketed prefix is machine metadata; the instruction is `check inbox` — so actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"`. The runner injects the cue but does NOT auto-consume mail; `check` is what CLAIMS and displays your mail, and `ack` commits it.
 
 **If startup enrollment doesn't run** (rare; indicates a setup gap):
 
@@ -49,4 +49,4 @@ agentchute gate --before finish --as "$AGENTCHUTE_AGENT_ID"
 Consume unread mail with `agentchute check --as "$AGENTCHUTE_AGENT_ID"` (CLAIMS + displays — at-least-once; a crash before `ack` re-delivers), then `ack` to commit — that clears the finish gate (which blocks only on unread/malformed mail). Reply to any message that needs one with `agentchute send --reply-to <ref>`; reply obligations are asker-owned (`.owed`) and never block the recipient. The Stop hook runs `ack` then the gate for you.
 
 Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v18 end -->
+<!-- agentchute-enrollment v19 end -->

--- a/web/spec.html
+++ b/web/spec.html
@@ -52,7 +52,7 @@
       <strong>Reference implementation</strong>:
       Markdown files on a shared filesystem · unique-temp + atomic <code>link()</code>-no-clobber delivery ·
       fixed <code>.agentchute/loop</code> directory · two-phase consume (<code>check</code> claims, <code>ack</code> commits) ·
-      the runner (<code>agentchute run</code> / the <code>ac</code> dispatcher, <code>ac run &lt;wrapper&gt;</code>) polls the agent's own inbox and injects a <code>check inbox</code> cue — no wake adapters, no central process.
+      the runner (<code>agentchute serve</code> / the <code>ac</code> dispatcher, <code>ac serve &lt;wrapper&gt;</code>) polls the agent's own inbox and injects a <code>check inbox</code> cue — no wake adapters, no central process.
     </p>
     <p>
       Alternate inbox transports (queues, S3-prefixed inboxes, HTTP endpoints, git-backed)


### PR DESCRIPTION
Unanimous 4-way spec. `serve` is the primary launch verb; `run` stays a SILENT deprecated alias for v0.9.0 (removed v0.10.0, COMPAT-marked). No deprecation spam into the wrapper PTY.

**Verb:** cmdRun->cmdServe; dispatch registers both `serve` and `run` -> cmdServe; parseDispatch launches on either; buildDispatchRunArgs + the legacy ac-* shim now exec `serve` (canonical cmdlines).
**Cue prefix:** `[agentchute:run] check inbox` -> `[agentchute] check inbox` (verb-agnostic — nothing parses it; future-proof against any further rename).
**Pool matcher:** setupCommandMatchesPool attributes BOTH `agentchute serve` AND the `run` alias (so a run-launched supervisor is still reset/wiped/presence-matched) — tested.
**Marker:** enrollment block prose run->serve + alias note; enrollmentVersion v18->v19 across template + 5 wrappers + tests (future->v20); drift green.
**Docs:** run->serve across AGENTS/CLAUDE/wrappers/README/AGENTCHUTE/SECURITY/etc. + a one-line alias deprecation note; §13.1 updated.

**Crown jewel:** run.go PTY submit/injection BYTES unchanged (only the verb name + prompt-text constant) — TestPromptInjectionBytes* pass. Full test + conformance + drift green; gofmt/vet/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)