### PR TITLE
P5: precise malformed/error model + conformance invariant

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -233,6 +233,8 @@ Triggers include malformed inbox filenames, unparseable frontmatter, or unparsea
 
 A well-formed canonical seq file is never quarantined; only a genuinely-unrecognized name is enforced on.
 
+Quarantine happens **pre-claim** (`check` validates before it claims, §6.3 step 3): a quarantined item is never claimed and never archived, so it never counts as **consumed**. It has no effect on `seq` either way — `seq` is the sender's own durable per-`(from,to)` counter (§6.1), not something a reader advances by claiming or quarantining a message, so a malformed item simply never touches it. It is never silently dropped: it persists as a file under `.agentchute/loop/malformed/` until an operator or agent inspects it. This is surfaced proactively, not just documented — `doctor`/`pending`/`boot` report the malformed count with a `check`-to-quarantine hint, and `gate` (including `--before finish`) blocks on any unquarantined malformed file until `check` runs.
+
 ## 12. Non-goals (v1)
 - No non-filesystem transport in the reference CLI.
 - No sender-side wake / push presence / reachability cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The repo follows a release-squash convention: each release lands on `main` as a 
 - `AGENTCHUTE.md` §6.4 updated: `to`/`task`/`status` no longer get special-case compat framing — they're unrecognized fields, ignored per §6.5 like any other.
 - No replacement field added. A message's subject, if any, remains a body convention (first Markdown line) per the RFC's leanest option.
 
+**Precise malformed/error model (P5 of the 0.9.1 post-release finish-line worklist)**
+- `AGENTCHUTE.md` §11.1 now states the invariants that were previously only implicit in the code: a quarantined message is never claimed/archived (never counts as consumed), never touches `seq` (a sender-owned counter quarantine has no path to), and is never silently dropped — it persists under `.agentchute/loop/malformed/` until inspected. Cites the existing `doctor`/`pending`/`boot`/`gate` surfacing rather than inventing new UX.
+- **Executable-spec change, not a docs pass**: added a malformed-quarantine invariant to `conformance/` (previously zero coverage there). Inbox-only by design — quarantine is a wire/filename-grammar concern specific to the FS+frontmatter substrate; the shared-log binding has no analogous concept (a log record is already-typed data, nothing like a bad filename can occur once it's in the stream), so it's not run via `eachBinding`, matching the existing `TestInbox_PostConsumeResendRelandsThenKeyDedup` precedent. Extends `inboxBinding` with a `DeliverRaw`/`MalformedItems` test-only affordance rather than the shared `Binding` interface — malformed-ness isn't one of the seven substrate-agnostic invariants.
+
 ## v0.9.1 (2026-07-01) — the lean release, finished
 
 A fast-follow that completes the v0.9.0 subtraction: remove all remaining legacy not in the current protocol spirit, then relocate the code into a clean shape. No new features; no wire-format change. Six dual-gated PRs (five code + one release-prep), each reviewed by codex + sonnet, plus a full 4-way docs sweep.

--- a/conformance/inbox_binding.go
+++ b/conformance/inbox_binding.go
@@ -24,12 +24,13 @@ type inboxBinding struct {
 	inbox     map[string][]Msg     // id -> ordered messages
 	seen      map[string]time.Time // id -> last_seen  (the .live fact)
 	delivered map[string]bool      // "to|from|seq" -> already landed (EEXIST dedup)
+	malformed map[string][]string  // id -> quarantined item names (§11.1)
 	window    time.Duration        // freshness window for "alive"
 	crash     bool                 // C1 fault: panic after act, before commit
 }
 
 func newInbox() *inboxBinding {
-	return &inboxBinding{inbox: map[string][]Msg{}, seen: map[string]time.Time{}, delivered: map[string]bool{}, window: 30 * time.Second}
+	return &inboxBinding{inbox: map[string][]Msg{}, seen: map[string]time.Time{}, delivered: map[string]bool{}, malformed: map[string][]string{}, window: 30 * time.Second}
 }
 
 func (b *inboxBinding) Name() string { return "inbox (N private inboxes)" }
@@ -180,4 +181,40 @@ func (b *inboxBinding) deliverSlow(to string, m Msg, staged chan<- struct{}, com
 	b.inbox[to] = append(b.inbox[to], m) // atomic make-visible
 	b.mu.Unlock()
 	return nil
+}
+
+// DeliverRaw models §11.1 quarantine at the substrate boundary: an inbound
+// item either decodes into a Msg (m != nil — same as Deliver) or it doesn't
+// (m == nil), in which case it is quarantined rather than delivered. This is
+// deliberately NOT part of the Binding interface: malformed-ness is a
+// wire/filename-grammar concern specific to the FS+frontmatter substrate, not
+// one of the seven substrate-agnostic invariants (a log-model record is
+// already-typed Go data with nothing analogous to a bad filename or
+// unparseable YAML — see logBinding, which has no DeliverRaw).
+//
+// Real reference behavior this stands in for (internal/loop.QuarantineInboxFile
+// + check.go): quarantine is a pure directory move done BEFORE any seq/consume
+// bookkeeping runs, so it never advances a seq counter and never occupies a
+// delivery/consume slot — modeled here by routing straight to the `malformed`
+// bucket instead of `inbox[to]`, touching no seq/delivered state at all.
+func (b *inboxBinding) DeliverRaw(to, item string, m *Msg) error {
+	if m == nil {
+		// §11.1.1 (quarantine) + §11.1.3 (continue): record it where it stays
+		// observable — never silently dropped — and do not block delivery of
+		// any other item to this or any other recipient.
+		b.mu.Lock()
+		b.malformed[to] = append(b.malformed[to], item)
+		b.mu.Unlock()
+		return nil
+	}
+	return b.Deliver(to, *m)
+}
+
+// MalformedItems returns the quarantined item names for id, oldest-first.
+func (b *inboxBinding) MalformedItems(id string) []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]string, len(b.malformed[id]))
+	copy(out, b.malformed[id])
+	return out
 }

