### PR TITLE
P4: link extension implementation guidance

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -9,6 +9,9 @@ shared filesystem, delivered with a unique-temp + atomic `link()`-no-clobber.
 Anything that preserves the protocol's semantics is a valid agentchute
 implementation.
 
+For a copy-pasteable filesystem walkthrough, see
+[`AGENTCHUTE.md` Appendix C](AGENTCHUTE.md#appendix-c-hand-protocol-walkthrough).
+
 The seven invariants (`R1`/`D1`/`D2`/`O1`/`C1`/`E1`/`B1`) *are* those semantics,
 and [`conformance/`](conformance/) is the executable spec — the invariants as a
 Go test suite driven against multiple substrate bindings. An implementation that

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A small Markdown protocol that lets AI agents hand off work, request review, and
 
 [![MIT](https://img.shields.io/badge/license-MIT-1e6f57.svg)](LICENSE) [![Go 1.21+](https://img.shields.io/badge/go-1.21+-1e6f57.svg)](go.mod) [![Spec](https://img.shields.io/badge/spec-AGENTCHUTE.md-1e6f57.svg)](AGENTCHUTE.md)
 
-[Spec](AGENTCHUTE.md) · [Conformance suite](conformance/) · [Website](https://agentchute.dev)
+[Spec](AGENTCHUTE.md) · [Extensions](EXTENSIONS.md) · [Conformance suite](conformance/) · [Website](https://agentchute.dev)
 
 <img src="docs/agentchute-hero.svg" alt="AI agents — e.g. claude, codex, gemini, grok, but any terminal-based agent works — each with its own inbox, passing Markdown messages peer to peer with no central broker." width="760">
 
@@ -26,7 +26,7 @@ curl -fsSL https://raw.githubusercontent.com/agentchute/agentchute/main/install.
 >
 > Open a new shell (or `hash -r`) so the new `ac` dispatcher resolves (it installs at `~/.agentchute/bin/ac` and must precede the system `/usr/sbin/ac` on PATH). Verify with `ac doctor`, then restart each agent: `ac serve claude`, `ac serve codex`, … See [CHANGELOG](CHANGELOG.md).
 
-That's the reference CLI. The protocol itself is just files — a filesystem implementation of your own interoperates with it directly; over another transport it's protocol-compatible (see [`AGENTCHUTE.md`](AGENTCHUTE.md)).
+That's the reference CLI. The protocol itself is just files — a filesystem implementation of your own interoperates with it directly; over another transport it's protocol-compatible (see [`AGENTCHUTE.md`](AGENTCHUTE.md) and [`EXTENSIONS.md`](EXTENSIONS.md)).
 
 ---
 


### PR DESCRIPTION
## Summary
- add README links to EXTENSIONS.md for alternate implementations/transports
- point EXTENSIONS.md to AGENTCHUTE.md Appendix C as the copy-pasteable filesystem hand-protocol walkthrough

## Verification
- git diff --check
- gofmt -l .
- env -u AGENTCHUTE_SERVE_TOKEN go vet ./...
- env -u AGENTCHUTE_SERVE_TOKEN go test ./...
- env -u AGENTCHUTE_SERVE_TOKEN go build ./...
- (cd conformance && go test ./...)
- env -u AGENTCHUTE_SERVE_TOKEN go test ./internal/cli -run 'TestPromptInjectionBytesDefaultUsesCarriageReturn|TestPromptInjectionBytesCodexUsesBracketedPasteAndEnhancedEnter|TestPromptInjectionBytesCodexWrapperUsesEnhancedEnter|TestTemplatesMatchRepoWrappers'