### PR TITLE
v0.10.2 [CODE]: owed discharge sender guard + regression (N1)

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -253,10 +253,11 @@ func displayConsumed(cfg *loop.Config, agentID string, msg loop.Message, content
 	fm := loop.ParseMessageFrontmatter(content)
 
 	// Asker-side owed flip. ClearOwed only touches OUR ledger and only removes a
-	// matching key, so the From==agentID guard (we are the asker) is the
-	// authority check; a non-matching ref is a harmless no-op.
+	// matching key. The ref must name us as asker, and the consumed reply must
+	// come from the agent that owed it; otherwise a third party could clear an
+	// obligation by echoing someone else's ref.
 	if ref := strings.TrimSpace(fm["in_reply_to"]); ref != "" {
-		if key, ok := loop.ParseMsgIDRef(ref); ok && key.From == agentID {
+		if key, ok := loop.ParseMsgIDRef(ref); ok && key.From == agentID && msg.Sender == key.To {
 			if err := loop.ClearOwed(cfg, agentID, key); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: failed to clear owed obligation %s: %v\n", ref, err)
 			}

--- a/internal/cli/consume_boundary_test.go
+++ b/internal/cli/consume_boundary_test.go
@@ -273,3 +273,77 @@ func TestOwedFlip_RecordClearExpireGateWarn(t *testing.T) {
 		t.Fatalf("gate warnings missing the expired-owed signal; warnings=%v", st.Warnings)
 	}
 }
+
+func TestOwedFlip_ThirdPartyReplyDoesNotClear(t *testing.T) {
+	root, cfg := setupConsumeFixture(t)
+	withCwd(t, root, func() {
+		if err := cmdRegister([]string{"--as", "carol", "--vendor", "google", "--host", "third-host"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// alice asks bob; alice is owed a reply specifically by bob.
+	withCwd(t, root, func() {
+		if err := cmdSend([]string{"--from", "alice", "--to", "bob",
+			"--ask", "--body", "please review"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	owed, err := loop.LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := owed.OutstandingOwed()
+	if len(out) != 1 {
+		t.Fatalf("alice .owed has %d entries after --ask; want 1", len(out))
+	}
+	key := out[0].Key()
+	if key.To != "bob" || key.From != "alice" || key.Seq != 1 {
+		t.Fatalf("owed key = %+v; want {To:bob From:alice Seq:1}", key)
+	}
+	ref := key.RefString()
+
+	// carol forges a reply using bob's ref; consuming it must not clear bob's
+	// obligation.
+	withCwd(t, root, func() {
+		if err := cmdSend([]string{"--from", "carol", "--to", "alice",
+			"--reply-to", ref, "--body", "spoofed"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := captureStdout(t, func() error { return cmdAck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+	})
+	owed, err = loop.LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out = owed.OutstandingOwed()
+	if len(out) != 1 {
+		t.Fatalf("forged third-party reply cleared obligation; alice .owed has %d entries, want 1", len(out))
+	}
+	if got := out[0].Key(); !got.Equal(key) {
+		t.Fatalf("remaining owed key = %+v; want %+v", got, key)
+	}
+
+	// bob's actual reply still clears the obligation.
+	withCwd(t, root, func() {
+		if err := cmdSend([]string{"--from", "bob", "--to", "alice",
+			"--reply-to", ref, "--body", "done"}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+	})
+	owed, err = loop.LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(owed.OutstandingOwed()); n != 0 {
+		t.Fatalf("alice .owed has %d entries after bob's reply; want 0", n)
+	}
+}


### PR DESCRIPTION
PR-A-code (split from PR-A). Authored by codex. **Merge AFTER the spec PR.**

**Fix:** `displayConsumed` clears `.owed` only when `key.From==agentID && msg.Sender==key.To`. A third party echoing someone else's `in_reply_to` — adversarially, OR via a stale/hallucinated ref from a well-meaning peer (this team's own grok/gemini resend flakiness is exactly this non-adversarial class, per sonnet) — can no longer clear an obligation it doesn't own. Impact bounded to a non-blocking gate warning; `ClearOwed` signature unchanged (single call site).

**Test:** `TestOwedFlip_ThirdPartyReplyDoesNotClear` — Carol's reply carrying Alice→Bob's ref does NOT clear Alice's owed-to-Bob; Bob's correct reply still clears.

**Severity:** Medium (real correctness hole in the only cross-agent-state machine; capped at Medium because impact is a suppressed warning, no state/authority breach). Rationale per sonnet's correction: NOT §15 spoofing (message is honestly self-attributed) — it's missing input hygiene, triggerable non-adversarially.

Verification: gofmt/vet/build; `go test ./...`+`-race`; conformance; crown-jewel `TestPromptInjectionBytes*`; `TestOwedFlip*` — all green.

Gates: **sonnet + claude** (codex authored).