### PR TITLE
D2: key dropped-wrapper shim cleanup

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -256,11 +256,7 @@ Quarantine happens **pre-claim** (`check` validates before it claims, §6.3 step
 
 ### 13.1 Compatibility & deprecations (scheduled removals)
 
-A deferred-cleanup ledger. The one-release, marker-backed compat items carried from v0.8.0 have all been removed (see the DONE notes below); what remains is a single internal cleanup that is NOT a mechanical grep-delete and has no `// COMPAT` marker. **Re-listing is not retiring:** if an item's gate stays unmet release after release, escalate — do not silently re-defer.
-
-| Item | Location | Target | Gate / why deferred |
-|------|----------|--------|---------------------|
-| `selectShimSpecs`/`shimInstallNames` selectors → static legacy-name list | `internal/cli/shims.go`, `internal/cli/setup.go` | when unblocked | **NOT a safe mechanical swap** — the `--wrapper` filtering is still wired via `removeSetupShimsForWrapper(dir, wrapper)` for the dropped-wrapper cleanup path (`droppedWrappers`), so replacing the selectors with a static "all" list would change cleanup behavior. Defer until that path is provably dead. |
+A deferred-cleanup ledger. It is currently empty; prior completed cleanups remain below for release-history context. **Re-listing is not retiring:** if an item's gate stays unmet release after release, escalate — do not silently re-defer.
 
 **DONE in v0.9.1 — dead shim-generation code removed (clean delete).** `renderShimScript` (the legacy per-wrapper shim generator) had zero production callers and moved to a test-only `legacyShimScript` fixture helper. `removeSetupAliasShimsForWrapper` was deleted outright (zero callers — the same-name alias cleanup is unreachable now that aliases are never installed). The misnamed `gitignoreBeginV1`/`gitignoreEndV1` constants (they held the current `v3` marker) were renamed `gitignoreBegin`/`gitignoreEnd`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The repo follows a release-squash convention: each release lands on `main` as a 
 - `AGENTCHUTE.md` §11.1 now states the invariants that were previously only implicit in the code: a quarantined message is never claimed/archived (never counts as consumed), never touches `seq` (a sender-owned counter quarantine has no path to), and is never silently dropped — it persists under `.agentchute/loop/malformed/` until inspected. Cites the existing `doctor`/`pending`/`boot`/`gate` surfacing rather than inventing new UX.
 - **Executable-spec change, not a docs pass**: added a malformed-quarantine invariant to `conformance/` (previously zero coverage there). Inbox-only by design — quarantine is a wire/filename-grammar concern specific to the FS+frontmatter substrate; the shared-log binding has no analogous concept (a log record is already-typed data, nothing like a bad filename can occur once it's in the stream), so it's not run via `eachBinding`, matching the existing `TestInbox_PostConsumeResendRelandsThenKeyDedup` precedent. Extends `inboxBinding` with a `DeliverRaw`/`MalformedItems` test-only affordance rather than the shared `Binding` interface — malformed-ness isn't one of the seven substrate-agnostic invariants.
 
+**Replaced the dropped-wrapper legacy shim selector cleanup (D2 of the 0.9.1 post-release finish-line worklist)**
+- `removeSetupShimsForWrapper` now uses a static map keyed by setup wrapper name (`claude-code`, `codex`, `gemini-cli`, `grok`) to remove only that dropped wrapper's legacy `ac-*` and same-name shims.
+- Deleted the `selectShimSpecs`/`shimInstallNames` selector helpers; cleanup still marker-checks files, preserves the `ac` dispatcher, and leaves user-owned same-name files untouched.
+- Removed the now-satisfied §13.1 deferred ledger row from `AGENTCHUTE.md`.
+
 ## v0.9.1 (2026-07-01) — the lean release, finished
 
 A fast-follow that completes the v0.9.0 subtraction: remove all remaining legacy not in the current protocol spirit, then relocate the code into a clean shape. No new features; no wire-format change. Six dual-gated PRs (five code + one release-prep), each reviewed by codex + sonnet, plus a full 4-way docs sweep.

--- a/internal/cli/grok_parity_test.go
+++ b/internal/cli/grok_parity_test.go
@@ -29,21 +29,16 @@ func TestShimsInstallGrok(t *testing.T) {
 }
 
 func TestShimsAllIncludesGrok(t *testing.T) {
-	specs, err := selectShimSpecs("all")
-	if err != nil {
-		t.Fatal(err)
+	spec, ok := wrapperSpecForName("ac-grok")
+	if !ok {
+		t.Fatal("ac-grok legacy shim spec is missing")
 	}
-	var found bool
-	for _, s := range specs {
-		if s.Name == "ac-grok" {
-			found = true
-			if s.AgentID != "grok" || s.Vendor != "xai" {
-				t.Errorf("grok shim spec = %+v, want AgentID=grok Vendor=xai", s)
-			}
-		}
+	if spec.AgentID != "grok" || spec.Vendor != "xai" {
+		t.Errorf("grok shim spec = %+v, want AgentID=grok Vendor=xai", spec)
 	}
-	if !found {
-		t.Error("`shims install --wrapper all` does not include grok")
+	names := legacyShimNamesForSetupWrapper("grok")
+	if !stringSliceContains(names, "ac-grok") || !stringSliceContains(names, "grok") {
+		t.Errorf("grok legacy cleanup names = %v, want ac-grok and grok", names)
 	}
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1109,7 +1109,7 @@ func removeSetupShims(dir string) error {
 	if strings.TrimSpace(dir) == "" {
 		return nil
 	}
-	for _, name := range allShimCommandNames(true) {
+	for _, name := range allLegacyShimNames() {
 		path := filepath.Join(dir, name)
 		if err := removeAgentchuteShim(path); err != nil {
 			return err
@@ -1142,15 +1142,13 @@ func removeSetupShimsForWrapper(dir, wrapper string) error {
 	if strings.TrimSpace(dir) == "" {
 		return nil
 	}
-	specs, err := selectShimSpecs(wrapper)
-	if err != nil {
+	names := legacyShimNamesForSetupWrapper(wrapper)
+	if len(names) == 0 {
 		return nil
 	}
-	for _, spec := range specs {
-		for _, name := range shimInstallNames(spec, true) {
-			if err := removeAgentchuteShim(filepath.Join(dir, name)); err != nil {
-				return err
-			}
+	for _, name := range names {
+		if err := removeAgentchuteShim(filepath.Join(dir, name)); err != nil {
+			return err
 		}
 	}
 	fmt.Printf("removed setup-managed %s shims from %s\n", wrapper, dir)

--- a/internal/cli/shims.go
+++ b/internal/cli/shims.go
@@ -30,6 +30,15 @@ var wrapperSpecs = []wrapperSpec{
 	{Key: "grok", Name: "ac-grok", Aliases: []string{"grok"}, AgentID: "grok", Vendor: "xai", Candidates: []string{"grok"}},
 }
 
+var legacyShimNamesBySetupWrapper = map[string][]string{
+	"claude-code": {"ac-claude", "claude", "claude-code"},
+	"codex":       {"ac-codex", "codex"},
+	"gemini-cli":  {"ac-gemini", "gemini", "gemini-cli", "agy"},
+	"grok":        {"ac-grok", "grok"},
+}
+
+var legacyShimSetupWrapperOrder = []string{"claude-code", "codex", "gemini-cli", "grok"}
+
 // wrapperForToken resolves a dispatcher wrapper token (`ac serve <token>`) by
 // canonical Key or alias. It deliberately does NOT match the legacy ac-* Name —
 // the dispatcher addresses wrappers, not generated shim filenames.
@@ -129,71 +138,20 @@ func cmdShimsInstall(args []string) error {
 	return nil
 }
 
-func shimInstallNames(spec wrapperSpec, aliases bool) []string {
-	names := []string{spec.Name}
-	if aliases {
-		names = append(names, spec.Aliases...)
+func legacyShimNamesForSetupWrapper(wrapper string) []string {
+	names := legacyShimNamesBySetupWrapper[strings.TrimSpace(wrapper)]
+	if len(names) == 0 {
+		return nil
 	}
-	return names
+	return append([]string(nil), names...)
 }
 
-func allShimCommandNames(aliases bool) []string {
+func allLegacyShimNames() []string {
 	var names []string
-	for _, spec := range wrapperSpecs {
-		names = append(names, shimInstallNames(spec, aliases)...)
+	for _, wrapper := range legacyShimSetupWrapperOrder {
+		names = append(names, legacyShimNamesBySetupWrapper[wrapper]...)
 	}
 	return names
-}
-
-func selectShimSpecs(wrapper string) ([]wrapperSpec, error) {
-	wrapper = strings.TrimSpace(wrapper)
-	if wrapper == "" || wrapper == "all" {
-		return wrapperSpecs, nil
-	}
-	wanted := map[string]bool{}
-	for _, part := range strings.Split(wrapper, ",") {
-		key := strings.TrimSpace(part)
-		if key == "" {
-			continue
-		}
-		wanted[key] = true
-	}
-	if len(wanted) == 0 {
-		return nil, fmt.Errorf("--wrapper must not be empty")
-	}
-	var selected []wrapperSpec
-	matched := map[string]bool{}
-	for _, spec := range wrapperSpecs {
-		if wanted[spec.Name] || wanted[spec.AgentID] || wantedAny(wanted, spec.Aliases) {
-			selected = append(selected, spec)
-			if wanted[spec.Name] {
-				matched[spec.Name] = true
-			}
-			if wanted[spec.AgentID] {
-				matched[spec.AgentID] = true
-			}
-			for _, alias := range spec.Aliases {
-				if wanted[alias] {
-					matched[alias] = true
-				}
-			}
-		}
-	}
-	for key := range wanted {
-		if !matched[key] {
-			return nil, fmt.Errorf("--wrapper %q is not recognized; known: claude-code, codex, gemini-cli, grok, all", key)
-		}
-	}
-	return selected, nil
-}
-
-func wantedAny(wanted map[string]bool, values []string) bool {
-	for _, v := range values {
-		if wanted[v] {
-			return true
-		}
-	}
-	return false
 }
 
 // renderDispatcherScript renders the single `ac` dispatcher that setup /
@@ -274,7 +232,7 @@ func removeLegacyWrapperShims(absDir string) ([]string, error) {
 		return nil, nil
 	}
 	var removed []string
-	for _, name := range allShimCommandNames(true) {
+	for _, name := range allLegacyShimNames() {
 		path := filepath.Join(absDir, name)
 		owned, err := isAgentchuteShim(path)
 		if err != nil {

--- a/internal/cli/shims_test.go
+++ b/internal/cli/shims_test.go
@@ -20,6 +20,15 @@ exec "$AGENTCHUTE_BIN" shims exec --name %s --shim-dir %s -- "$@"
 `, shellQuote(agentchuteBin), shellQuote(name), shellQuote(shimDir))
 }
 
+func stringSliceContains(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestShimsInstallWritesDispatcher(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "bin")
 	if err := cmdShims([]string{"install", "--dir", dir, "--quiet"}); err != nil {
@@ -254,6 +263,64 @@ func TestRemoveLegacyWrapperShims(t *testing.T) {
 	}
 }
 
+func TestRemoveSetupShimsForWrapperNarrowsToDroppedWrapper(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range legacyShimNamesForSetupWrapper("gemini-cli") {
+		mustWrite(t, filepath.Join(dir, name), []byte(legacyShimScript("/bin/agentchute", dir, name)))
+	}
+	for _, name := range legacyShimNamesForSetupWrapper("codex") {
+		mustWrite(t, filepath.Join(dir, name), []byte(legacyShimScript("/bin/agentchute", dir, name)))
+	}
+	mustWrite(t, filepath.Join(dir, "ac"), []byte(renderDispatcherScript("/bin/agentchute", dir)))
+	userClaude := []byte("#!/bin/sh\n# user-owned claude wrapper\nexec /opt/claude \"$@\"\n")
+	mustWrite(t, filepath.Join(dir, "claude"), userClaude)
+
+	if err := removeSetupShimsForWrapper(dir, "gemini-cli"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range legacyShimNamesForSetupWrapper("gemini-cli") {
+		if _, err := os.Stat(filepath.Join(dir, name)); !os.IsNotExist(err) {
+			t.Fatalf("%s should be removed for dropped gemini-cli: %v", name, err)
+		}
+	}
+	for _, name := range legacyShimNamesForSetupWrapper("codex") {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("%s should survive dropping gemini-cli: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "ac")); err != nil {
+		t.Fatalf("dispatcher must survive per-wrapper cleanup: %v", err)
+	}
+	if string(mustRead(t, filepath.Join(dir, "claude"))) != string(userClaude) {
+		t.Fatal("user-owned non-target wrapper file was modified/removed")
+	}
+}
+
+func TestRemoveSetupShimsForWrapperPreservesUserOwnedTargetName(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(dir, "ac-codex"), []byte(legacyShimScript("/bin/agentchute", dir, "ac-codex")))
+	userCodex := []byte("#!/bin/sh\n# user-owned codex wrapper\nexec /opt/codex \"$@\"\n")
+	mustWrite(t, filepath.Join(dir, "codex"), userCodex)
+
+	if err := removeSetupShimsForWrapper(dir, "codex"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "ac-codex")); !os.IsNotExist(err) {
+		t.Fatalf("agentchute-owned ac-codex should be removed: %v", err)
+	}
+	if string(mustRead(t, filepath.Join(dir, "codex"))) != string(userCodex) {
+		t.Fatal("user-owned targeted same-name file was modified/removed")
+	}
+}
+
 // WI-E3 (gemini input): `agy` is the actual gemini-cli binary name on PATH, so
 // the launcher must recognize it as the gemini-cli wrapper / ac-gemini.
 func TestShims_AgyResolvesToGeminiWrapper(t *testing.T) {
@@ -264,13 +331,9 @@ func TestShims_AgyResolvesToGeminiWrapper(t *testing.T) {
 	if spec.Name != "ac-gemini" || spec.AgentID != "gemini-cli" {
 		t.Fatalf("agy resolved to %s/%s, want ac-gemini/gemini-cli", spec.Name, spec.AgentID)
 	}
-	// agy must also be a valid --wrapper alias selector and a real-binary candidate.
-	selected, err := selectShimSpecs("agy")
-	if err != nil {
-		t.Fatalf("selectShimSpecs(\"agy\"): %v", err)
-	}
-	if len(selected) != 1 || selected[0].Name != "ac-gemini" {
-		t.Fatalf("selectShimSpecs(\"agy\") = %v, want [ac-gemini]", selected)
+	// agy must also remain in the keyed legacy cleanup map and real-binary candidates.
+	if !stringSliceContains(legacyShimNamesForSetupWrapper("gemini-cli"), "agy") {
+		t.Fatalf("gemini-cli legacy cleanup names %v missing agy", legacyShimNamesForSetupWrapper("gemini-cli"))
 	}
 	foundCandidate := false
 	for _, c := range spec.Candidates {


### PR DESCRIPTION
Summary:
- replace dropped-wrapper cleanup selector use with a static setup-wrapper -> legacy shim-name map
- delete selectShimSpecs/shimInstallNames and migrate direct tests
- add narrowing coverage for per-wrapper cleanup, dispatcher preservation, and user-owned same-name files
- remove the satisfied AGENTCHUTE.md §13.1 deferred row and document the change under Unreleased

Verification:
- git diff --check
- gofmt -l .
- env -u AGENTCHUTE_SERVE_TOKEN go vet ./...
- env -u AGENTCHUTE_SERVE_TOKEN go test ./...
- env -u AGENTCHUTE_SERVE_TOKEN go build ./...
- env -u AGENTCHUTE_SERVE_TOKEN go test ./... (conformance/)
- go test ./internal/cli -run 'TestRemoveSetupShimsForWrapper|TestRemoveLegacyWrapperShims|TestShims_AgyResolvesToGeminiWrapper|TestShimsAllIncludesGrok'\n- go test ./internal/cli -run 'TestPromptInjectionBytes|TestTemplatesMatchRepoWrappers|TestRenderWrapperBlockLeavesNoUnexpandedTokens|TestHookTemplates|TestGeminiHookTemplateUsesBeforeAgentJSONGate'\n\nReviewers requested via agentchute: claude-code-agentchute + sonnet.