### PR TITLE
v0.9.1: dead-code + naming sweep

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -252,8 +252,9 @@ One-release compatibility carried from v0.8.0. Each has an in-code `// COMPAT(re
 
 | Item | Location | Target | Gate |
 |------|----------|--------|------|
-| `renderShimScript` (legacy shim generator) | `shims.go` | v0.8.9 | **none** — zero production callers; migrate its 3 test-fixture callers to inline legacy content |
-| `selectShimSpecs`/`shimInstallNames` selectors → static legacy-name list | `shims.go`, `setup.go` | v0.8.9 | **none** — behavior-preserving swap; the cleanup only needs the legacy `ac-*` name set, not generation logic |
+| `selectShimSpecs`/`shimInstallNames` selectors → static legacy-name list | `shims.go`, `setup.go` | later | **NOT a safe mechanical swap** — the `--wrapper` filtering is still wired via `removeSetupShimsForWrapper(dir, wrapper)` for the dropped-wrapper cleanup path (`droppedWrappers`), so replacing the selectors with a static "all" list would change cleanup behavior. Defer until that path is provably dead. |
+
+**DONE in v0.9.1 — dead shim-generation code removed (clean delete).** `renderShimScript` (the legacy per-wrapper shim generator) had zero production callers and moved to a test-only `legacyShimScript` fixture helper. `removeSetupAliasShimsForWrapper` was deleted outright (zero callers — the same-name alias cleanup is unreachable now that aliases are never installed). The misnamed `gitignoreBeginV1`/`gitignoreEndV1` constants (they held the current `v3` marker) were renamed `gitignoreBegin`/`gitignoreEnd`.
 
 **DONE in v0.9.1 — deprecated no-op flags + `--wake` collapse removed (clean delete).** The `ac` dispatcher cutover is complete (live pool on v0.8.8+), so the accept-and-ignore `shims install --wrapper`/`--aliases` and `setup --aliases` flags were removed outright (passing them now errors), along with the persisted `aliases` field (setupPoolState/setupGlobalState) and update's `--aliases` re-pass. Separately, `--wake` collapsed to runner-only: the `tmux`/`herdr`/`both`/`all` aliases + set machinery (`wakeSetContains`, `normalizeSetupWake`'s multi-value parsing, `canonicalizePersistedWake`) are gone — any persisted legacy wake reads back as `runner`.
 

--- a/init.go
+++ b/init.go
@@ -32,8 +32,8 @@ var embeddedSpecContent string
 const (
 	enrollmentVersion       = 21
 	gitignoreVersion        = 3
-	gitignoreBeginV1        = "# agentchute-gitignore v3 begin"
-	gitignoreEndV1          = "# agentchute-gitignore v3 end"
+	gitignoreBegin          = "# agentchute-gitignore v3 begin"
+	gitignoreEnd            = "# agentchute-gitignore v3 end"
 	defaultNamespace        = "agentchute"
 	specRecognitionSentinel = "# AGENTCHUTE.md"
 )

--- a/init_test.go
+++ b/init_test.go
@@ -290,10 +290,10 @@ func TestInitCreatesGitignoreInGitWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(got), gitignoreBeginV1) {
+	if !strings.Contains(string(got), gitignoreBegin) {
 		t.Errorf(".gitignore missing gitignore begin marker:\n%s", got)
 	}
-	if !strings.Contains(string(got), gitignoreEndV1) {
+	if !strings.Contains(string(got), gitignoreEnd) {
 		t.Errorf(".gitignore missing gitignore end marker:\n%s", got)
 	}
 	if !strings.Contains(string(got), ".agentchute/loop/agents/*.md") {

--- a/setup.go
+++ b/setup.go
@@ -1156,24 +1156,6 @@ func removeSetupShimsForWrapper(dir, wrapper string) error {
 	return nil
 }
 
-func removeSetupAliasShimsForWrapper(dir, wrapper string) error {
-	if strings.TrimSpace(dir) == "" {
-		return nil
-	}
-	specs, err := selectShimSpecs(wrapper)
-	if err != nil {
-		return nil
-	}
-	for _, spec := range specs {
-		for _, alias := range spec.Aliases {
-			if err := removeAgentchuteShim(filepath.Join(dir, alias)); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 func removeAgentchuteShim(path string) error {
 	owned, err := isAgentchuteShim(path)
 	if err != nil {

--- a/setup_test.go
+++ b/setup_test.go
@@ -475,7 +475,7 @@ func TestSetupRemovesOwnedSameNameAliasesOnly(t *testing.T) {
 
 	shimDir := filepath.Join(home, ".agentchute", "bin")
 	mustMkdir(t, shimDir)
-	mustWrite(t, filepath.Join(shimDir, "codex"), []byte(renderShimScript("/usr/local/bin/agentchute", shimDir, "codex")))
+	mustWrite(t, filepath.Join(shimDir, "codex"), []byte(legacyShimScript("/usr/local/bin/agentchute", shimDir, "codex")))
 	mustWrite(t, filepath.Join(shimDir, "claude"), []byte("#!/bin/sh\nexit 0\n"))
 	if err := os.Chmod(filepath.Join(shimDir, "codex"), 0o755); err != nil {
 		t.Fatal(err)

--- a/shims.go
+++ b/shims.go
@@ -196,20 +196,12 @@ func wantedAny(wanted map[string]bool, values []string) bool {
 	return false
 }
 
-func renderShimScript(agentchuteBin, shimDir, name string) string {
-	return fmt.Sprintf(`#!/bin/sh
-# agentchute shim v1
-AGENTCHUTE_BIN=${AGENTCHUTE_BIN:-%s}
-exec "$AGENTCHUTE_BIN" shims exec --name %s --shim-dir %s -- "$@"
-`, shellQuote(agentchuteBin), shellQuote(name), shellQuote(shimDir))
-}
-
 // renderDispatcherScript renders the single `ac` dispatcher that setup /
 // `shims install` writes. It is wrapper-agnostic: it execs `agentchute dispatch`,
 // which routes `ac <command>` and `ac serve <wrapper>` (parsed in dispatch.go). The
 // --shim-dir argument lets dispatch exclude a stale same-name alias shim inside
-// the shim dir during the transition. Mirrors renderShimScript's AGENTCHUTE_BIN
-// override + shellQuote discipline.
+// the shim dir during the transition (AGENTCHUTE_BIN override + shellQuote
+// discipline).
 func renderDispatcherScript(agentchuteBin, shimDir string) string {
 	return fmt.Sprintf(`#!/bin/sh
 # agentchute dispatcher v1

