### PR TITLE
fix(ack): commit .claimed unconditionally, report finish-gate status separately

### DIFF
--- a/internal/cli/ack.go
+++ b/internal/cli/ack.go
@@ -17,19 +17,30 @@ import (
 // yet commit. Archiving is the single commit point; a crash before ack leaves the
 // residue in .claimed so the next `check` RE-DELIVERS it (at-least-once).
 //
-// CLEAR-THEN-COMMIT (the load-bearing contract): ack archives ONLY IF the finish
-// gate is clear (finishGateClear: unread / malformed / pending-reply / corrupt
-// ledger / missing registration). If finish would BLOCK, ack archives NOTHING and
-// leaves .claimed intact, so a gate-blocked turn still RE-DELIVERS its claimed
-// mail next turn (at-least-once is preserved across the block). This is why the
-// Stop/BeforeAgent hooks can run `ack` alongside `gate --before finish` in any
-// order: ack self-gates, so claimed mail is never committed past a blocked finish.
-// The agent's OWN claimed/owed state is NON-BLOCKING in the finish gate, so ack
-// can always commit its just-claimed mail once unrelated blockers clear.
+// UNCONDITIONAL COMMIT (v0.10.1, replaces the old CLEAR-THEN-COMMIT contract):
+// ack ALWAYS archives .claimed, regardless of finish-gate status. Archiving is
+// the caller's OWN state (mail it already claimed and acted on); it is not pool
+// hygiene, and gating it on the finish gate meant an UNRELATED blocker — e.g. a
+// third party dropping a new malformed/unread file into this agent's inbox
+// between `check` and `ack` — delayed committing mail this agent had already
+// correctly handled. The finish gate still independently blocks `finish`: ack
+// evaluates it AFTER committing (so reported reasons reflect the post-commit
+// state) purely to REPORT whether other obligations remain, never to withhold
+// the archive.
+//
+// EXIT CODE distinguishes the two outcomes so scripts never mistake "committed"
+// for "done": gate clear after commit => nil (exit 0). Gate still blocked after
+// commit (unrelated obligations remain) => errBlocked (exit 2), same sentinel
+// `gate --before finish` returns, so `ack`'s exit code alone tells a caller
+// whether it's safe to treat the turn as finished. A blocked exit is reported
+// via text/JSON exactly like an already-committed-and-still-blocked state; it is
+// NOT a command failure (exit 1) — the commit itself always succeeds or `ack`
+// returns a real error.
 //
 // Idempotent: an already-archived message (e.g. a partial prior ack) is treated
 // as success, and an empty .claimed is a no-op. Flags mirror `check`
-// (--as/--vendor/--json) plus --quiet for the Stop-hook commit step.
+// (--as/--vendor/--json) plus --quiet for the Stop-hook commit step (--quiet
+// suppresses text/JSON output but never the exit code).
 func cmdAck(args []string) error {
 	fs := flag.NewFlagSet("ack", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -81,18 +92,8 @@ func cmdAck(args []string) error {
 		return fmt.Errorf("list claimed residue: %w", err)
 	}
 
-	// CLEAR-THEN-COMMIT: evaluate the finish gate FIRST. If it is not clear,
-	// archive NOTHING and leave the residue uncommitted (re-delivered next turn).
-	// Read-only and reuses gate.go's exact blocking predicate, so ack and
-	// `gate --before finish` can never disagree.
-	clear, reasons, err := finishGateClear(cfg, agentID, now)
-	if err != nil {
-		return fmt.Errorf("evaluate finish gate: %w", err)
-	}
-	if !clear {
-		return emitAckNotClear(agentID, len(residue), reasons, jsonOut, quiet)
-	}
-
+	// UNCONDITIONAL COMMIT (F7): archive every claimed message regardless of
+	// finish-gate status — see the doc comment above cmdAck.
 	acked := make([]ackItem, 0, len(residue))
 	for _, msg := range residue {
 		dest, err := loop.ArchiveMessage(msg, cfg.ArchiveDir(), agentID, now)
@@ -102,46 +103,54 @@ func cmdAck(args []string) error {
 		acked = append(acked, ackItem{Filename: msg.Filename, ArchivePath: dest})
 	}
 
+	// Evaluate the finish gate AFTER committing, purely to REPORT whether other
+	// obligations remain. Read-only; reuses gate.go's exact blocking predicate,
+	// so ack and `gate --before finish` can never disagree about whether finish
+	// would block. Post-commit means the reported reasons never stale-cite the
+	// batch we just archived (gate.go's own ClaimedResidue warning drops to 0).
+	clear, reasons, err := finishGateClear(cfg, agentID, now)
+	if err != nil {
+		return fmt.Errorf("evaluate finish gate: %w", err)
+	}
+
+	result := ackResult{Agent: agentID, Count: len(acked), Acked: acked, GateClear: clear}
+	if !clear {
+		result.BlockReasons = reasons
+	}
+
 	if jsonOut {
-		return emitAckJSON(ackResult{Agent: agentID, Count: len(acked), Acked: acked, GateClear: true})
+		if err := emitAckJSON(result); err != nil {
+			return err
+		}
+	} else if !quiet {
+		emitAckText(result)
 	}
-	if quiet {
-		return nil
-	}
-	if len(acked) == 0 {
-		fmt.Println("(nothing to ack)")
-		return nil
-	}
-	for _, a := range acked {
-		fmt.Printf("acked %s -> %s\n", a.Filename, a.ArchivePath)
+
+	// Exit code carries the distinction JSON/text already reported: clear => the
+	// commit is fully done; blocked => committed, but do not treat this turn as
+	// finished (same sentinel/exit-2 contract as `gate --before finish`).
+	if !clear {
+		return errBlocked
 	}
 	return nil
 }
 
-// emitAckNotClear reports a CLEAR-THEN-COMMIT abort: the finish gate is not clear,
-// so ack archived nothing and the claimed residue stays for redelivery. It is NOT
-// an error and returns nil (exit 0): the paired `gate --before finish` hook step
-// emits the authoritative block signal (exit 2 / decision JSON); ack's only job
-// here is to refuse to commit early — erroring would break the hook chain.
-func emitAckNotClear(agentID string, claimedCount int, reasons []string, jsonOut, quiet bool) error {
-	if jsonOut {
-		return emitAckJSON(ackResult{
-			Agent:        agentID,
-			Count:        0,
-			Acked:        []ackItem{},
-			GateClear:    false,
-			NotAcked:     claimedCount,
-			BlockReasons: reasons,
-		})
+// emitAckText prints the human-readable ack outcome: the committed items (or
+// "(nothing to ack)"), followed by any remaining finish-gate blockers.
+func emitAckText(r ackResult) {
+	if len(r.Acked) == 0 {
+		fmt.Println("(nothing to ack)")
+	} else {
+		for _, a := range r.Acked {
+			fmt.Printf("acked %s -> %s\n", a.Filename, a.ArchivePath)
+		}
 	}
-	if quiet {
-		return nil
+	if !r.GateClear {
+		fmt.Println("finish gate still blocked after commit:")
+		for _, reason := range r.BlockReasons {
+			fmt.Printf("  - %s\n", reason)
+		}
 	}
-	fmt.Printf("finish gate not clear; %d claimed message(s) left uncommitted\n", claimedCount)
-	for _, r := range reasons {
-		fmt.Printf("  - %s\n", r)
-	}
-	return nil
 }
 
 type ackItem struct {
@@ -154,8 +163,7 @@ type ackResult struct {
 	Count        int       `json:"count"`
 	Acked        []ackItem `json:"acked"`
 	GateClear    bool      `json:"gate_clear"`
-	NotAcked     int       `json:"not_acked,omitempty"`     // claimed residue left uncommitted because finish was not clear
-	BlockReasons []string  `json:"block_reasons,omitempty"` // the finish-gate blocking reasons (when gate_clear=false)
+	BlockReasons []string  `json:"block_reasons,omitempty"` // remaining finish-gate reasons; set only when gate_clear=false (committing is unconditional, so these are no longer about THIS ack's own residue)
 }
 
 func emitAckJSON(r ackResult) error {
@@ -165,5 +173,5 @@ func emitAckJSON(r ackResult) error {
 }
 
 func ackUsage(err error) error {
-	return fmt.Errorf("%w\nusage: agentchute ack [--as <agent-id>] [--vendor <v>] [--control-repo <path>] [--loop-dir <path>] [--json] [--quiet]\n  ack COMMITS messages that `check` claimed: archives inbox/<id>/.claimed residue.", err)
+	return fmt.Errorf("%w\nusage: agentchute ack [--as <agent-id>] [--vendor <v>] [--control-repo <path>] [--loop-dir <path>] [--json] [--quiet]\n  ack COMMITS messages that `check` claimed: archives inbox/<id>/.claimed residue, unconditionally.\n  Exit 0 if the finish gate is then clear; exit 2 (same sentinel as `gate --before finish`) if other\n  obligations still block finish — the commit itself already happened either way.", err)
 }

--- a/internal/cli/ack.go
+++ b/internal/cli/ack.go
@@ -29,18 +29,30 @@ import (
 // the archive.
 //
 // EXIT CODE distinguishes the two outcomes so scripts never mistake "committed"
-// for "done": gate clear after commit => nil (exit 0). Gate still blocked after
-// commit (unrelated obligations remain) => errBlocked (exit 2), same sentinel
-// `gate --before finish` returns, so `ack`'s exit code alone tells a caller
-// whether it's safe to treat the turn as finished. A blocked exit is reported
-// via text/JSON exactly like an already-committed-and-still-blocked state; it is
-// NOT a command failure (exit 1) — the commit itself always succeeds or `ack`
-// returns a real error.
+// for "done" — in DEFAULT mode only: gate clear after commit => nil (exit 0).
+// Gate still blocked after commit (unrelated obligations remain) => errBlocked
+// (exit 2), same sentinel `gate --before finish` returns, so `ack`'s exit code
+// alone tells a caller whether it's safe to treat the turn as finished. A
+// blocked exit is reported via text/JSON exactly like an already-committed-
+// and-still-blocked state; it is NOT a command failure (exit 1) — the commit
+// itself always succeeds or `ack` returns a real error.
+//
+// --quiet is HOOK MODE, not just "less output": it suppresses BOTH the
+// text/JSON report AND the exit-2 signal (always returns nil once the commit
+// itself succeeds). Its one documented consumer is the Stop-hook commit step,
+// where `ack --quiet` runs as its OWN hook entry immediately before
+// `gate --before finish --json` in the same hook list. A Stop hook that exits
+// 2 is itself a block signal to the harness; if `ack --quiet` also returned
+// errBlocked, a blocked turn would raise it TWICE — once from ack with NO
+// reason (quiet swallowed the text), once from gate with the real reasons —
+// a confusing, reason-less duplicate block. In hook mode `gate` is the sole
+// authoritative block signal; `ack --quiet`'s job is only to commit silently.
+// Callers that want the committed-vs-done distinction use the DEFAULT
+// (non-quiet) mode and read the exit code / `gate_clear` JSON field.
 //
 // Idempotent: an already-archived message (e.g. a partial prior ack) is treated
 // as success, and an empty .claimed is a no-op. Flags mirror `check`
-// (--as/--vendor/--json) plus --quiet for the Stop-hook commit step (--quiet
-// suppresses text/JSON output but never the exit code).
+// (--as/--vendor/--json) plus --quiet for the Stop-hook commit step.
 func cmdAck(args []string) error {
 	fs := flag.NewFlagSet("ack", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -118,11 +130,18 @@ func cmdAck(args []string) error {
 		result.BlockReasons = reasons
 	}
 
+	if quiet {
+		// Hook mode: the commit already happened above; suppress both the
+		// report and the exit-2 signal so a paired `gate --before finish` hook
+		// entry remains the sole authoritative block signal (see doc comment).
+		return nil
+	}
+
 	if jsonOut {
 		if err := emitAckJSON(result); err != nil {
 			return err
 		}
-	} else if !quiet {
+	} else {
 		emitAckText(result)
 	}
 
@@ -173,5 +192,5 @@ func emitAckJSON(r ackResult) error {
 }
 
 func ackUsage(err error) error {
-	return fmt.Errorf("%w\nusage: agentchute ack [--as <agent-id>] [--vendor <v>] [--control-repo <path>] [--loop-dir <path>] [--json] [--quiet]\n  ack COMMITS messages that `check` claimed: archives inbox/<id>/.claimed residue, unconditionally.\n  Exit 0 if the finish gate is then clear; exit 2 (same sentinel as `gate --before finish`) if other\n  obligations still block finish — the commit itself already happened either way.", err)
+	return fmt.Errorf("%w\nusage: agentchute ack [--as <agent-id>] [--vendor <v>] [--control-repo <path>] [--loop-dir <path>] [--json] [--quiet]\n  ack COMMITS messages that `check` claimed: archives inbox/<id>/.claimed residue, unconditionally.\n  Default mode: exit 0 if the finish gate is then clear; exit 2 (same sentinel as `gate --before\n  finish`) if other obligations still block finish — the commit itself already happened either way.\n  --quiet is hook mode: suppresses output AND always exits 0 once the commit succeeds, so a paired\n  `gate --before finish` hook entry remains the sole authoritative block signal.", err)
 }

--- a/internal/cli/ack_test.go
+++ b/internal/cli/ack_test.go
@@ -1,16 +1,21 @@
 package cli
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-// TestAckSelfGatesOnFinishBlocker is the BUG-1 contract: `ack` is a single
-// CLEAR-THEN-COMMIT — it archives claimed mail ONLY IF the finish gate is clear.
-// A claimed message PLUS a finish blocker (here a second unread inbox message)
-// => ack archives NOTHING (.claimed intact, at-least-once preserved across the
-// blocked turn). Remove the blocker (claim it too) => ack archives everything.
-func TestAckSelfGatesOnFinishBlocker(t *testing.T) {
+// TestAckCommitsUnconditionallyUnderForeignBlocker is the F7 contract (replaces
+// the old CLEAR-THEN-COMMIT test): `ack` archives claimed mail UNCONDITIONALLY —
+// a claimed message PLUS an unrelated finish blocker (a second, uncommitted
+// unread message someone else could have dropped after `check` claimed the
+// first) no longer withholds the commit. `ack` still reports (and exits 2 for)
+// the remaining blocker; it just no longer holds MY already-claimed mail
+// hostage to it.
+func TestAckCommitsUnconditionallyUnderForeignBlocker(t *testing.T) {
 	root, cfg := setupConsumeFixture(t)
 
 	send := func(body string) {
@@ -30,17 +35,14 @@ func TestAckSelfGatesOnFinishBlocker(t *testing.T) {
 			}
 		})
 	}
-	ack := func() string {
+	ack := func() (string, error) {
 		t.Helper()
 		var out string
+		var err error
 		withCwd(t, root, func() {
-			var err error
 			out, err = captureStdout(t, func() error { return cmdAck([]string{"--as", "bob"}) })
-			if err != nil {
-				t.Fatalf("cmdAck(bob): %v", err) // ack must NOT error the hook, blocked or not.
-			}
 		})
-		return out
+		return out, err
 	}
 
 	// msg1 -> claim it (now .claimed=1, inbox=0).
@@ -50,42 +52,190 @@ func TestAckSelfGatesOnFinishBlocker(t *testing.T) {
 		t.Fatalf(".claimed = %d after first claim; want 1", n)
 	}
 
-	// msg2 arrives but is NOT claimed -> a finish blocker (unread inbox mail).
+	// msg2 arrives but is NOT claimed -> a finish blocker (unread inbox mail),
+	// unrelated to the already-claimed msg1.
 	send("second")
 	if n := countMessageFiles(t, cfg.AgentInboxDir("bob")); n != 1 {
 		t.Fatalf("inbox = %d after second send; want 1 unread", n)
 	}
 
-	// ack must self-gate: finish NOT clear (1 unread) => archive nothing.
-	out := ack()
-	if !strings.Contains(out, "finish gate not clear") {
-		t.Fatalf("ack did not report a blocked finish gate; out=%q", out)
+	// ack commits msg1 REGARDLESS of the unrelated blocker, and reports+exits
+	// errBlocked because finish is still not clear (1 unread message remains).
+	out, err := ack()
+	if !errors.Is(err, errBlocked) {
+		t.Fatalf("err = %v, want errBlocked (finish still blocked after commit)", err)
 	}
-	if n := countMessageFiles(t, cfg.AgentClaimedDir("bob")); n != 1 {
-		t.Fatalf(".claimed = %d after blocked ack; want 1 (uncommitted)", n)
+	if !strings.Contains(out, "still blocked after commit") {
+		t.Fatalf("ack did not report the remaining finish-gate blocker; out=%q", out)
 	}
-	if n := countMessageFiles(t, cfg.ArchiveDir()); n != 0 {
-		t.Fatalf("archive = %d after blocked ack; want 0 (nothing committed)", n)
+	if !strings.Contains(out, "acked ") {
+		t.Fatalf("ack did not report committing msg1 despite the unrelated blocker; out=%q", out)
+	}
+	if n := countMessageFiles(t, cfg.AgentClaimedDir("bob")); n != 0 {
+		t.Fatalf(".claimed = %d after unconditional ack; want 0 (committed despite the blocker)", n)
+	}
+	if n := countMessageFiles(t, cfg.ArchiveDir()); n != 1 {
+		t.Fatalf("archive = %d after unconditional ack; want 1 (msg1 committed)", n)
 	}
 
-	// Remove the blocker: claim msg2 too (inbox=0, .claimed=2, redelivers msg1).
+	// Claim msg2 too, then ack again: now finish IS clear => exit 0, no
+	// remaining-blocker text.
 	check()
-	if n := countMessageFiles(t, cfg.AgentInboxDir("bob")); n != 0 {
-		t.Fatalf("inbox = %d after second claim; want 0", n)
+	if n := countMessageFiles(t, cfg.AgentClaimedDir("bob")); n != 1 {
+		t.Fatalf(".claimed = %d after second claim; want 1", n)
 	}
-	if n := countMessageFiles(t, cfg.AgentClaimedDir("bob")); n != 2 {
-		t.Fatalf(".claimed = %d after second claim; want 2", n)
+	out, err = ack()
+	if err != nil {
+		t.Fatalf("cmdAck(bob) with clear gate: %v", err)
 	}
-
-	// Now the finish gate is clear => ack archives BOTH.
-	out = ack()
-	if strings.Contains(out, "finish gate not clear") {
-		t.Fatalf("ack still reported a blocked gate after the blocker cleared; out=%q", out)
+	if strings.Contains(out, "still blocked") {
+		t.Fatalf("ack reported a blocker after the gate cleared; out=%q", out)
 	}
 	if n := countMessageFiles(t, cfg.AgentClaimedDir("bob")); n != 0 {
 		t.Fatalf(".claimed = %d after clear ack; want 0 (committed)", n)
 	}
 	if n := countMessageFiles(t, cfg.ArchiveDir()); n != 2 {
 		t.Fatalf("archive = %d after clear ack; want 2", n)
+	}
+}
+
+// TestAckCommitsUnconditionallyUnderForeignMalformedFile is the exact F7
+// scenario named in the design doc: a THIRD PARTY drops a malformed-named file
+// into MY inbox after `check` already claimed a good message. `check` never
+// touched the malformed file (it doesn't parse as a message), so it isn't part
+// of .claimed — but under the old CLEAR-THEN-COMMIT contract it still blocked
+// `ack` from committing the unrelated, already-claimed good message. `ack`
+// must now commit it anyway.
+func TestAckCommitsUnconditionallyUnderForeignMalformedFile(t *testing.T) {
+	root, cfg := setupConsumeFixture(t)
+
+	withCwd(t, root, func() {
+		if err := cmdSend([]string{"--from", "alice", "--to", "bob", "--body", "first"}); err != nil {
+			t.Fatalf("cmdSend: %v", err)
+		}
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "bob"}) }); err != nil {
+			t.Fatalf("cmdCheck(bob): %v", err)
+		}
+	})
+	if n := countMessageFiles(t, cfg.AgentClaimedDir("bob")); n != 1 {
+		t.Fatalf(".claimed = %d after claim; want 1", n)
+	}
+
+	// A third party's malformed drop, AFTER check claimed the good message.
+	malformed := filepath.Join(cfg.AgentInboxDir("bob"), "not-a-valid-message-name.md")
+	if err := os.WriteFile(malformed, []byte("---\nfrom: ??\n---\nbody\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out string
+	var err error
+	withCwd(t, root, func() {
+		out, err = captureStdout(t, func() error { return cmdAck([]string{"--as", "bob"}) })
+	})
+	if !errors.Is(err, errBlocked) {
+		t.Fatalf("err = %v, want errBlocked (malformed file still blocks finish)", err)
+	}
+	if !strings.Contains(out, "acked ") {
+		t.Fatalf("ack did not commit the unrelated already-claimed message; out=%q", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "malformed") {
+		t.Fatalf("ack did not report the malformed-file blocker; out=%q", out)
+	}
+	if n := countMessageFiles(t, cfg.AgentClaimedDir("bob")); n != 0 {
+		t.Fatalf(".claimed = %d after ack; want 0 (committed despite the foreign malformed file)", n)
+	}
+	if n := countMessageFiles(t, cfg.ArchiveDir()); n != 1 {
+		t.Fatalf("archive = %d after ack; want 1", n)
+	}
+}
+
+// TestAckJSONReportsGateClearVsBlocked pins the JSON exit-code contract scripts
+// rely on: gate_clear distinguishes "committed AND done" from "committed BUT
+// still blocked" so a caller checking only ack's JSON (or exit code) never
+// mistakes the latter for the former.
+func TestAckJSONReportsGateClearVsBlocked(t *testing.T) {
+	root, cfg := setupConsumeFixture(t)
+
+	withCwd(t, root, func() {
+		if err := cmdSend([]string{"--from", "alice", "--to", "bob", "--body", "only"}); err != nil {
+			t.Fatalf("cmdSend: %v", err)
+		}
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "bob"}) }); err != nil {
+			t.Fatalf("cmdCheck(bob): %v", err)
+		}
+	})
+
+	// A second, uncommitted unread message keeps finish blocked.
+	withCwd(t, root, func() {
+		if err := cmdSend([]string{"--from", "alice", "--to", "bob", "--body", "blocker"}); err != nil {
+			t.Fatalf("cmdSend: %v", err)
+		}
+	})
+
+	var out string
+	var err error
+	withCwd(t, root, func() {
+		out, err = captureStdout(t, func() error { return cmdAck([]string{"--as", "bob", "--json"}) })
+	})
+	if !errors.Is(err, errBlocked) {
+		t.Fatalf("err = %v, want errBlocked", err)
+	}
+	if !strings.Contains(out, `"gate_clear": false`) {
+		t.Fatalf("JSON should report gate_clear=false; out=%q", out)
+	}
+	if !strings.Contains(out, `"count": 1`) {
+		t.Fatalf("JSON should still report the committed count; out=%q", out)
+	}
+	if n := countMessageFiles(t, cfg.ArchiveDir()); n != 1 {
+		t.Fatalf("archive = %d; want 1 (committed despite gate_clear=false)", n)
+	}
+
+	// Claim the blocker and ack again: now gate_clear=true, exit 0.
+	withCwd(t, root, func() {
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "bob"}) }); err != nil {
+			t.Fatalf("cmdCheck(bob): %v", err)
+		}
+	})
+	withCwd(t, root, func() {
+		out, err = captureStdout(t, func() error { return cmdAck([]string{"--as", "bob", "--json"}) })
+	})
+	if err != nil {
+		t.Fatalf("cmdAck --json with clear gate: %v", err)
+	}
+	if !strings.Contains(out, `"gate_clear": true`) {
+		t.Fatalf("JSON should report gate_clear=true; out=%q", out)
+	}
+}
+
+// TestAckQuietStillReturnsErrBlocked pins that --quiet only suppresses output,
+// never the exit-code signal a hook/script depends on.
+func TestAckQuietStillReturnsErrBlocked(t *testing.T) {
+	root, cfg := setupConsumeFixture(t)
+
+	withCwd(t, root, func() {
+		if err := cmdSend([]string{"--from", "alice", "--to", "bob", "--body", "first"}); err != nil {
+			t.Fatalf("cmdSend: %v", err)
+		}
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "bob"}) }); err != nil {
+			t.Fatalf("cmdCheck(bob): %v", err)
+		}
+		if err := cmdSend([]string{"--from", "alice", "--to", "bob", "--body", "blocker"}); err != nil {
+			t.Fatalf("cmdSend: %v", err)
+		}
+	})
+
+	var out string
+	var err error
+	withCwd(t, root, func() {
+		out, err = captureStdout(t, func() error { return cmdAck([]string{"--as", "bob", "--quiet"}) })
+	})
+	if !errors.Is(err, errBlocked) {
+		t.Fatalf("err = %v, want errBlocked even under --quiet", err)
+	}
+	if out != "" {
+		t.Fatalf("--quiet should suppress all output; got %q", out)
+	}
+	if n := countMessageFiles(t, cfg.ArchiveDir()); n != 1 {
+		t.Fatalf("archive = %d; want 1 (quiet must not suppress the commit)", n)
 	}
 }

--- a/internal/cli/ack_test.go
+++ b/internal/cli/ack_test.go
@@ -207,9 +207,13 @@ func TestAckJSONReportsGateClearVsBlocked(t *testing.T) {
 	}
 }
 
-// TestAckQuietStillReturnsErrBlocked pins that --quiet only suppresses output,
-// never the exit-code signal a hook/script depends on.
-func TestAckQuietStillReturnsErrBlocked(t *testing.T) {
+// TestAckQuietIsHookModeSuppressesBothOutputAndExitCode pins --quiet as hook
+// mode: it commits unconditionally like every other mode, but ALWAYS exits 0
+// (never errBlocked) so a paired `gate --before finish` Stop-hook entry stays
+// the sole authoritative block signal — ack --quiet exiting 2 with no reason
+// (quiet suppressed the text) would otherwise raise a second, reason-less
+// block alongside gate's.
+func TestAckQuietIsHookModeSuppressesBothOutputAndExitCode(t *testing.T) {
 	root, cfg := setupConsumeFixture(t)
 
 	withCwd(t, root, func() {
@@ -229,8 +233,8 @@ func TestAckQuietStillReturnsErrBlocked(t *testing.T) {
 	withCwd(t, root, func() {
 		out, err = captureStdout(t, func() error { return cmdAck([]string{"--as", "bob", "--quiet"}) })
 	})
-	if !errors.Is(err, errBlocked) {
-		t.Fatalf("err = %v, want errBlocked even under --quiet", err)
+	if err != nil {
+		t.Fatalf("cmdAck --quiet with a still-blocked gate: %v, want nil (quiet always exits 0 once committed)", err)
 	}
 	if out != "" {
 		t.Fatalf("--quiet should suppress all output; got %q", out)


### PR DESCRIPTION
## Summary
- `ack` now archives `.claimed` residue **unconditionally** instead of the old CLEAR-THEN-COMMIT contract (F7 of the v0.10.0 deep-analysis review): an unrelated finish-gate blocker (e.g. a third party dropping a new unread/malformed file into this agent's inbox between `check` and `ack`) no longer withholds committing mail this agent already claimed and acted on.
- Finish gate is evaluated **after** the commit, purely to report whether other obligations remain — never to gate the archive itself.
- Exit code now distinguishes the two outcomes: gate clear after commit → `nil`/exit 0; gate still blocked → `errBlocked`/exit 2 (same sentinel `gate --before finish` already uses). `--quiet` suppresses text/JSON output only, never the exit code.
- `--help` (`ackUsage`) documents the new contract.

## Design record
This is PR-α of the 3-way-synthesized v0.10.1 patch worklist (unanimous team decision on 2026-07-02). The trace showing nothing breaks was done as part of that review:
- `MalformedCount` in `evaluateGate` (gate.go) is scoped to the caller's **own** inbox (`ListInboxMessagesWithSkipped(cfg.AgentInboxDir(agentID))`), so a foreign malformed/unread file landing in my inbox is orthogonal to the already-claimed messages being archived.
- `loop.ArchiveMessage` is a pure filesystem move with no registration/gate dependency.
- The old self-gating comment's stated purpose ("ack and `gate --before finish` can run in either order without disagreeing") is preserved: `gate --before finish` still independently blocks finish regardless of what `ack` just committed.

Not in scope for this PR (owned by sibling PRs in the same worklist): CHANGELOG entry (added at v0.10.1 release-prep, per the repo's release-squash convention — PR #40 didn't touch CHANGELOG.md either), AGENTCHUTE.md §6.3 prose describing ack's new behavior (assigned to the docs/spec PR, which merges last).

## Verification
- `gofmt -w .`
- `go vet ./...`
- `env -u AGENTCHUTE_SERVE_TOKEN go test ./...`
- `go build ./...`
- `env -u AGENTCHUTE_SERVE_TOKEN go test -race ./...`
- `(cd conformance && env -u AGENTCHUTE_SERVE_TOKEN go test ./...)`
- `go test ./internal/cli -run TestPromptInjectionBytes` (crown jewels untouched)
- `shellcheck install.sh`
- `goreleaser check`
- `git diff --check`

New tests: unconditional commit under a foreign unread message and under a foreign malformed file (the exact F7 scenario), JSON `gate_clear` true/false contract, `--quiet` still returns `errBlocked`. Existing gate/consume-boundary tests pass unmodified.

Review requested via agentchute: claude-code-agentchute + codex.