### PR TITLE
fix(runner): log diagnostics outside raw terminal

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -209,6 +209,7 @@ type runnerRuntime struct {
 	ptmx     *os.File
 	lease    *loop.ServeLease
 	done     <-chan error
+	diag     *runnerDiagnostics
 
 	mu                 sync.Mutex
 	ptmxMu             sync.Mutex
@@ -224,6 +225,108 @@ type runnerRuntime struct {
 
 	wakeCh chan struct{}
 	stopCh chan struct{}
+}
+
+type runnerDiagnostics struct {
+	mu         sync.Mutex
+	file       *os.File
+	dropped    int
+	fatalLines []string
+}
+
+func newRunnerDiagnostics(cfg *loop.Config, agentID string) *runnerDiagnostics {
+	d := &runnerDiagnostics{}
+	stateDir := cfg.AgentStateDir(agentID)
+	if err := loop.EnsurePrivateDir(stateDir); err != nil {
+		d.dropped++
+		return d
+	}
+	logFile, err := os.OpenFile(filepath.Join(stateDir, "runner.log"), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		d.dropped++
+		return d
+	}
+	d.file = logFile
+	return d
+}
+
+func (d *runnerDiagnostics) logf(format string, args ...any) {
+	if d == nil {
+		return
+	}
+	d.write(fmt.Sprintf(format, args...))
+}
+
+func (d *runnerDiagnostics) bufferFatalf(format string, args ...any) {
+	if d == nil {
+		return
+	}
+	msg := strings.TrimRight(fmt.Sprintf(format, args...), "\n")
+	d.logf("%s\n", msg)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.fatalLines = append(d.fatalLines, msg)
+}
+
+func (d *runnerDiagnostics) printBufferedFatal(w io.Writer) {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	lines := append([]string(nil), d.fatalLines...)
+	d.fatalLines = nil
+	d.mu.Unlock()
+	if len(lines) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "%s\n", strings.Join(lines, "; "))
+}
+
+func (d *runnerDiagnostics) close() {
+	if d == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.file != nil {
+		_ = d.file.Close()
+		d.file = nil
+	}
+}
+
+func (d *runnerDiagnostics) write(msg string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.file == nil {
+		d.dropped++
+		return
+	}
+	if _, err := io.WriteString(d.file, msg); err != nil {
+		d.dropped++
+		_ = d.file.Close()
+		d.file = nil
+	}
+}
+
+func (r *runnerRuntime) logf(format string, args ...any) {
+	if r == nil || r.diag == nil {
+		return
+	}
+	r.diag.logf(format, args...)
+}
+
+func (r *runnerRuntime) bufferFatalf(format string, args ...any) {
+	if r == nil || r.diag == nil {
+		return
+	}
+	r.diag.bufferFatalf(format, args...)
+}
+
+func restoreRunnerTerminal(restoreTerminal func() error, diag *runnerDiagnostics, stderr io.Writer) {
+	if err := restoreTerminal(); err != nil {
+		diag.bufferFatalf("agentchute serve: restore terminal: %v\n", err)
+	}
+	diag.printBufferedFatal(stderr)
 }
 
 func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
@@ -275,12 +378,12 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 		_ = loop.ReleaseLease(lease)
 		return fmt.Errorf("set stdin raw mode: %w", err)
 	}
