### PR TITLE
fix: sanitize control bytes from consumed message display (N3)

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -279,11 +279,36 @@ func printConsumedBody(msg loop.Message, content []byte, redelivered bool) {
 	} else {
 		fmt.Printf("---- %s ----\n", msg.Filename)
 	}
-	fmt.Print(string(content))
-	if !strings.HasSuffix(string(content), "\n") {
+	sanitized := sanitizeControlBytes(string(content))
+	fmt.Print(sanitized)
+	if !strings.HasSuffix(sanitized, "\n") {
 		fmt.Println()
 	}
 	fmt.Println()
+}
+
+// sanitizeControlBytes strips C0/C1 control code points from peer-controlled
+// text before it reaches a raw terminal (N3, deep-analysis-v2): a body
+// carrying ANSI/OSC escape sequences or bare C1 codes can repaint the
+// operator's screen, spoof a prompt, or set the window title. Applied
+// unconditionally (not just when stdout is a TTY) because message bodies are
+// spec'd UTF-8 free-form text — a control sequence is never legitimate
+// payload — and unconditional stripping avoids needing platform-specific
+// stdout-TTY detection. \n and \t are the only control code points kept.
+func sanitizeControlBytes(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r == '\n' || r == '\t':
+			b.WriteRune(r)
+		case r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f):
+			// drop: C0 (incl. ESC, CR), DEL, and C1 control code points.
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // printReplyRefIfRequired prints the copyable in_reply_to ref a reply to msg must