--- a/shims_test.go
+++ b/shims_test.go
@@ -1,11 +1,24 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+// legacyShimScript renders a pre-dispatcher per-wrapper `ac-*`/same-name shim
+// (the format the removed production renderShimScript emitted). Kept as a
+// test-only fixture generator so cleanup tests can plant legacy shims and assert
+// setup removes them; production no longer generates per-wrapper shims.
+func legacyShimScript(agentchuteBin, shimDir, name string) string {
+	return fmt.Sprintf(`#!/bin/sh
+# agentchute shim v1
+AGENTCHUTE_BIN=${AGENTCHUTE_BIN:-%s}
+exec "$AGENTCHUTE_BIN" shims exec --name %s --shim-dir %s -- "$@"
+`, shellQuote(agentchuteBin), shellQuote(name), shellQuote(shimDir))
+}
 
 func TestShimsInstallWritesDispatcher(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "bin")
@@ -206,8 +219,8 @@ func TestRemoveLegacyWrapperShims(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Marker-bearing agentchute shims (a namespaced launcher + a same-name alias).
-	mustWrite(t, filepath.Join(dir, "ac-codex"), []byte(renderShimScript("/bin/agentchute", dir, "ac-codex")))
-	mustWrite(t, filepath.Join(dir, "codex"), []byte(renderShimScript("/bin/agentchute", dir, "codex")))
+	mustWrite(t, filepath.Join(dir, "ac-codex"), []byte(legacyShimScript("/bin/agentchute", dir, "ac-codex")))
+	mustWrite(t, filepath.Join(dir, "codex"), []byte(legacyShimScript("/bin/agentchute", dir, "codex")))
 	// A user-owned same-name file WITHOUT the marker: must be left untouched.
 	userClaude := []byte("#!/bin/sh\n# my own claude wrapper\nexec /opt/claude \"$@\"\n")
 	mustWrite(t, filepath.Join(dir, "claude"), userClaude)


### PR DESCRIPTION
Fourth v0.9.1 lean PR — small, unambiguous dead-code removals.

## Removed / renamed
- **`renderShimScript`** (shims.go) — zero production callers; the legacy per-wrapper shim generator moved to a **test-only** `legacyShimScript` fixture helper (all 3 callers are tests that plant legacy shims to assert setup removes them). §13.1 row 256 done.
- **`removeSetupAliasShimsForWrapper`** (setup.go) — deleted outright, **zero callers** (the same-name alias cleanup is unreachable now that per-wrapper aliases are never installed).
- **`gitignoreBeginV1`/`gitignoreEndV1`** → `gitignoreBegin`/`gitignoreEnd` — the consts held the current `v3` marker string, so the `V1` suffix was a misnomer.

## Deferred (documented in §13.1 + commit)
- **`selectShimSpecs`/`shimInstallNames` → static list** (§13.1 row 257): **NOT** a safe mechanical swap — the `--wrapper` filtering is still wired via `removeSetupShimsForWrapper(dir, wrapper)`'s dropped-wrapper cleanup path (`droppedWrappers`). Reworded the row; deferred until that path is provably dead.
- **ComposeMessage workflow-vocab params (`now`/`to`/`task`/`status`) + `send --task`/`--status`**: a larger, design-flavored change (remove vs repurpose into the body; ~18 test occurrences) — its own PR.

## Verification
gofmt/vet/build · `go test . ./internal/loop` pass · conformance pass · drift(v21) + crown-jewel `TestPromptInjectionBytes*` pass. Net −13 lines.

Dual-gate: codex + sonnet.