### PR TITLE
v0.10.2 [SPEC]: §6.6 owed discharge requires the owing sender (N1, spec-first)

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -184,7 +184,7 @@ Receivers MUST ignore unrecognized frontmatter fields. `from` is required inform
 Reply obligations are **asker-owned only**. The asker's `.owed` ledger is the **sole** reply-obligation mechanism (non-blocking warning + expiry). **Recipients are never blocked at finish by a `reply_required` message** — delivery is best-effort pull, with no forcing function once delivered.
 
 - When an agent sends `--ask` (reply-required), it records its own obligation in `state/<asker>/owed.json`: "I am owed a reply to `(to=recipient, from=me, seq)` by `<deadline>`" (default 30m; override with `--reply-by`). The ledger is single-writer, atomic-rename, and the gate reads only its OWN ledger — it never scans peers.
-- When the asker later consumes a reply whose `in_reply_to` references that `(to,from,seq)`, the obligation is cleared (idempotent).
+- When the asker later consumes a reply whose `in_reply_to` references that `(to,from,seq)`, the obligation is cleared only if the consumed reply's canonical sender is the agent that owed the reply (idempotent).
 - The asker's gate surfaces **outstanding** and **expired** obligations as **non-blocking warnings**. An expired obligation is the asker-side dead-recipient signal: a dead recipient shows up twice over — the asker's expired `.owed` AND the recipient's stale `.live` — so the asker never waits on a corpse.
 - On the recipient side, consuming a `reply_required` message records **nothing** and merely **prints the reply-ref command** (`reply_required` is advisory on the wire). There is no recipient-side ledger and no `defer` command; both were removed in v0.9.0 (the `.owed` redesign). A reply is a normal `send --reply-to <ref>`, which discharges the asker's `.owed` when the asker consumes it.
 


### PR DESCRIPTION
PR-A-spec (split from PR-A per CONTRIBUTING.md §Spec-changes — spec-only PR first, code follows). Authored by codex.

**Change:** §6.6 — the asker's `.owed` obligation is discharged on a consumed reply only if the reply's **canonical sender is the agent that owed it**. Previously the sentence was sender-agnostic.

**Why spec-first (separate PR):** §6.6 is a listed covenant (spec line 3) and CONTRIBUTING.md:74-82 requires spec changes to land as their own PR before the code. Caught by sonnet in plan review; verified against CONTRIBUTING.md.

**Patch-safe:** `.owed` is asker-local, non-wire, non-blocking (a warning, never a finish blocker). This tightens *when a local ledger clears* — no envelope/filename/interop/conformance change. codex ratified the covenant call.

**Merge order:** this PR first; the code guard (PR-A-code, #next) merges after.

Gates: codex (author — needs sonnet + claude) → so **sonnet + claude** gate.