--- a/internal/cli/n3_sanitize_test.go
+++ b/internal/cli/n3_sanitize_test.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// n3_sanitize_test.go — N3 (deep-analysis-v2): raw message bodies and other
+// peer-controlled display text reach a terminal unsanitized. Control bytes
+// (ESC-driven ANSI/OSC sequences, C1 codes, bare CR) let a peer repaint the
+// operator's screen, spoof a prompt, or set the window title. Fix: strip C0/C1
+// control code points from peer-controlled text before it is printed on the
+// human-facing text path, unconditionally (no stdout-TTY gating — bodies are
+// spec'd UTF-8 free-form text, so control sequences are never legitimate
+// payload). \n and \t are the only control code points kept.
+
+// TestCheckSanitizesControlBytesInConsumedBody is the load-bearing N3 test for
+// the primary exposure: `check`'s human-facing display of a consumed message
+// body (printConsumedBody, check.go). An ANSI/OSC/C0-laden body must print
+// inert — the escape/control bytes stripped, the human-readable text intact.
+func TestCheckSanitizesControlBytesInConsumedBody(t *testing.T) {
+	root, _ := setupConsumeFixture(t)
+
+	// A body carrying: CSI color escape (ESC [ ... m), an OSC window-title
+	// sequence terminated by BEL, a bare CR (overwrite trick), and a C1 CSI
+	// byte (0x9B) with no ESC prefix — plus plain visible text and a real
+	// newline that must survive.
+	evilBody := "line one\x1b[31mRED\x1b[0m\r" +
+		"\x1b]0;pwned\x07" +
+		"\x9bevil-c1" +
+		"\nline two"
+
+	withCwd(t, root, func() {
+		if err := cmdSend([]string{"--from", "bob", "--to", "alice", "--body", evilBody}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	var out string
+	withCwd(t, root, func() {
+		o, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "alice"}) })
+		if err != nil {
+			t.Fatal(err)
+		}
+		out = o
+	})
+
+	for _, bad := range []string{"\x1b", "\r", "\x9b", "\x07"} {
+		if strings.Contains(out, bad) {
+			t.Fatalf("consumed body output still contains raw control byte %q; got:\n%q", bad, out)
+		}
+	}
+	if !strings.Contains(out, "line one") || !strings.Contains(out, "RED") || !strings.Contains(out, "line two") {
+		t.Fatalf("sanitization dropped legitimate visible text; got:\n%q", out)
+	}
+	// \n must survive stripping even though it is itself a control code
+	// point: it sits immediately before "line two" in evilBody, with only
+	// stripped bytes in between, so it must still sit immediately before
+	// "line two" in the sanitized output.
+	if !strings.Contains(out, "\nline two") {
+		t.Fatalf("sanitization dropped \\n; got:\n%q", out)
+	}
+}
+
+// TestPendingTextSanitizesPriorityControlBytes covers the secondary N3
+// exposure (codex's gate-review catch): pending's text-mode `[priority:...]`
+// flag prints e.Priority raw, and e.Priority is sourced from the UNVALIDATED
+// frontmatter peek path (readFrontmatter -> loop.ParseMessageFrontmatter,
+// with no loop.ValidateMessageFrontmatter gate in front of it, unlike
+// check.go's consume path) — so a sender-controlled `priority:` value can
+// carry ANSI/OSC/C0 bytes straight into `agentchute pending`'s text output.
+// e.From/e.Timestamp are filename-derived (constrained by the seq-filename
+// regex) and intentionally NOT covered here.
+func TestPendingTextSanitizesPriorityControlBytes(t *testing.T) {
+	root, cfg := setupSendFixture(t)
+	inbox := cfg.AgentInboxDir("claude-code")
+
+	evilPriority := "\x1b[31murgent\x1b[0m\x9b"
+	body := "---\n" +
+		"from: codex\n" +
+		"to: claude-code\n" +
+		"priority: " + evilPriority + "\n" +
+		"---\n\nbody\n"
+	mustWriteSeqInbox(t, inbox, "codex", 1, []byte(body))
+
+	withCwd(t, root, func() {
+		out, err := captureStdout(t, func() error { return cmdPending(pendingArgs()) })
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, bad := range []string{"\x1b", "\x9b"} {
+			if strings.Contains(out, bad) {
+				t.Fatalf("pending text output still contains raw control byte %q; got:\n%q", bad, out)
+			}
+		}
+		if !strings.Contains(out, "urgent") {
+			t.Fatalf("sanitization dropped legitimate priority text; got:\n%q", out)
+		}
+	})
+}
+
+// TestSanitizeControlBytes pins the exact keep/drop boundary of the helper
+// underlying both tests above: \n and \t are the only control code points
+// kept; all other C0, DEL, and C1 code points are dropped; ordinary text
+// (including multi-byte UTF-8 and invalid UTF-8) passes through unchanged
+// or degrades safely.
+func TestSanitizeControlBytes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text unchanged", "hello world", "hello world"},
+		{"newline and tab kept", "a\nb\tc", "a\nb\tc"},
+		{"CR dropped", "a\rb", "ab"},
+		{"ESC dropped", "a\x1bb", "ab"},
+		{"BEL dropped", "a\x07b", "ab"},
+		{"DEL dropped", "a\x7fb", "ab"},
+		{"C1 CSI rune dropped (valid UTF-8 encoding of U+009B)", "a\u009bb", "ab"},
+		// A bare 0x9b byte on its own is invalid UTF-8 (C1 requires the
+		// 2-byte encoding \xc2\x9b to be valid UTF-8, matching the previous
+		// case). Go's `range` over invalid UTF-8 yields U+FFFD before the
+		// filter's C1 range check ever sees byte 0x9b \u2014 so it never passes
+		// through raw either way, it just surfaces as the inert replacement
+		// character instead of being silently dropped. Pin that behavior.
+		{"invalid UTF-8 byte neutralized to U+FFFD, never passed through raw", "a\x9bb", "a\ufffdb"},
+		{"C1 range boundary kept just outside", "a\xc2\xa0b", "a\u00a0b"}, // U+00A0 NBSP, just past C1 (U+009F)
+		{"multi-byte UTF-8 preserved", "héllo 日本語", "héllo 日本語"},
+		{"full ANSI CSI sequence stripped to bare text", "\x1b[31mRED\x1b[0m", "[31mRED[0m"},
+		{"empty string", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeControlBytes(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeControlBytes(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/pending.go
+++ b/internal/cli/pending.go
@@ -217,7 +217,11 @@ func emitPendingText(entries []pendingEntry, owed []loop.OwedEntry, malformed in
 				flags += " [REPLY-REQUIRED]"
 			}
 			if e.Priority != "" && e.Priority != "normal" {
-				flags += " [priority:" + e.Priority + "]"
+				// e.Priority is sourced from the unvalidated frontmatter peek
+				// path (readFrontmatter), so it must be sanitized before
+				// reaching a raw terminal here (N3, deep-analysis-v2) — see
+				// sanitizeControlBytes in check.go.
+				flags += " [priority:" + sanitizeControlBytes(e.Priority) + "]"
 			}
 			if e.Stale {
 				flags += " [stale]"


### PR DESCRIPTION
## Summary
- N3 (deep-analysis-v2, part of the v0.10.2 fix list): `check`'s `printConsumedBody` printed raw message bodies to the terminal with zero filtering, and `pending`'s text-mode `[priority:...]` flag printed an unvalidated frontmatter value the same way. A peer-controlled body/priority field carrying ANSI/OSC/C1 control sequences could repaint the operator's screen, spoof a prompt, or set the window title.
- Adds `sanitizeControlBytes`: strips C0/C1 control code points (keeping `\n`/`\t`) **unconditionally**, not TTY-gated — bodies are spec'd UTF-8 free-form text, so a control sequence is never legitimate payload, and this avoids new platform-specific stdout-TTY detection code. Wired into `check.go:printConsumedBody` and `pending.go`'s `e.Priority` text-mode display.
- `--json` output and `--show-body` are untouched (already JSON-escaped, so control bytes reach the consumer as safe `\u00XX` escapes, not raw). `e.From`/`e.Timestamp` in `pending` are filename-derived (constrained by the seq-filename regex) and intentionally not touched.

Part of the agreed v0.10.2 "trust boundary + operational honesty" plan (Task 2 / PR-B).

## Test plan
- [x] TDD: RED confirmed for both new integration tests before the fix (raw control bytes present in captured stdout), GREEN after.
- [x] `TestCheckSanitizesControlBytesInConsumedBody` — ANSI CSI, OSC+BEL, bare CR, and a C1 CSI byte in a message body all print inert; visible text and `\n` survive.
- [x] `TestPendingTextSanitizesPriorityControlBytes` — a malicious `priority:` frontmatter value prints inert in `pending`'s text mode.
- [x] `TestSanitizeControlBytes` — table test pinning the exact keep/drop boundary, including the Go UTF-8-iteration edge case where a lone invalid byte surfaces as `U+FFFD` rather than passing through raw (still safe either way).
- [x] `gofmt -l .` clean, `go vet ./...` clean, `go build ./...` clean.
- [x] `go test ./...` — full suite green.
- [x] `go test -race ./...` — race-clean.
- [x] `conformance` module — green.
- [x] Crown jewels (`TestPromptInjectionBytes*`) — byte-identical, unaffected (this PR never touches `serve.go`'s injection bytes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)