--- a/conformance/inbox_malformed_test.go
+++ b/conformance/inbox_malformed_test.go
@@ -1,0 +1,55 @@
+package conformance
+
+import "testing"
+
+// TestInbox_MalformedQuarantineNeverDeliveredOrConsumedOrDropped pins §11.1's
+// enforcement-action contract at the substrate boundary: an item that fails
+// to decode is quarantined, not delivered — it never reaches Poll or
+// Consume, it is never silently dropped (it stays observable via
+// MalformedItems), and it never blocks or reorders valid mail to the same
+// recipient. This is the one lifecycle guarantee the reference CLI's
+// check.go + internal/loop.QuarantineInboxFile provide that the core seven
+// invariants (R1/D1/D2/O1/C1/E1/B1) don't otherwise cover.
+//
+// Inbox-only on purpose: quarantine is a wire/filename-grammar concern
+// specific to the FS+frontmatter substrate. The shared-log binding has no
+// analogous concept — a log record is already-typed Go data, nothing like a
+// bad filename or unparseable YAML can occur once it's in the stream — so
+// this is not run via eachBinding (same rationale as
+// TestInbox_PostConsumeResendRelandsThenKeyDedup).
+func TestInbox_MalformedQuarantineNeverDeliveredOrConsumedOrDropped(t *testing.T) {
+	b := newInbox()
+	must(t, b.Register("bob"))
+
+	must(t, b.DeliverRaw("bob", "valid-1", &Msg{From: "alice", Body: "first"}))
+	must(t, b.DeliverRaw("bob", "not-a-valid-message-name.md", nil))
+	must(t, b.DeliverRaw("bob", "valid-2", &Msg{From: "alice", Body: "second"}))
+
+	// Never delivered, never blocks/reorders valid mail: Poll shows exactly
+	// the two valid messages, in arrival order, with the malformed item absent.
+	got, _ := b.Poll("bob")
+	if len(got) != 2 || got[0].Body != "first" || got[1].Body != "second" {
+		t.Fatalf("malformed item must not appear in Poll and must not disturb valid message order/continuity; got %+v", got)
+	}
+
+	// Never silently dropped: it is quarantined (observable), not vanished.
+	mal := b.MalformedItems("bob")
+	if len(mal) != 1 || mal[0] != "not-a-valid-message-name.md" {
+		t.Fatalf("malformed item must be quarantined (observable via MalformedItems), not silently dropped; got %v", mal)
+	}
+
+	// Never counted as consumed: Consume only sees the 2 valid messages.
+	var acts []string
+	n, err := b.Consume("bob", func(m Msg) error { acts = append(acts, m.Body); return nil })
+	must(t, err)
+	if n != 2 || len(acts) != 2 {
+		t.Fatalf("consume must only see the 2 valid messages, never the quarantined item; n=%d acts=%v", n, acts)
+	}
+
+	// A second quarantine of a DIFFERENT item is additive, not overwriting —
+	// mirrors the real malformed/ dir accumulating distinct quarantined files.
+	must(t, b.DeliverRaw("bob", "also-bad.md", nil))
+	if mal := b.MalformedItems("bob"); len(mal) != 2 {
+		t.Fatalf("a second malformed item must accumulate, not overwrite the first; got %v", mal)
+	}
+}


