### PR TITLE
v0.9.1: collapse `--wake` to runner-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,11 @@ This file follows the [AGENTS.md](https://agents.md) convention. Any AI agent �
 
 ---
 
-<!-- agentchute-enrollment v20 begin -->
+<!-- agentchute-enrollment v21 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 **1. Setup / Startup Path**
-Run `agentchute setup` once per control repo. `runner` is the only supported wake path: coordination is pull-only, so senders write your inbox and never poke you, and the runner polls your own inbox to wake you. (`--wake all`/`both` are deprecated aliases for `runner`; `tmux`/`herdr` adapters were removed.) The canonical post-install step is:
+Run `agentchute setup` once per control repo. `runner` is the only supported wake path: coordination is pull-only, so senders write your inbox and never poke you, and the runner polls your own inbox to wake you. The canonical post-install step is:
 
 ```sh
 agentchute setup --wake runner --wrappers all --yes
@@ -85,7 +85,7 @@ agentchute gate --before finish --as <your-id>
 The gate (read-only) blocks `finish` on unread direct mail or an unregistered self; it does NOT check `.live` at `finish`/`continue` (a stale/absent `.live` blocks only the `commit`/`release` gates). Reply obligations are asker-owned only: outstanding/expired `.owed` obligations surface as non-blocking warnings, and a `reply_required` message never blocks the recipient. Clear the gate by consuming mail with `agentchute check --as <your-id>` (then `ack`); reply to any message that needs one with `agentchute send --reply-to <ref>`.
 
 Hand-protocol path (no binary): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v20 end -->
+<!-- agentchute-enrollment v21 end -->
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-<!-- agentchute-enrollment v20 begin -->
+<!-- agentchute-enrollment v21 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 Canonical enrollment spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
@@ -51,7 +51,7 @@ agentchute gate --before finish --as "$AGENTCHUTE_AGENT_ID"
 Consume unread mail with `agentchute check --as "$AGENTCHUTE_AGENT_ID"` (CLAIMS + displays — at-least-once; a crash before `ack` re-delivers), then `ack` to commit — that clears the finish gate (which blocks only on unread/malformed mail). Reply to any message that needs one with `agentchute send --reply-to <ref>`; reply obligations are asker-owned (`.owed`) and never block the recipient. The Stop hook runs `ack` then the gate for you.
 
 Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v20 end -->
+<!-- agentchute-enrollment v21 end -->
 
 ---
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,6 +1,6 @@
 # CODEX.md
 
-<!-- agentchute-enrollment v20 begin -->
+<!-- agentchute-enrollment v21 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 Canonical enrollment spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
@@ -51,7 +51,7 @@ agentchute gate --before finish --as "$AGENTCHUTE_AGENT_ID"
 Consume unread mail with `agentchute check --as "$AGENTCHUTE_AGENT_ID"` (CLAIMS + displays — at-least-once; a crash before `ack` re-delivers), then `ack` to commit — that clears the finish gate (which blocks only on unread/malformed mail). Reply to any message that needs one with `agentchute send --reply-to <ref>`; reply obligations are asker-owned (`.owed`) and never block the recipient. The Stop hook runs `ack` then the gate for you.
 
 Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v20 end -->
+<!-- agentchute-enrollment v21 end -->
 
 ---
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # GEMINI.md
 
-<!-- agentchute-enrollment v20 begin -->
+<!-- agentchute-enrollment v21 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 Canonical enrollment spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
@@ -51,7 +51,7 @@ agentchute gate --before finish --as "$AGENTCHUTE_AGENT_ID"
 Consume unread mail with `agentchute check --as "$AGENTCHUTE_AGENT_ID"` (CLAIMS + displays — at-least-once; a crash before `ack` re-delivers), then `ack` to commit — that clears the finish gate (which blocks only on unread/malformed mail). Reply to any message that needs one with `agentchute send --reply-to <ref>`; reply obligations are asker-owned (`.owed`) and never block the recipient. The Stop hook runs `ack` then the gate for you.
 
 Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v20 end -->
+<!-- agentchute-enrollment v21 end -->
 
 ---
 

--- a/GROK.md
+++ b/GROK.md
@@ -1,6 +1,6 @@
 # GROK.md
 
-<!-- agentchute-enrollment v20 begin -->
+<!-- agentchute-enrollment v21 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 Canonical enrollment spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
@@ -51,7 +51,7 @@ agentchute gate --before finish --as "$AGENTCHUTE_AGENT_ID"
 Consume unread mail with `agentchute check --as "$AGENTCHUTE_AGENT_ID"` (CLAIMS + displays — at-least-once; a crash before `ack` re-delivers), then `ack` to commit — that clears the finish gate (which blocks only on unread/malformed mail). Reply to any message that needs one with `agentchute send --reply-to <ref>`; reply obligations are asker-owned (`.owed`) and never block the recipient. The Stop hook runs `ack` then the gate for you.
 
 Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v20 end -->
+<!-- agentchute-enrollment v21 end -->
 
 ---
 

--- a/doctor.go
+++ b/doctor.go
@@ -320,16 +320,6 @@ func checkWrapperShadowing(cfg *loop.Config, agentID string, opts doctorOptions)
 		shimDir = filepath.Join(home, ".agentchute", "bin")
 	}
 
-	// Set-aware: the lifecycle-hook skip applies only when runner is NOT among
-	// the wake paths (runner requires the dispatcher on PATH). A legacy
-	// tmux/herdr-only set — single or combined ("tmux,herdr") — relies on the
-	// hookable wrapper's lifecycle hook, so the dispatcher is optional there.
-	if !setupNeedsShims(wake) && (wakeSetContains(wake, setupWakeTmux) || wakeSetContains(wake, setupWakeHerdr)) {
-		if _, hookable := hookWrapperForAgent(agentID); hookable {
-			return doctorCheck{Name: name, Severity: severitySkip, Message: fmt.Sprintf("%s wake uses lifecycle hooks for this wrapper; ac dispatcher is optional", wake)}
-		}
-	}
-
 	pathEnv := opts.PathEnv
 	if pathEnv == "" {
 		pathEnv = os.Getenv("PATH")

--- a/doctor_test.go
+++ b/doctor_test.go
@@ -316,25 +316,6 @@ func TestDoctorAsBlocksWhenActingWrapperHookDiverged(t *testing.T) {
 // hook and shadowing is not applicable. Regression for the pre-fix `wake ==
 // tmux || wake == herdr` equality, which failed any multi-token set and emitted
 // false shadowing WARNs.
-func TestDoctorShadowingSkipsHookableWrapperForTmuxHerdrSet(t *testing.T) {
-	cfg := newDoctorCfg(t)
-	// Cover BOTH the base id and the contextual id real setups enroll with —
-	// the contextual case is the one the exact-match bug missed.
-	for _, agentID := range []string{"codex", "codex-agentchute", "claude-code-agentchute"} {
-		for _, wake := range []string{"tmux", "herdr", "tmux,herdr"} {
-			got := checkWrapperShadowing(cfg, agentID, doctorOptions{PoolState: &setupPoolState{Wake: wake}})
-			if got.Severity != severitySkip {
-				t.Fatalf("wrapper_shadowing severity = %q for agent %q wake %q, want SKIP; msg=%q", got.Severity, agentID, wake, got.Message)
-			}
-		}
-		// When runner is in the set, shims ARE required on PATH, so never skip.
-		got := checkWrapperShadowing(cfg, agentID, doctorOptions{PoolState: &setupPoolState{Wake: "runner,tmux"}})
-		if got.Severity == severitySkip {
-			t.Fatalf("wrapper_shadowing must not skip for agent %q when runner is in the set; msg=%q", agentID, got.Message)
-		}
-	}
-}
-
 // The v0.8.8 ac_dispatcher check: OK when the `ac` dispatcher resolves from the
 // shim dir ahead of any other `ac` (e.g. the system /usr/sbin/ac), WARN when a
 // non-shim-dir `ac` shadows it or the shim dir is absent from PATH.

--- a/init.go
+++ b/init.go
@@ -30,7 +30,7 @@ var enrollmentMarkerRE = regexp.MustCompile(`<!-- agentchute-enrollment v(\d+) (
 var embeddedSpecContent string
 
 const (
-	enrollmentVersion       = 20
+	enrollmentVersion       = 21
 	gitignoreVersion        = 3
 	gitignoreBeginV1        = "# agentchute-gitignore v3 begin"
 	gitignoreEndV1          = "# agentchute-gitignore v3 end"

--- a/init_test.go
+++ b/init_test.go
@@ -18,11 +18,11 @@ func TestInitFreshEmpty(t *testing.T) {
 	}
 
 	expectAction(t, plan, "AGENTCHUTE.md", "write")
-	expectAction(t, plan, "CLAUDE.md", "create v20")
-	expectAction(t, plan, "CODEX.md", "create v20")
-	expectAction(t, plan, "GEMINI.md", "create v20")
-	expectAction(t, plan, "GROK.md", "create v20")
-	expectAction(t, plan, "AGENTS.md", "create v20")
+	expectAction(t, plan, "CLAUDE.md", "create v21")
+	expectAction(t, plan, "CODEX.md", "create v21")
+	expectAction(t, plan, "GEMINI.md", "create v21")
+	expectAction(t, plan, "GROK.md", "create v21")
+	expectAction(t, plan, "AGENTS.md", "create v21")
 	expectAction(t, plan, ".gitignore", "skip") // not in git
 	expectAction(t, plan, ".agentchute/loop/agents", "mkdir 0700")
 	expectAction(t, plan, ".agentchute/loop/inbox", "mkdir 0700")
@@ -81,14 +81,14 @@ func TestInitPrependsBlockWhenNoMarker(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectAction(t, plan, "CLAUDE.md", "prepend v20")
+	expectAction(t, plan, "CLAUDE.md", "prepend v21")
 	applyAll(t, plan)
 
 	got, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(got), "agentchute-enrollment v20 begin") {
+	if !strings.Contains(string(got), "agentchute-enrollment v21 begin") {
 		t.Errorf("CLAUDE.md missing marker after prepend:\n%s", got)
 	}
 	if !strings.HasSuffix(string(got), originalContent) {
@@ -143,7 +143,7 @@ func TestInitReplacesDriftedV1Content(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectAction(t, plan, "CLAUDE.md", "replace v1→v20")
+	expectAction(t, plan, "CLAUDE.md", "replace v1→v21")
 	applyAll(t, plan)
 
 	got, err := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
@@ -167,7 +167,7 @@ func TestInitUpgradesV11EnrollmentBlockToV13(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectAction(t, plan, "CODEX.md", "replace v11→v20")
+	expectAction(t, plan, "CODEX.md", "replace v11→v21")
 	applyAll(t, plan)
 
 	got, err := os.ReadFile(filepath.Join(root, "CODEX.md"))
@@ -189,7 +189,7 @@ func TestInitUpgradesV11EnrollmentBlockToV13(t *testing.T) {
 // Existing file with a future version marker → leave alone with warning.
 func TestInitLeavesNewerVersionAlone(t *testing.T) {
 	root := t.TempDir()
-	future := "<!-- agentchute-enrollment v21 begin -->\nfuture\n<!-- agentchute-enrollment v21 end -->\n"
+	future := "<!-- agentchute-enrollment v22 begin -->\nfuture\n<!-- agentchute-enrollment v22 end -->\n"
 	mustWrite(t, filepath.Join(root, "CLAUDE.md"), []byte(future))
 
 	plan, err := computeInitPlan(root, "agentchute", false)

--- a/prepare_pool_test.go
+++ b/prepare_pool_test.go
@@ -46,8 +46,8 @@ func TestPreparePoolPlanFreshTarget(t *testing.T) {
 		t.Fatalf("WrapperActions count = %d, want 5", len(tp.WrapperActions))
 	}
 	for _, w := range tp.WrapperActions {
-		if w.Action != "create v20" {
-			t.Errorf("wrapper %s action = %q, want 'create v20'", filepath.Base(w.Target), w.Action)
+		if w.Action != "create v21" {
+			t.Errorf("wrapper %s action = %q, want 'create v21'", filepath.Base(w.Target), w.Action)
 		}
 	}
 	if tp.GitignoreAction != nil {

--- a/setup.go
+++ b/setup.go
@@ -18,10 +18,7 @@ import (
 )
 
 const (
-	setupWakeTmux   = "tmux"
-	setupWakeHerdr  = "herdr"
 	setupWakeRunner = "runner"
-	setupWakeBoth   = "both"
 
 	setupPathBlockBegin = "# >>> agentchute setup PATH >>>"
 	setupPathBlockEnd   = "# <<< agentchute setup PATH <<<"
@@ -82,7 +79,7 @@ func cmdSetup(args []string) error {
 	fs.SetOutput(io.Discard)
 
 	var opts setupOptions
-	fs.StringVar(&opts.Wake, "wake", "", "wake path to install: runner (the only supported value; all/both are deprecated aliases for runner)")
+	fs.StringVar(&opts.Wake, "wake", "", "wake path to install: runner (the only supported value)")
 	fs.StringVar(&opts.Wrappers, "wrappers", "all", "all (detected on PATH), none, or comma list: claude-code,codex,gemini-cli,grok")
 	fs.StringVar(&opts.ControlRepo, "control-repo", "", "control repo path (default: env or current git/cwd root)")
 	fs.StringVar(&opts.ShimDir, "shim-dir", "", "launcher shim directory (default: $HOME/.agentchute/bin)")
@@ -134,14 +131,11 @@ func cmdSetup(args []string) error {
 		}
 		opts.Wake = wake
 	}
-	canonWake, wakeDeprecation, err := normalizeSetupWake(opts.Wake)
+	canonWake, err := normalizeSetupWake(opts.Wake)
 	if err != nil {
 		return err
 	}
 	opts.Wake = canonWake
-	if wakeDeprecation != "" {
-		fmt.Println(wakeDeprecation)
-	}
 	if err := guardSetupInitRoot(root, opts); err != nil {
 		return err
 	}
@@ -210,9 +204,7 @@ ac dispatcher (e.g. ac serve codex); peers deliver by writing the inbox and neve
 
 Flags:
   --wake runner          install the runner wake path (the only supported value;
-                         prompted when omitted). "all"/"both" are deprecated
-                         aliases that now install runner only; tmux/herdr are
-                         rejected.
+                         prompted when omitted).
   --wrappers <set>       all (detected on PATH), none, or comma list
                          (claude-code,codex,gemini-cli,grok; default all)
   --control-repo <path>  repo to initialize (default env or current git/cwd root)
@@ -260,54 +252,15 @@ func defaultSetupShimDir() (string, error) {
 	return filepath.Join(home, ".agentchute", "bin"), nil
 }
 
-// wakeSetContains reports whether the canonical comma-joined wake set includes
-// method. Retained for the legacy-persisted-state cleanup/diagnostic paths
-// (previousSetupShimWrappers, doctor's wake check), which still read older
-// setup.json records that named tmux/herdr.
-func wakeSetContains(wake, method string) bool {
-	for _, m := range strings.Split(wake, ",") {
-		if strings.TrimSpace(m) == method {
-			return true
-		}
+// normalizeSetupWake validates a raw --wake value. After the pull-only redesign
+// the tmux/herdr wake adapters were removed and `runner` is the only installable
+// wake path; every other value (including the old `all`/`both`/`tmux`/`herdr`
+// aliases) is rejected. Empty is handled by the caller (interactive prompt).
+func normalizeSetupWake(raw string) (string, error) {
+	if strings.ToLower(strings.TrimSpace(raw)) == setupWakeRunner {
+		return setupWakeRunner, nil
 	}
-	return false
-}
-
-// normalizeSetupWake parses a raw --wake value into the single supported wake
-// path. After the pull-only redesign (simple-again) the tmux/herdr wake adapters
-// were removed, so `runner` is the only installable wake path. `all`/`both`
-// (which historically meant runner+tmux+herdr) are accepted as DEPRECATED
-// aliases that now install runner only; `tmux`/`herdr` (alone or in a combo) are
-// rejected with a clear message. Returns the canonical value ("runner") and an
-// optional deprecation note to surface to the user.
-func normalizeSetupWake(raw string) (string, string, error) {
-	raw = strings.ToLower(strings.TrimSpace(raw))
-	unrecognized := func(tok string) error {
-		return fmt.Errorf("--wake %q is not recognized; the only supported wake path is runner", tok)
-	}
-	if raw == "" {
-		return "", "", unrecognized("")
-	}
-	var deprecation string
-	for _, part := range strings.Split(raw, ",") {
-		tok := strings.TrimSpace(part)
-		switch tok {
-		case "":
-			// Reject empty tokens (stray/leading/trailing commas) for CLI typo safety.
-			return "", "", unrecognized(raw)
-		case setupWakeRunner:
-			// The one supported path.
-		case "all", setupWakeBoth:
-			// Legacy aliases: historically runner+tmux+herdr. The tmux/herdr
-			// adapters are gone, so they now install runner only.
-			deprecation = fmt.Sprintf("note: --wake %q is deprecated; the tmux/herdr wake adapters were removed — installing runner only", tok)
-		case setupWakeTmux, setupWakeHerdr:
-			return "", "", fmt.Errorf("--wake %q is no longer supported: the tmux/herdr wake adapters were removed in the pull-only redesign; use --wake runner", tok)
-		default:
-			return "", "", unrecognized(tok)
-		}
-	}
-	return setupWakeRunner, deprecation, nil
+	return "", fmt.Errorf("--wake %q is not recognized; the only supported wake path is runner", strings.TrimSpace(raw))
 }
 
 func guardSetupInitRoot(root string, opts setupOptions) error {
@@ -502,7 +455,7 @@ func findExecutableOutsideDir(name, skipDir string) string {
 }
 
 func printSetupPlan(w io.Writer, root string, opts setupOptions, wrappers []string, detected map[string]string) {
-	shimWrappers := setupShimWrappers(opts.Wake, wrappers)
+	shimWrappers := setupShimWrappers(opts.Wake)
 	hookWrappers := setupHookableWrappers(wrappers)
 
 	fmt.Fprintln(w, "agentchute setup")
@@ -552,19 +505,14 @@ func printSetupPlan(w io.Writer, root string, opts setupOptions, wrappers []stri
 }
 
 func setupNeedsShims(wake string) bool {
-	return wakeSetContains(wake, setupWakeRunner)
+	return strings.TrimSpace(wake) == setupWakeRunner
 }
 
-func setupShimWrappers(wake string, wrappers []string) []string {
+func setupShimWrappers(wake string) []string {
 	if setupNeedsShims(wake) {
-		// INVARIANT: Install all known wrappers when runner is among the wake
-		// paths so that a later install of a real binary works immediately.
+		// INVARIANT: runner is the only wake path — install all known wrappers so
+		// a later install of a real binary works immediately.
 		return setupWrapperNames()
-	}
-	if wakeSetContains(wake, setupWakeTmux) || wakeSetContains(wake, setupWakeHerdr) {
-		// INVARIANT: In tmux/herdr-only mode, we must install shims for hookless
-		// wrappers (grok) so they can enroll on startup via the shim.
-		return compactSetupWrappers(wrappers, func(w setupWrapper) bool { return !w.Hookable })
 	}
 	return nil
 }
@@ -605,7 +553,7 @@ func setupWrapperByName(name string) (setupWrapper, bool) {
 }
 
 func previousSetupShimWrappers(state setupGlobalState) []string {
-	wrappers := setupShimWrappers(state.Wake, state.Wrappers)
+	wrappers := setupShimWrappers(state.Wake)
 	if len(wrappers) == 0 && state.ShimsInstalled {
 		return state.Wrappers
 	}
@@ -693,7 +641,7 @@ func applySetup(root string, opts setupOptions, wrappers []string) error {
 			}
 		}
 
-		currentShimWrappers := setupShimWrappers(opts.Wake, wrappers)
+		currentShimWrappers := setupShimWrappers(opts.Wake)
 		currentNeedsShims := len(currentShimWrappers) > 0
 		for _, wrapper := range droppedWrappers(previousSetupShimWrappers(globalState), currentShimWrappers) {
 			if err := removeSetupShimsForWrapper(globalState.ShimDir, wrapper); err != nil {
@@ -1279,20 +1227,6 @@ func setupGlobalStatePath() (string, error) {
 	return filepath.Join(base, "agentchute", "setup.json"), nil
 }
 
-// canonicalizePersistedWake best-effort normalizes a wake value read back from
-// saved setup state so legacy/non-canonical values map to the same set the
-// set-aware predicates expect. Critically, pre-combination installs persisted
-// `Wake: "both"`; without this, setupShimWrappers("both", …) returns nil and
-// previousSetupShimWrappers mis-computes the prior shim set, orphaning shims on
-// a narrowing re-setup. Invalid or empty values are left untouched (callers that
-// require a wake mode validate separately).
-func canonicalizePersistedWake(wake string) string {
-	if canon, _, err := normalizeSetupWake(wake); err == nil {
-		return canon
-	}
-	return wake
-}
-
 func readSetupGlobalState() (setupGlobalState, error) {
 	path, err := setupGlobalStatePath()
 	if err != nil {
@@ -1306,7 +1240,9 @@ func readSetupGlobalState() (setupGlobalState, error) {
 	if err := json.Unmarshal(data, &state); err != nil {
 		return setupGlobalState{}, err
 	}
-	state.Wake = canonicalizePersistedWake(state.Wake)
+	// runner is the only wake path — any persisted value (incl. a pre-redesign
+	// "both"/"all"/"tmux"/"herdr" or an absent field) resolves to runner.
+	state.Wake = setupWakeRunner
 	return state, nil
 }
 
@@ -1319,7 +1255,9 @@ func readSetupPoolState(cfg *loop.Config) (setupPoolState, error) {
 	if err := json.Unmarshal(data, &state); err != nil {
 		return setupPoolState{}, err
 	}
-	state.Wake = canonicalizePersistedWake(state.Wake)
+	// runner is the only wake path — any persisted value (incl. a pre-redesign
+	// "both"/"all"/"tmux"/"herdr" or an absent field) resolves to runner.
+	state.Wake = setupWakeRunner
 	return state, nil
 }
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -76,35 +76,28 @@ func TestSetupRunnerInstallsAllFourShimsRegardlessOfDetection(t *testing.T) {
 
 func TestNormalizeSetupWakeCombinations(t *testing.T) {
 	cases := []struct {
-		in        string
-		want      string
-		deprecate bool
-		wantErr   bool
+		in      string
+		want    string
+		wantErr bool
 	}{
-		// Pull-only redesign: runner is the only installable wake path. tmux/herdr
-		// (alone or in a combo) are rejected; all/both are deprecated aliases that
-		// now resolve to runner only.
+		// Pull-only redesign: runner is the only installable wake path. Every other
+		// value — including the removed all/both/tmux/herdr aliases and any combo —
+		// is rejected.
 		{in: "runner", want: "runner"},
 		{in: "RUNNER", want: "runner"}, // case-insensitive
 		{in: " runner ", want: "runner"},
-		{in: "runner,runner", want: "runner"},        // dedup
-		{in: "all", want: "runner", deprecate: true}, // legacy keyword → runner
-		{in: "both", want: "runner", deprecate: true},
-		{in: "tmux", wantErr: true},        // adapter removed
-		{in: "herdr", wantErr: true},       // adapter removed
-		{in: "runner,tmux", wantErr: true}, // combo with removed adapter
-		{in: "tmux,runner", wantErr: true},
-		{in: "runner,tmux,herdr", wantErr: true},
+		{in: "runner,runner", wantErr: true}, // combos no longer accepted
+		{in: "all", wantErr: true},           // removed alias
+		{in: "both", wantErr: true},          // removed alias
+		{in: "tmux", wantErr: true},          // adapter removed
+		{in: "herdr", wantErr: true},         // adapter removed
+		{in: "runner,tmux", wantErr: true},
 		{in: "", wantErr: true},
 		{in: ",", wantErr: true},
-		{in: "runner,", wantErr: true},    // trailing comma → empty token
-		{in: "runner,,", wantErr: true},   // doubled comma → empty token
-		{in: "all, ,both", wantErr: true}, // whitespace-only token
 		{in: "bogus", wantErr: true},
-		{in: "runner,bogus", wantErr: true},
 	}
 	for _, tc := range cases {
-		got, deprecation, err := normalizeSetupWake(tc.in)
+		got, err := normalizeSetupWake(tc.in)
 		if tc.wantErr {
 			if err == nil {
 				t.Errorf("normalizeSetupWake(%q): expected error, got %q", tc.in, got)
@@ -117,9 +110,6 @@ func TestNormalizeSetupWakeCombinations(t *testing.T) {
 		}
 		if got != tc.want {
 			t.Errorf("normalizeSetupWake(%q) = %q, want %q", tc.in, got, tc.want)
-		}
-		if (deprecation != "") != tc.deprecate {
-			t.Errorf("normalizeSetupWake(%q) deprecation = %q, want deprecate=%v", tc.in, deprecation, tc.deprecate)
 		}
 	}
 }
@@ -194,22 +184,19 @@ esac
 	}
 }
 
-func TestSetupShimWrappersForWakeCombinations(t *testing.T) {
-	wrappers := []string{"claude-code", "codex", "gemini-cli", "grok"}
-	// runner anywhere in the set installs all four shims.
-	for _, wake := range []string{"runner", "runner,tmux", "runner,tmux,herdr"} {
-		if got := setupShimWrappers(wake, wrappers); len(got) != 4 {
-			t.Errorf("setupShimWrappers(%q) = %v, want all 4", wake, got)
-		}
-		if !setupNeedsShims(wake) {
-			t.Errorf("setupNeedsShims(%q) = false, want true", wake)
-		}
+func TestSetupShimWrappersForWake(t *testing.T) {
+	// runner is the only wake path: it installs all four shims.
+	if got := setupShimWrappers("runner"); len(got) != 4 {
+		t.Errorf(`setupShimWrappers("runner") = %v, want all 4`, got)
 	}
-	// tmux/herdr without runner installs hookless shims only (grok).
-	for _, wake := range []string{"tmux", "herdr", "tmux,herdr"} {
-		got := setupShimWrappers(wake, wrappers)
-		if len(got) != 1 || got[0] != "grok" {
-			t.Errorf("setupShimWrappers(%q) = %v, want [grok]", wake, got)
+	if !setupNeedsShims("runner") {
+		t.Errorf(`setupNeedsShims("runner") = false, want true`)
+	}
+	// Any non-runner value installs nothing (and is rejected upstream by
+	// normalizeSetupWake anyway).
+	for _, wake := range []string{"", "tmux", "herdr", "bogus"} {
+		if got := setupShimWrappers(wake); got != nil {
+			t.Errorf("setupShimWrappers(%q) = %v, want nil", wake, got)
 		}
 		if setupNeedsShims(wake) {
 			t.Errorf("setupNeedsShims(%q) = true, want false", wake)
@@ -217,35 +204,10 @@ func TestSetupShimWrappersForWakeCombinations(t *testing.T) {
 	}
 }
 
-// Legacy installs persisted Wake:"both" (a runner-equivalent that installed all
-// shims). Read-time canonicalization must normalize it to a runner-equivalent so
-// previousSetupShimWrappers reports the full shim set the old install actually
-// wrote — not just the detected wrapper list — otherwise a re-setup orphans
-// shims. Post pull-only redesign "both" canonicalizes to "runner" (which still
-// resolves to all four shims because runner installs them all).
-func TestPersistedBothWakeCanonicalizedForShimCleanup(t *testing.T) {
-	if got := canonicalizePersistedWake("both"); got != "runner" {
-		t.Fatalf(`canonicalizePersistedWake("both") = %q, want "runner"`, got)
-	}
-	canon := setupGlobalState{Wake: canonicalizePersistedWake("both"), Wrappers: []string{"codex"}, ShimsInstalled: true}
-	if got := previousSetupShimWrappers(canon); len(got) != 4 {
-		t.Fatalf("previousSetupShimWrappers(canonicalized both) = %v, want all 4 setup wrappers", got)
-	}
-	// Document the bug canonicalization prevents: raw "both" falls back to the
-	// detected wrapper list (1), so the other 3 prior shims would be orphaned.
-	raw := setupGlobalState{Wake: "both", Wrappers: []string{"codex"}, ShimsInstalled: true}
-	if got := previousSetupShimWrappers(raw); len(got) == 4 {
-		t.Fatalf("raw \"both\" unexpectedly resolved all 4 (%v); canonicalization would be redundant", got)
-	}
-	// Invalid/empty persisted values pass through untouched.
-	if got := canonicalizePersistedWake(""); got != "" {
-		t.Fatalf(`canonicalizePersistedWake("") = %q, want ""`, got)
-	}
-}
-
-// Pins the read-time canonicalization in BOTH state readers — not just the
-// helper. If the `state.Wake = canonicalizePersistedWake(...)` assignments are
-// removed, these reads return raw "both" and this fails.
+// Pins the read-time wake normalization in BOTH state readers: runner is the only
+// wake path, so a legacy persisted `wake:"both"` (or any other value) resolves to
+// runner on read. If the `state.Wake = setupWakeRunner` assignments are removed,
+// these reads return raw "both" and this fails.
 func TestReadSetupStateCanonicalizesLegacyBothWake(t *testing.T) {
 	// Pool state reader.
 	root := t.TempDir()
@@ -342,21 +304,6 @@ func TestSetupHelpAndInvalidWakeRunnerOnly(t *testing.T) {
 			t.Fatalf("invalid wake error should name runner as the only supported path, got %v", err)
 		}
 	})
-}
-
-func TestSetupHerdrPlanLabelsHooklessShim(t *testing.T) {
-	var out strings.Builder
-	printSetupPlan(&out, "/repo", setupOptions{
-		Wake:      setupWakeHerdr,
-		Wrappers:  "grok",
-		ShimDir:   "/shim",
-		NoProfile: true,
-	}, []string{"grok"}, map[string]string{"grok": "/usr/bin/grok"})
-
-	text := out.String()
-	if !strings.Contains(text, "shim wrappers: grok (hookless startup enrollment)") {
-		t.Fatalf("herdr plan should label hookless shim wrappers:\n%s", text)
-	}
 }
 
 func TestSetupClearsExistingLiveRegistrations(t *testing.T) {
@@ -506,8 +453,8 @@ func TestSetupRefreshesExistingEnrollmentBlocks(t *testing.T) {
 	if strings.Contains(text, "stale identity instructions") {
 		t.Fatalf("setup did not replace stale enrollment block:\n%s", text)
 	}
-	if !strings.Contains(text, "agentchute-enrollment v20 begin") || !strings.Contains(text, "AGENTCHUTE_AGENT_ID") {
-		t.Fatalf("setup did not refresh CODEX.md to v20 env identity guidance:\n%s", text)
+	if !strings.Contains(text, "agentchute-enrollment v21 begin") || !strings.Contains(text, "AGENTCHUTE_AGENT_ID") {
+		t.Fatalf("setup did not refresh CODEX.md to v21 env identity guidance:\n%s", text)
 	}
 	if !strings.Contains(text, "Local notes.") {
 		t.Fatalf("setup lost non-enrollment content:\n%s", text)

--- a/templates/enrollment/agents.md
+++ b/templates/enrollment/agents.md
@@ -1,8 +1,8 @@
-<!-- agentchute-enrollment v20 begin -->
+<!-- agentchute-enrollment v21 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 **1. Setup / Startup Path**
-Run `agentchute setup` once per control repo. `runner` is the only supported wake path: coordination is pull-only, so senders write your inbox and never poke you, and the runner polls your own inbox to wake you. (`--wake all`/`both` are deprecated aliases for `runner`; `tmux`/`herdr` adapters were removed.) The canonical post-install step is:
+Run `agentchute setup` once per control repo. `runner` is the only supported wake path: coordination is pull-only, so senders write your inbox and never poke you, and the runner polls your own inbox to wake you. The canonical post-install step is:
 
 ```sh
 agentchute setup --wake runner --wrappers all --yes
@@ -79,4 +79,4 @@ agentchute gate --before finish --as <your-id>
 The gate (read-only) blocks `finish` on unread direct mail or an unregistered self; it does NOT check `.live` at `finish`/`continue` (a stale/absent `.live` blocks only the `commit`/`release` gates). Reply obligations are asker-owned only: outstanding/expired `.owed` obligations surface as non-blocking warnings, and a `reply_required` message never blocks the recipient. Clear the gate by consuming mail with `agentchute check --as <your-id>` (then `ack`); reply to any message that needs one with `agentchute send --reply-to <ref>`.
 
 Hand-protocol path (no binary): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v20 end -->
+<!-- agentchute-enrollment v21 end -->

--- a/templates/enrollment/wrapper.md
+++ b/templates/enrollment/wrapper.md
@@ -1,4 +1,4 @@
-<!-- agentchute-enrollment v20 begin -->
+<!-- agentchute-enrollment v21 begin -->
 ## ENROLLMENT — agentchute coordination loop
 
 Canonical enrollment spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
@@ -49,4 +49,4 @@ agentchute gate --before finish --as "$AGENTCHUTE_AGENT_ID"
 Consume unread mail with `agentchute check --as "$AGENTCHUTE_AGENT_ID"` (CLAIMS + displays — at-least-once; a crash before `ack` re-delivers), then `ack` to commit — that clears the finish gate (which blocks only on unread/malformed mail). Reply to any message that needs one with `agentchute send --reply-to <ref>`; reply obligations are asker-owned (`.owed`) and never block the recipient. The Stop hook runs `ack` then the gate for you.
 
 Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGENTCHUTE.md) §5.
-<!-- agentchute-enrollment v20 end -->
+<!-- agentchute-enrollment v21 end -->


### PR DESCRIPTION
Second v0.9.1 lean PR. `runner` has been the only wake path since the pull-only redesign (v0.8.0); this removes all the remaining `tmux`/`herdr`/`both`/`all` wake vestige. Pure subtraction (**−144 lines**).

## Removed
- `normalizeSetupWake` → runner-only: `(string, error)`, no deprecation return. The old `all`/`both` deprecated-alias acceptance, the `tmux`/`herdr` rejection special-case, `wakeSetContains`, and the comma multi-value **set machinery** are all gone. Every non-`runner` value now errors.
- `setupWakeTmux` / `setupWakeHerdr` / `setupWakeBoth` consts.
- `setupNeedsShims` = plain `wake == runner` check. `setupShimWrappers` drops its now-unused `wrappers` param + the tmux/herdr-only branch (3 callers updated).
- `canonicalizePersistedWake` deleted — both state readers set `state.Wake = runner` directly (any legacy persisted `"both"`/`"tmux"`/… resolves to runner, so no old install strands).
- `doctor.go`: the now-unreachable tmux/herdr lifecycle-hook skip branch.
- `--wake` flag help + usage text + enrollment prose drop the all/both mention; marker **v20→v21** (re-stamped via `init`).

## Kept (deliberately)
- `compactSetupWrappers` / `Hookable` (still used by `setupHookableWrappers` + doctor).
- The `--wrapper`/`--aliases` no-op flags + shims alias-gen — separate follow-up PR.

## Verification
gofmt/vet/build · `go test . ./internal/loop` pass · conformance module pass · drift `TestTemplatesMatchRepoWrappers` (v21) pass · crown-jewel `TestPromptInjectionBytes*` pass. Tests: wake tests rewritten for runner-only; obsolete herdr/tmux tests removed; version asserts v20→v21 (future→v22).

Dual-gate: codex + sonnet.