### PR TITLE
fix: bundle v0.10.1 code fixes

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -283,7 +283,30 @@ func checkStaleTempFiles(cfg *loop.Config, now time.Time) doctorCheck {
 
 func findStaleTempFiles(cfg *loop.Config, now time.Time, olderThan time.Duration) ([]staleTempFile, error) {
 	var stale []staleTempFile
-	scanChildren := func(parent string) error {
+	scanDir := func(dir string) error {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasPrefix(entry.Name(), staleTempFilePrefix) {
+				continue
+			}
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			age := now.Sub(info.ModTime())
+			if age > olderThan {
+				stale = append(stale, staleTempFile{path: filepath.Join(dir, entry.Name()), age: age})
+			}
+		}
+		return nil
+	}
+	scanChildDirs := func(parent string) error {
 		children, err := os.ReadDir(parent)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -295,31 +318,22 @@ func findStaleTempFiles(cfg *loop.Config, now time.Time, olderThan time.Duration
 			if !child.IsDir() {
 				continue
 			}
-			dir := filepath.Join(parent, child.Name())
-			entries, err := os.ReadDir(dir)
-			if err != nil {
+			if err := scanDir(filepath.Join(parent, child.Name())); err != nil {
 				return err
-			}
-			for _, entry := range entries {
-				if entry.IsDir() || !strings.HasPrefix(entry.Name(), staleTempFilePrefix) {
-					continue
-				}
-				info, err := entry.Info()
-				if err != nil {
-					return err
-				}
-				age := now.Sub(info.ModTime())
-				if age > olderThan {
-					stale = append(stale, staleTempFile{path: filepath.Join(dir, entry.Name()), age: age})
-				}
 			}
 		}
 		return nil
 	}
-	if err := scanChildren(filepath.Join(cfg.LoopDir, "inbox")); err != nil {
+	if err := scanChildDirs(filepath.Join(cfg.LoopDir, "inbox")); err != nil {
 		return nil, err
 	}
-	if err := scanChildren(filepath.Join(cfg.LoopDir, "state")); err != nil {
+	if err := scanChildDirs(filepath.Join(cfg.LoopDir, "state")); err != nil {
+		return nil, err
+	}
+	if err := scanDir(cfg.AgentsDir()); err != nil {
+		return nil, err
+	}
+	if err := scanDir(filepath.Join(cfg.LoopDir, "live")); err != nil {
 		return nil, err
 	}
 	sort.Slice(stale, func(i, j int) bool { return stale[i].path < stale[j].path })

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -45,6 +46,11 @@ var (
 	// Env-only form. Distinct from templated because absent
 	// AGENTCHUTE_BIN there is no fallback.
 	hookEnvOnlyRE = regexp.MustCompile(`\$AGENTCHUTE_BIN[ \t]+[a-z]`)
+)
+
+const (
+	staleTempFilePrefix = ".tmp_"
+	staleTempFileAge    = time.Hour
 )
 
 // cmdDoctor is the diagnostic aggregator. Walks an
@@ -176,6 +182,7 @@ type doctorOptions struct {
 func runDoctorChecks(cfg *loop.Config, agentID string, opts doctorOptions) doctorReport {
 	checks := []doctorCheck{
 		checkLoopDirScaffold(cfg),
+		checkStaleTempFiles(cfg, opts.Now),
 		checkBinaryOnPath(),
 		checkHookFilePresence(cfg, agentID),
 		checkHookContentSanity(cfg),
@@ -252,6 +259,97 @@ func checkLoopDirScaffold(cfg *loop.Config) doctorCheck {
 		}
 	}
 	return doctorCheck{Name: "loop_dir_scaffold", Severity: severityOK, Message: "agents/, inbox/ present with correct shape"}
+}
+
+type staleTempFile struct {
+	path string
+	age  time.Duration
+}
+
+func checkStaleTempFiles(cfg *loop.Config, now time.Time) doctorCheck {
+	stale, err := findStaleTempFiles(cfg, now, staleTempFileAge)
+	if err != nil {
+		return doctorCheck{Name: "stale_temp_files", Severity: severityWarn, Message: fmt.Sprintf("stale temp scan error: %v", err)}
+	}
+	if len(stale) == 0 {
+		return doctorCheck{Name: "stale_temp_files", Severity: severityOK, Message: "no stale .tmp_* files found"}
+	}
+	return doctorCheck{
+		Name:     "stale_temp_files",
+		Severity: severityWarn,
+		Message:  fmt.Sprintf("%d stale .tmp_* file(s) older than %s: %s", len(stale), staleTempFileAge, formatStaleTempFiles(cfg, stale)),
+	}
+}
+
+func findStaleTempFiles(cfg *loop.Config, now time.Time, olderThan time.Duration) ([]staleTempFile, error) {
+	var stale []staleTempFile
+	scanChildren := func(parent string) error {
+		children, err := os.ReadDir(parent)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		for _, child := range children {
+			if !child.IsDir() {
+				continue
+			}
+			dir := filepath.Join(parent, child.Name())
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				return err
+			}
+			for _, entry := range entries {
+				if entry.IsDir() || !strings.HasPrefix(entry.Name(), staleTempFilePrefix) {
+					continue
+				}
+				info, err := entry.Info()
+				if err != nil {
+					return err
+				}
+				age := now.Sub(info.ModTime())
+				if age > olderThan {
+					stale = append(stale, staleTempFile{path: filepath.Join(dir, entry.Name()), age: age})
+				}
+			}
+		}
+		return nil
+	}
+	if err := scanChildren(filepath.Join(cfg.LoopDir, "inbox")); err != nil {
+		return nil, err
+	}
+	if err := scanChildren(filepath.Join(cfg.LoopDir, "state")); err != nil {
+		return nil, err
+	}
+	sort.Slice(stale, func(i, j int) bool { return stale[i].path < stale[j].path })
+	return stale, nil
+}
+
+func formatStaleTempFiles(cfg *loop.Config, files []staleTempFile) string {
+	const maxShown = 5
+	parts := make([]string, 0, minInt(len(files), maxShown))
+	for i, f := range files {
+		if i >= maxShown {
+			break
+		}
+		path := f.path
+		if rel, err := filepath.Rel(cfg.ControlRepo, f.path); err == nil && !strings.HasPrefix(rel, "..") {
+			path = rel
+		}
+		parts = append(parts, fmt.Sprintf("%s (%s old)", path, f.age.Round(time.Minute)))
+	}
+	if len(files) > maxShown {
+		parts = append(parts, fmt.Sprintf("... %d more", len(files)-maxShown))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func checkBinaryOnPath() doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -66,6 +66,56 @@ func TestDoctorMissingScaffoldBlocks(t *testing.T) {
 	}
 }
 
+func TestDoctorWarnsOnStaleTempFiles(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	now := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+	inboxDir := cfg.AgentInboxDir("codex")
+	stateDir := cfg.AgentStateDir("codex")
+	if err := os.MkdirAll(inboxDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	staleInbox := filepath.Join(inboxDir, ".tmp_inbox")
+	staleState := filepath.Join(stateDir, ".tmp_lease")
+	freshInbox := filepath.Join(inboxDir, ".tmp_fresh")
+	normalState := filepath.Join(stateDir, "serve.claim")
+	for _, path := range []string{staleInbox, staleState, freshInbox, normalState} {
+		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	staleTime := now.Add(-2 * time.Hour)
+	freshTime := now.Add(-30 * time.Minute)
+	for _, path := range []string{staleInbox, staleState} {
+		if err := os.Chtimes(path, staleTime, staleTime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Chtimes(freshInbox, freshTime, freshTime); err != nil {
+		t.Fatal(err)
+	}
+
+	r := runDoctorChecks(cfg, "", doctorOptions{Now: now})
+	got := findCheck(t, r, "stale_temp_files")
+	if got.Severity != severityWarn {
+		t.Fatalf("stale_temp_files severity = %q, want WARN; message=%q", got.Severity, got.Message)
+	}
+	for _, want := range []string{
+		"2 stale .tmp_* file(s)",
+		".agentchute/loop/inbox/codex/.tmp_inbox",
+		".agentchute/loop/state/codex/.tmp_lease",
+	} {
+		if !strings.Contains(got.Message, want) {
+			t.Fatalf("stale_temp_files message missing %q:\n%s", want, got.Message)
+		}
+	}
+	if strings.Contains(got.Message, ".tmp_fresh") || strings.Contains(got.Message, "serve.claim") {
+		t.Fatalf("stale_temp_files reported non-stale/non-temp file:\n%s", got.Message)
+	}
+}
+
 func TestDoctorBareAgentchuteCheckInHookBlocks(t *testing.T) {
 	cfg := newDoctorCfg(t)
 	// Drop a hook file that contains the silent-drain antipattern.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -71,24 +71,26 @@ func TestDoctorWarnsOnStaleTempFiles(t *testing.T) {
 	now := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
 	inboxDir := cfg.AgentInboxDir("codex")
 	stateDir := cfg.AgentStateDir("codex")
-	if err := os.MkdirAll(inboxDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		t.Fatal(err)
+	liveDir := filepath.Join(cfg.LoopDir, "live")
+	for _, dir := range []string{inboxDir, stateDir, liveDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
 	}
 	staleInbox := filepath.Join(inboxDir, ".tmp_inbox")
 	staleState := filepath.Join(stateDir, ".tmp_lease")
+	staleAgent := filepath.Join(cfg.AgentsDir(), ".tmp_codex.md_123")
+	staleLive := filepath.Join(liveDir, ".tmp_codex.live_123")
 	freshInbox := filepath.Join(inboxDir, ".tmp_fresh")
 	normalState := filepath.Join(stateDir, "serve.claim")
-	for _, path := range []string{staleInbox, staleState, freshInbox, normalState} {
+	for _, path := range []string{staleInbox, staleState, staleAgent, staleLive, freshInbox, normalState} {
 		if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
 	staleTime := now.Add(-2 * time.Hour)
 	freshTime := now.Add(-30 * time.Minute)
-	for _, path := range []string{staleInbox, staleState} {
+	for _, path := range []string{staleInbox, staleState, staleAgent, staleLive} {
 		if err := os.Chtimes(path, staleTime, staleTime); err != nil {
 			t.Fatal(err)
 		}
@@ -103,8 +105,10 @@ func TestDoctorWarnsOnStaleTempFiles(t *testing.T) {
 		t.Fatalf("stale_temp_files severity = %q, want WARN; message=%q", got.Severity, got.Message)
 	}
 	for _, want := range []string{
-		"2 stale .tmp_* file(s)",
+		"4 stale .tmp_* file(s)",
+		".agentchute/loop/agents/.tmp_codex.md_123",
 		".agentchute/loop/inbox/codex/.tmp_inbox",
+		".agentchute/loop/live/.tmp_codex.live_123",
 		".agentchute/loop/state/codex/.tmp_lease",
 	} {
 		if !strings.Contains(got.Message, want) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -103,6 +103,14 @@ func TestRunnerDiagnosticsLogFileOnlyDuringRawWindow(t *testing.T) {
 	if !strings.Contains(log, "agentchute serve: inject prompt:") {
 		t.Fatalf("runner.log missing inject diagnostic:\n%s", log)
 	}
+	firstLine := strings.Split(strings.TrimSpace(log), "\n")[0]
+	fields := strings.Fields(firstLine)
+	if len(fields) < 2 {
+		t.Fatalf("runner.log line missing timestamp/message fields: %q", firstLine)
+	}
+	if _, err := time.Parse(time.RFC3339, fields[0]); err != nil {
+		t.Fatalf("runner.log timestamp = %q, want RFC3339: %v", fields[0], err)
+	}
 }
 
 func TestRunRefusesLiveRunnerCollision(t *testing.T) {
@@ -505,7 +513,7 @@ func TestRunnerPoll_WakesOnBackdatedFilename(t *testing.T) {
 // target each tick and record a cached reachability fact (ReachableAt) in its
 // registration. Gate 6a (pull-only): TestRunnerPollLoop_WritesReachableAt was
 // removed. pollOnce no longer reproves or records ReachableAt (the own-wake
-// reprove call at run.go's poll tick was deleted), so there is nothing to assert.
+// reprove call at serve.go's poll tick was deleted), so there is nothing to assert.
 
 func setupShortRunFixture(t *testing.T) string {
 	t.Helper()

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -158,12 +158,13 @@ func cmdSend(args []string) error {
 	}
 	// idempotencyKey is "": send has no stable per-message content key, so a
 	// sender crash between the durable seq commit and the link loses the
-	// allocated seq as a legal gap (at-most-once for this message). Acceptable
-	// for the transition. serveToken rides AGENTCHUTE_SERVE_TOKEN (Gate 6b): a
+	// allocated seq as a legal gap (at-most-once for this message). The library
+	// re-issue path remains available to callers that supply a stable non-empty
+	// idempotency key. serveToken rides AGENTCHUTE_SERVE_TOKEN: a
 	// send from a child launched under `agentchute serve` carries the runner's
 	// active serve-lease fence, so a write from a fenced (reclaimed) agent fails
 	// closed (AllocateSeq VerifyFence -> ErrFenced). Empty env (no serve lease) =>
-	// unfenced, the transitional off-bus mode (unchanged behavior).
+	// intentionally unfenced.
 	id, err := loop.SendSeqMessage(cfg, fromID, toID, content, "", os.Getenv("AGENTCHUTE_SERVE_TOKEN"))
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -254,7 +254,8 @@ func (d *runnerDiagnostics) logf(format string, args ...any) {
 	if d == nil {
 		return
 	}
-	d.write(fmt.Sprintf(format, args...))
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	d.write(timestamp + " " + fmt.Sprintf(format, args...))
 }
 
 func (d *runnerDiagnostics) bufferFatalf(format string, args ...any) {

--- a/internal/loop/filelock_test.go
+++ b/internal/loop/filelock_test.go
@@ -242,7 +242,7 @@ func TestUpdateLastSeen_NoLostUpdateUnderConcurrency(t *testing.T) {
 	}
 }
 
-// TestRunnerOfflineNotResurrectedByConcurrentLastSeen models the run.go shutdown
+// TestRunnerOfflineNotResurrectedByConcurrentLastSeen models the serve.go shutdown
 // race: a registration marked offline must not be flipped back to active by a
 // concurrent last_seen refresh. With both writers serialized through
 // withAgentLock and the offline write applied last, the terminal state is

--- a/internal/loop/inbox.go
+++ b/internal/loop/inbox.go
@@ -33,7 +33,6 @@ const (
 )
 
 var (
-	removeFile   = os.Remove
 	readInboxDir = os.ReadDir
 )
 

--- a/internal/loop/inbox_test.go
+++ b/internal/loop/inbox_test.go
@@ -179,17 +179,7 @@ func TestArchiveMessageIdempotentWhenDestinationIsSameFile(t *testing.T) {
 	}
 }
 
-// TestWriteSeqMessageIgnoresTempCleanupError: a failed temp-file cleanup after a
-// successful link must not fail the write; the leftover temp is left behind.
-func TestWriteSeqMessageIgnoresTempCleanupError(t *testing.T) {
-	oldRemoveFile := removeFile
-	t.Cleanup(func() {
-		removeFile = oldRemoveFile
-	})
-	removeFile = func(string) error {
-		return errors.New("cleanup failed")
-	}
-
+func TestWriteSeqMessageCleansTempFile(t *testing.T) {
 	root := t.TempDir()
 	inbox := filepath.Join(root, "inbox", "claude-code")
 	if err := os.MkdirAll(inbox, 0o755); err != nil {
@@ -200,22 +190,14 @@ func TestWriteSeqMessageIgnoresTempCleanupError(t *testing.T) {
 	if _, err := os.Stat(msg.Path); err != nil {
 		t.Fatal(err)
 	}
-	// The temp file now uses a unique os.CreateTemp name (not the deterministic
-	// .tmp_<final>), so locate the leftover by its tempFilePrefix rather than an
-	// exact name.
 	entries, err := os.ReadDir(inbox)
 	if err != nil {
 		t.Fatal(err)
 	}
-	foundTemp := false
 	for _, e := range entries {
 		if strings.HasPrefix(e.Name(), tempFilePrefix) {
-			foundTemp = true
-			break
+			t.Fatalf("temp file should be cleaned after successful link; found %s", e.Name())
 		}
-	}
-	if !foundTemp {
-		t.Fatalf("a temp file should remain after fake cleanup failure; inbox entries: %v", entries)
 	}
 }
 

--- a/internal/loop/lease_pid_unix.go
+++ b/internal/loop/lease_pid_unix.go
@@ -9,7 +9,7 @@ import (
 )
 
 // pidAlive reports whether pid names a live process on THIS host, via the
-// classic FindProcess + Signal(0) probe (mirrors run.go:processAlive, which
+// classic FindProcess + Signal(0) probe (mirrors serve.go:processAlive, which
 // lives in package main and is unreachable from internal/loop). EPERM means the
 // process exists but is owned by another uid — still alive for our purposes.
 //

--- a/internal/loop/message.go
+++ b/internal/loop/message.go
@@ -77,8 +77,9 @@ func AnnounceEnrollment(cfg *Config, self *Registration) (AnnounceResult, error)
 		}
 		result.Total++
 		content := ComposeMessage(self.AgentID, "", body)
-		// Gate 4: deliver under the canonical (to,from,seq) identity (empty
-		// idempotencyKey/serveToken = transitional at-most-once, unfenced).
+		// Deliver under the canonical (to,from,seq) identity. Empty
+		// idempotencyKey means at-most-once across a sender crash between seq
+		// allocation and link; empty serveToken means intentionally unfenced.
 		if _, err := SendSeqMessage(cfg, self.AgentID, peer.AgentID, content, "", ""); err != nil {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("send to %s: %v", peer.AgentID, err))
 			continue
@@ -185,8 +186,9 @@ func SendCorrective(cfg *Config, from, offender, malformedItem, reason, sectionR
 	body := CorrectiveBody(malformedItem, reason, sectionRef)
 	content := ComposeMessage(from, "", body)
 
-	// Gate 4: deliver under the canonical (to,from,seq) identity (empty
-	// idempotencyKey/serveToken = transitional at-most-once, unfenced).
+	// Deliver under the canonical (to,from,seq) identity. Empty idempotencyKey
+	// means at-most-once across a sender crash between seq allocation and link;
+	// empty serveToken means intentionally unfenced.
 	id, err := SendSeqMessage(cfg, from, offender, content, "", "")
 	if err != nil {
 		return Message{}, err

--- a/internal/loop/seq.go
+++ b/internal/loop/seq.go
@@ -236,9 +236,8 @@ var afterOuterFenceHook func()
 // serveToken: the active serve lease fence (lease.go). When non-empty,
 // AllocateSeq VerifyFence's it BEFORE persisting the counter, so a zombie/paused
 // holder whose lease was reclaimed can NOT advance the counter (closes the
-// dup-writer hole launch-time guarding alone leaves open). When EMPTY the write
-// is UNFENCED — the documented Gate-2/off-bus/degraded mode; serve supplies a
-// real token once the lease is wired in (Gate 6).
+// dup-writer hole launch-time guarding alone leaves open). When EMPTY, the write
+// is intentionally UNFENCED for callers that are not running under a serve lease.
 //
 // FENCING (fail-closed): when serveToken != "", VerifyFence is checked TWICE —
 // once OUTSIDE withAgentLock (fast fail-closed) and AGAIN INSIDE the lock,
@@ -361,23 +360,19 @@ func writeSeqMessage(inboxDir string, id MsgID, content []byte) (alreadyLanded b
 		return false, err
 	}
 	tempPath := tempFile.Name()
+	defer func() { _ = os.Remove(tempPath) }()
 	if err := writeAndSyncOpenFile(tempFile, content); err != nil {
-		_ = os.Remove(tempPath)
 		return false, err
 	}
 
 	finalPath := filepath.Join(inboxDir, id.Filename())
 	if err := linkNoClobber(tempPath, finalPath); err != nil {
-		_ = os.Remove(tempPath)
 		if errors.Is(err, os.ErrExist) {
 			// This exact (to,from,seq) is still present in the inbox — safe no-op
 			// success (pre-consume; post-consume relies on receiver Key dedup).
 			return true, nil
 		}
 		return false, fmt.Errorf("link to %s: %w", finalPath, err)
-	}
-	if err := removeFile(tempPath); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: failed to remove temp seq file %s: %v\n", tempPath, err)
 	}
 	if err := syncDir(inboxDir); err != nil {
 		return false, err
@@ -405,7 +400,7 @@ func SendSeqMessage(cfg *Config, from, to string, content []byte, idempotencyKey
 	// fully eliminate the link race (a reclaim can always slip between this read and
 	// the link); the durable+monotonic seq guarantees no REUSE regardless, so any
 	// residual late write lands at a seq the new owner will never re-issue. Only
-	// enforced when fenced (serveToken != ""); empty = unfenced transitional mode.
+	// enforced when fenced (serveToken != ""); empty = intentionally unfenced.
 	if serveToken != "" {
 		if err := VerifyFence(cfg, from, serveToken); err != nil {
 			return MsgID{}, err


### PR DESCRIPTION
## Summary
- report stale `.tmp_*` residue older than 1h from nested `inbox/*` + `state/*` dirs and flat `agents/` + `live/` dirs in `doctor`
- make seq message temp cleanup defer-based and remove the old cleanup test seam
- rewrite stale at-most-once / transitional comments around empty idempotency keys and unfenced sends
- add RFC3339 timestamps to `state/<agent-id>/runner.log` lines
- rename `internal/cli/run.go` to `internal/cli/serve.go`

## Verification
- `gofmt -w .`
- `go vet ./...`
- `env -u AGENTCHUTE_SERVE_TOKEN go test ./...`
- `go build ./...`
- `env -u AGENTCHUTE_SERVE_TOKEN go test -race ./...`
- `(cd conformance && env -u AGENTCHUTE_SERVE_TOKEN go test ./...)`
- `shellcheck install.sh`
- `sh tests/install_test.sh`
- `goreleaser check`
- `env -u AGENTCHUTE_SERVE_TOKEN go test ./internal/cli -run 'TestPromptInjectionBytes|TestRunnerDiagnosticsLogFileOnlyDuringRawWindow'`
- `env -u AGENTCHUTE_SERVE_TOKEN go test ./internal/cli -run 'TestDoctorWarnsOnStaleTempFiles|TestRunnerDiagnosticsLogFileOnlyDuringRawWindow|TestPromptInjectionBytes'`
- `git diff --check`

Note: tests are run with `AGENTCHUTE_SERVE_TOKEN` unset because this runner session exports it; inherited stale serve tokens intentionally make existing send tests fail closed.

Gate requested via agentchute: claude-code-agentchute + sonnet.