### PR DESCRIPTION
## Summary
Finish-line worklist P5. Two parts per the locked scope:

**1. AGENTCHUTE.md §11.1 precision** — much already existed (quarantine action, notify, continue). Added the invariants that were only implicit in code:
- A quarantined message is never claimed/archived — never counts as **consumed** (quarantine happens pre-claim, `check` validates before it claims per §6.3 step 3).
- It never touches `seq` either way — confirmed against `QuarantineInboxFile` (`internal/loop/inbox.go`): it's a pure filesystem move (link-no-clobber + remove source) on an opaque byte blob, no seq/filename parsing at all. `seq` is the sender's own durable per-`(from,to)` counter; quarantine has no path to it.
- Explicitly "never silently dropped" — persists under `malformed/` until inspected.
- Cites the **existing** surfacing rather than inventing new UX: `doctor`/`pending`/`boot` report the malformed count with a `check`-to-quarantine hint (`pending.go`), `gate` (including `--before finish`) blocks on any unquarantined malformed file (`gate.go:327`, cites §11).

**2. The real work — malformed-quarantine invariant in `conformance/`** (zero coverage there today; the 7 core invariants R1/D1/D2/O1/C1/E1/B1 never covered it). Judgment call, per the kickoff's explicit permission to choose the fallback and justify it:

- `conformance/` is a **separate Go module** (`agentchute.dev/spike/conformance`) that can't import `internal/loop` (different import-path root — the internal-package rule blocks it) and deliberately elides wire encoding: `Binding.Deliver` takes an already-parsed `Msg`, with no concept of "raw bytes that might fail to parse."
- Bending the shared `Binding` interface to add a raw-delivery path would force `logBinding` to fake an unrelated concept — a log record is already-typed Go data; there is nothing analogous to a bad filename or unparseable YAML once something is in the append-only stream. Malformed-ness is a wire/filename-grammar concern specific to the FS+frontmatter substrate, not one of the seven substrate-agnostic invariants.
- Chose codex's pre-agreed fallback: extended `inboxBinding` (not the `Binding` interface) with `DeliverRaw`/`MalformedItems` test-only affordances, and added `TestInbox_MalformedQuarantineNeverDeliveredOrConsumedOrDropped` as an **inbox-only** test with an explicit "why not eachBinding" comment — this exactly matches the codebase's own established precedent, `TestInbox_PostConsumeResendRelandsThenKeyDedup` (same file style, same reasoning shape, same "Inbox-only on purpose" framing).
- The test proves: a malformed item never appears in `Poll` (never delivered), never disturbs the order/continuity of valid mail around it, is never silently dropped (observable via `MalformedItems`), and is never passed to `Consume`'s handler (never consumed).

**Reviewer note** (per the plan): this PR adds a conformance invariant — treat it as an executable-spec change, not a docs pass.

## Test plan
- [x] `gofmt -l .` (both modules) — clean
- [x] `go vet ./...` (both modules) — clean
- [x] `go build ./...` (both modules) — clean
- [x] `go test ./...` (main module) — all packages pass
- [x] `(cd conformance && go test ./...)` — all pass, including new + all 12 existing tests re-verified green (ran full `-v` sweep)
- [x] `TestPromptInjectionBytes*` (×3, crown jewel) — pass
- [x] `TestTemplatesMatchRepoWrappers` — pass
- [x] New test run standalone first to confirm it actually exercises the guard (not a vacuous pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)