### PR TITLE
v0.9.0: two-tier CLI help — 8 primary commands prominent, internal/plumbing demoted

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,20 +33,8 @@ Commands:
   status         print registry overview, inbox depths, and .live presence freshness
   doctor         diagnostic aggregator: scaffold, hook content, registration, inbox, .live presence
 
-Advanced / internal:
-  boot           session-start ritual: register + peek inbox + owed-reply summary (use in SessionStart hooks)
-  register       create or update a live registration for an agent
-  gate           lifecycle gate: block declaring done while unread inbox mail is outstanding
-  pending        peek unread messages (read-only; safe for lifecycle hooks)
-  poller         recipient-side poller heartbeat/run/status that keeps .live fresh
-  self-check     refresh own registration/last_seen and .live presence (pull-only: no wake target to reconcile)
-  hooks          install canonical hook templates into .claude/ / .codex/ / .gemini/ (v0.2.1)
-  shims          install/pass-through launcher shims for known wrappers
-  prepare-pool   prepare one or more folders as pool participants (writes pointer file + enrollment blocks)
-  identity       resolve and print the contextual agent identity (alias of default-id)
-  default-id     print the contextual default agent id for a wrapper/vendor
-  update         self-update the binary to a release, then re-sync this repo's setup
-  run            deprecated alias of 'serve' (removed in v0.10.0)
+Advanced / internal (mostly hook- or setup-driven; run 'agentchute <cmd> --help' for any):
+  boot · register · gate · pending · poller · self-check · hooks · shims · prepare-pool · identity · default-id · update · run (deprecated alias of serve)
 
 Run 'agentchute <command> --help' for command-specific flags.
 See AGENTCHUTE.md for the full spec.

--- a/main.go
+++ b/main.go
@@ -24,26 +24,29 @@ Usage:
   agentchute <command> [flags]
 
 Commands:
+  setup          one-command control-repo setup; installs the runner wake path (the only supported path)
   init           scaffold a project for agentchute (writes AGENTCHUTE.md, loop dirs, enrollment blocks)
-  prepare-pool   prepare one or more folders as pool participants (writes pointer file + enrollment blocks)
-  register       create or update a live registration for an agent
-  boot           session-start ritual: register + peek inbox + owed-reply summary (use in SessionStart hooks)
-  gate           lifecycle gate: block declaring done while unread inbox mail is outstanding
+  serve          launch a wrapper under the PTY runner (serve lease + inbox polling + check-inbox injection; pull-only, no wake socket)
   send           send a message from one agent to another
   check          claim + display messages addressed to me (at-least-once; run ack to commit)
   ack            commit messages claimed by check (archive the .claimed residue)
-  pending        peek unread messages (read-only; safe for lifecycle hooks)
-  default-id     print the contextual default agent id for a wrapper/vendor
-  serve          launch a wrapper under the PTY runner (serve lease + inbox polling + check-inbox injection; pull-only, no wake socket). "run" is a deprecated alias (removed in v0.10.0)
-  setup          one-command control-repo setup; installs the runner wake path (the only supported path)
-  update         self-update the binary to a release, then re-sync this repo's setup
-  self-check     refresh own registration/last_seen and .live presence (pull-only: no wake target to reconcile)
-  poller         recipient-side poller heartbeat/run/status that keeps .live fresh
-  identity       resolve and print the contextual agent identity (alias of default-id)
-  shims          install/pass-through launcher shims for known wrappers
   status         print registry overview, inbox depths, and .live presence freshness
   doctor         diagnostic aggregator: scaffold, hook content, registration, inbox, .live presence
+
+Advanced / internal:
+  boot           session-start ritual: register + peek inbox + owed-reply summary (use in SessionStart hooks)
+  register       create or update a live registration for an agent
+  gate           lifecycle gate: block declaring done while unread inbox mail is outstanding
+  pending        peek unread messages (read-only; safe for lifecycle hooks)
+  poller         recipient-side poller heartbeat/run/status that keeps .live fresh
+  self-check     refresh own registration/last_seen and .live presence (pull-only: no wake target to reconcile)
   hooks          install canonical hook templates into .claude/ / .codex/ / .gemini/ (v0.2.1)
+  shims          install/pass-through launcher shims for known wrappers
+  prepare-pool   prepare one or more folders as pool participants (writes pointer file + enrollment blocks)
+  identity       resolve and print the contextual agent identity (alias of default-id)
+  default-id     print the contextual default agent id for a wrapper/vendor
+  update         self-update the binary to a release, then re-sync this repo's setup
+  run            deprecated alias of 'serve' (removed in v0.10.0)
 
 Run 'agentchute <command> --help' for command-specific flags.
 See AGENTCHUTE.md for the full spec.


### PR DESCRIPTION
Alex's "biggest simplicity lever": top-level `agentchute` help now leads with the 8 everyday commands (setup, init, serve, send, check, ack, status, doctor); the ~13 internal/hook-driven commands (boot, register, gate, pending, poller, self-check, hooks, shims, prepare-pool, identity, default-id, update, + run=deprecated alias) are demoted to a single compact "Advanced / internal" line.

HELP-TEXT ONLY — no command removed, no routing/behavior change, every command still runs + keeps its own --help. No new flag. main.go usage const only.

Verify: gofmt/build/full-test green; no test asserts top-level help; advanced commands spot-checked still route (identity/default-id/run-alias). run.go/enrollment markers untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)