+	diag := newRunnerDiagnostics(cfg, opts.AgentID)
+	defer diag.close()
 	if rawEnabled {
-		defer func() {
-			if err := restoreTerminal(); err != nil {
-				fmt.Fprintf(os.Stderr, "agentchute serve: restore terminal: %v\n", err)
-			}
-		}()
+		defer restoreRunnerTerminal(restoreTerminal, diag, os.Stderr)
+	} else {
+		defer diag.printBufferedFatal(os.Stderr)
 	}
 
 	rt := &runnerRuntime{
@@ -293,6 +396,7 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 		ptmx:           ptmx,
 		lease:          lease,
 		done:           done,
+		diag:           diag,
 		wakeCh:         make(chan struct{}, 1),
 		stopCh:         make(chan struct{}),
 		seenInboxFiles: make(map[string]struct{}),
@@ -301,7 +405,7 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 	rt.lastOutputUnixNano.Store(nowUnix)
 	rt.lastInputUnixNano.Store(nowUnix)
 	if err := rt.saveState(); err != nil {
-		fmt.Fprintf(os.Stderr, "agentchute serve: write runner state: %v\n", err)
+		rt.logf("agentchute serve: write runner state: %v\n", err)
 	}
 
 	defer func() {
@@ -317,7 +421,7 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 		// (another serve owns the id); releasing would be a no-op and must not
 		// delete the new owner's claim, so it is not an error to report.
 		if err := loop.ReleaseLease(rt.lease); err != nil && !errors.Is(err, loop.ErrFenced) {
-			fmt.Fprintf(os.Stderr, "agentchute serve: release serve lease: %v\n", err)
+			rt.logf("agentchute serve: release serve lease: %v\n", err)
 		}
 	}()
 
@@ -444,15 +548,15 @@ func (r *runnerRuntime) pollOnce(enqueueNew bool) {
 	if r.lease != nil {
 		if err := loop.RenewLease(r.lease); err != nil {
 			if errors.Is(err, loop.ErrFenced) {
-				fmt.Fprintf(os.Stderr, "agentchute serve: serve lease reclaimed (fenced); shutting down\n")
+				r.bufferFatalf("agentchute serve: serve lease reclaimed (fenced); shutting down\n")
 				r.requestShutdown(syscall.SIGTERM)
 				return
 			}
-			fmt.Fprintf(os.Stderr, "agentchute serve: renew serve lease: %v\n", err)
+			r.logf("agentchute serve: renew serve lease: %v\n", err)
 		}
 	}
 	if err := loop.UpdateLastSeen(r.cfg, r.opts.AgentID, now); err != nil {
-		fmt.Fprintf(os.Stderr, "agentchute serve: update last_seen: %v\n", err)
+		r.logf("agentchute serve: update last_seen: %v\n", err)
 	}
 	// Track a SEEN-filename snapshot across BOTH parsed messages and skipped
 	// (malformed/unparseable) files. Lexicographic-newest tracking misses two
@@ -463,7 +567,7 @@ func (r *runnerRuntime) pollOnce(enqueueNew bool) {
 	// filename not already in the set is unseen mail and must enqueue a wake.
 	msgs, skipped, err := loop.ListInboxMessagesWithSkipped(r.cfg.AgentInboxDir(r.opts.AgentID))
 	if err != nil && !errors.Is(err, loop.ErrInboxMissing) {
-		fmt.Fprintf(os.Stderr, "agentchute serve: list inbox: %v\n", err)
+		r.logf("agentchute serve: list inbox: %v\n", err)
 	}
 	r.mu.Lock()
 	if r.seenInboxFiles == nil {
@@ -490,7 +594,7 @@ func (r *runnerRuntime) pollOnce(enqueueNew bool) {
 	r.lastPoll = now
 	r.mu.Unlock()
 	if err := r.saveState(); err != nil {
-		fmt.Fprintf(os.Stderr, "agentchute serve: write runner state: %v\n", err)
+		r.logf("agentchute serve: write runner state: %v\n", err)
 	}
 }
 
@@ -564,7 +668,7 @@ func (r *runnerRuntime) isIdle() bool {
 
 func (r *runnerRuntime) injectPrompt() {
 	if err := r.writePTY(promptInjectionBytes(r.opts)); err != nil {
-		fmt.Fprintf(os.Stderr, "agentchute serve: inject prompt: %v\n", err)
+		r.logf("agentchute serve: inject prompt: %v\n", err)
 		return
 	}
 	now := time.Now().UTC()
@@ -605,7 +709,7 @@ func (r *runnerRuntime) copyPTYOutput() {
 		if n > 0 {
 			r.lastOutputUnixNano.Store(time.Now().UnixNano())
 			if _, werr := os.Stdout.Write(buf[:n]); werr != nil {
-				fmt.Fprintf(os.Stderr, "agentchute serve: write stdout: %v\n", werr)
+				r.logf("agentchute serve: write stdout: %v\n", werr)
 				return
 			}
 		}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -77,6 +80,28 @@ func TestRunnerMakeRawNoopsForNonTerminal(t *testing.T) {
 	}
 	if err := restore(); err != nil {
 		t.Fatalf("restore err = %v", err)
+	}
+}
+
+func TestRunnerDiagnosticsLogFileOnlyDuringRawWindow(t *testing.T) {
+	root := setupShortRunFixture(t)
+	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := newPollTestRuntime(t, cfg, "runner-test")
+	rt.diag = newRunnerDiagnostics(cfg, "runner-test")
+	defer rt.diag.close()
+
+	stderr := captureStderr(t, func() {
+		rt.injectPrompt()
+	})
+	if stderr != "" {
+		t.Fatalf("raw-window diagnostic wrote stderr: %q", stderr)
+	}
+	log := readRunnerLog(t, cfg, "runner-test")
+	if !strings.Contains(log, "agentchute serve: inject prompt:") {
+		t.Fatalf("runner.log missing inject diagnostic:\n%s", log)
 	}
 }
 
@@ -178,6 +203,81 @@ func TestRunnerPollShutsDownWhenFenced(t *testing.T) {
 	}
 	if rt.drainWake() {
 		t.Fatal("fenced runner enqueued a wake instead of shutting down")
+	}
+}
+
+func TestRunnerFencedShutdownLogsAndBuffersFatal(t *testing.T) {
+	root := setupShortRunFixture(t)
+	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := newPollTestRuntime(t, cfg, "runner-test")
+	rt.diag = newRunnerDiagnostics(cfg, "runner-test")
+	defer rt.diag.close()
+	lease, err := loop.AcquireServeLease(cfg, "runner-test")
+	if err != nil {
+		t.Fatalf("acquire lease: %v", err)
+	}
+	rt.lease = lease
+
+	reclaimed := loop.ServeClaim{
+		ID:         "runner-test",
+		Host:       "other-host",
+		PID:        os.Getpid(),
+		ServeToken: "ffffffffffffffffffffffffffffffff",
+		StartedAt:  time.Now().UTC(),
+		LastSeen:   time.Now().UTC(),
+	}
+	data, err := json.Marshal(reclaimed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(cfg.AgentStateDir("runner-test"), "serve.claim"), data)
+
+	stderr := captureStderr(t, func() {
+		rt.pollOnce(true)
+	})
+	if stderr != "" {
+		t.Fatalf("fenced shutdown wrote raw stderr: %q", stderr)
+	}
+	if !rt.shutdownRequested.Load() {
+		t.Fatal("fenced runner did not request shutdown")
+	}
+	log := readRunnerLog(t, cfg, "runner-test")
+	want := "agentchute serve: serve lease reclaimed (fenced); shutting down"
+	if !strings.Contains(log, want) {
+		t.Fatalf("runner.log missing fenced fatal:\n%s", log)
+	}
+
+	var postRestore bytes.Buffer
+	restoreRunnerTerminal(func() error { return nil }, rt.diag, &postRestore)
+	if got := postRestore.String(); got != want+"\n" {
+		t.Fatalf("post-restore fatal = %q, want %q", got, want+"\n")
+	}
+}
+
+func TestRestoreRunnerTerminalBuffersRestoreFailure(t *testing.T) {
+	root := setupShortRunFixture(t)
+	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	diag := newRunnerDiagnostics(cfg, "runner-test")
+	defer diag.close()
+
+	var stderr bytes.Buffer
+	restoreRunnerTerminal(func() error {
+		return errors.New("raw mode still active")
+	}, diag, &stderr)
+
+	want := "agentchute serve: restore terminal: raw mode still active"
+	if got := stderr.String(); got != want+"\n" {
+		t.Fatalf("restore fatal = %q, want %q", got, want+"\n")
+	}
+	log := readRunnerLog(t, cfg, "runner-test")
+	if !strings.Contains(log, want) {
+		t.Fatalf("runner.log missing restore fatal:\n%s", log)
 	}
 }
 
@@ -312,6 +412,34 @@ func (r *runnerRuntime) drainWake() bool {
 	default:
 	}
 	return pending
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+	fn()
+	_ = w.Close()
+	t.Cleanup(func() { _ = r.Close() })
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+func readRunnerLog(t *testing.T, cfg *loop.Config, agentID string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(cfg.AgentStateDir(agentID), "runner.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
 }
 
 // A malformed/skipped inbox file (parse failure) must still wake the runner:


### PR DESCRIPTION
## Summary
- write runner diagnostics emitted during the raw terminal window to `state/<agent-id>/runner.log`
- keep raw-window diagnostics file-only, including lease release cleanup
- buffer fenced shutdown and restore failure as the only post-restore stderr fatal line cases
- add focused coverage for file-only diagnostics and post-restore fatal output; prompt injection tests unchanged

## Manual acceptance
- Long-running wrapper status/input rows should stop disappearing from raw stderr smears. The observed failure mode is raw stderr landing at the TUI cursor position, usually parked near bottom status/input rows.

## Verification
- `gofmt -w .`
- `go vet ./...`
- `env -u AGENTCHUTE_SERVE_TOKEN go test ./...`
- `go build ./...`
- `env -u AGENTCHUTE_SERVE_TOKEN go test -race ./...`
- `(cd conformance && env -u AGENTCHUTE_SERVE_TOKEN go test ./...)`
- `shellcheck install.sh`
- `sh tests/install_test.sh`
- `goreleaser check`
- `go test ./internal/cli -run 'TestPromptInjectionBytes'`
- `git diff --check`

Note: plain `go test ./...` inherits this agentchute runner session's `AGENTCHUTE_SERVE_TOKEN` and causes existing send tests to fail closed with a fenced-token mismatch; unsetting that runner-only env var gives the valid test environment.

Review requested via agentchute: claude-code-agentchute + sonnet.
