### PR TITLE
fix: re-check inbox non-empty before injecting wake cue (M4)

### DIFF
--- a/internal/cli/m4_inject_recheck_test.go
+++ b/internal/cli/m4_inject_recheck_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// m4_inject_recheck_test.go — M4 (deep-analysis-v2 addendum): the runner's
+// injectLoop enqueues a wake as soon as pollOnce sees unseen inbox mail, but
+// previously fired injectPrompt unconditionally once the injection window
+// opened — with NO re-check that the mail was still there. In the claim
+// race, the agent's own `check` (triggered by an earlier cue in the same
+// batch) can claim the mail (moving it inbox -> .claimed) before this later
+// cue actually injects, producing a spurious "check inbox" prompt into an
+// already-empty inbox. Fix: injectIfPending re-lists the inbox immediately
+// before injectPrompt and skips injection if nothing is pending.
+
+// TestInjectIfPendingSkipsWhenInboxAlreadyClaimed is the load-bearing race
+// test: mail that was claimed (moved out of the raw inbox) before injection
+// fires must NOT produce an injection attempt.
+func TestInjectIfPendingSkipsWhenInboxAlreadyClaimed(t *testing.T) {
+	root := setupShortRunFixture(t)
+	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := newPollTestRuntime(t, cfg, "runner-test")
+	rt.diag = newRunnerDiagnostics(cfg, "runner-test")
+	defer rt.diag.close()
+
+	inbox := cfg.AgentInboxDir("runner-test")
+	mustWriteSeqInbox(t, inbox, "peer", 1, []byte("---\nfrom: peer\nto: runner-test\n---\n\nhi\n"))
+	msgs, _, err := loop.ListInboxMessagesWithSkipped(inbox)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("seed: got %d inbox messages, want 1", len(msgs))
+	}
+	// Simulate the claim race: `check` (from an earlier cue) claims the mail
+	// — moves it out of the raw inbox — before THIS wake gets to inject.
+	if _, err := loop.ClaimMessage(msgs[0], cfg.AgentClaimedDir("runner-test")); err != nil {
+		t.Fatal(err)
+	}
+
+	rt.injectIfPending()
+
+	log := readRunnerLog(t, cfg, "runner-test")
+	if strings.Contains(log, "agentchute serve: inject prompt:") {
+		t.Fatalf("injectIfPending attempted an injection into an already-claimed (empty) inbox; log:\n%s", log)
+	}
+}
+
+// TestInjectIfPendingStillInjectsWhenMailPending is the non-regression half:
+// a wake with mail genuinely still sitting in the inbox must still inject.
+func TestInjectIfPendingStillInjectsWhenMailPending(t *testing.T) {
+	root := setupShortRunFixture(t)
+	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := newPollTestRuntime(t, cfg, "runner-test")
+	rt.diag = newRunnerDiagnostics(cfg, "runner-test")
+	defer rt.diag.close()
+
+	inbox := cfg.AgentInboxDir("runner-test")
+	mustWriteSeqInbox(t, inbox, "peer", 1, []byte("---\nfrom: peer\nto: runner-test\n---\n\nhi\n"))
+	// Mail is genuinely still pending (never claimed).
+
+	rt.injectIfPending()
+
+	log := readRunnerLog(t, cfg, "runner-test")
+	if !strings.Contains(log, "agentchute serve: inject prompt:") {
+		t.Fatalf("injectIfPending did not attempt an injection with mail still pending; log:\n%s", log)
+	}
+}
+
+// TestInjectIfPendingStillInjectsOnMalformedFile mirrors the poll-side rule
+// (TestRunnerPoll_WakesOnMalformedFile): a skipped/malformed file still
+// counts as pending — the agent needs to run `check` to see it quarantined
+// and get the corrective notice, so the cue must not be suppressed.
+func TestInjectIfPendingStillInjectsOnMalformedFile(t *testing.T) {
+	root := setupShortRunFixture(t)
+	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := newPollTestRuntime(t, cfg, "runner-test")
+	rt.diag = newRunnerDiagnostics(cfg, "runner-test")
+	defer rt.diag.close()
+
+	inbox := cfg.AgentInboxDir("runner-test")
+	mustWrite(t, filepath.Join(inbox, "not-a-seq-name.md"), []byte("body"))
+
+	rt.injectIfPending()
+
+	log := readRunnerLog(t, cfg, "runner-test")
+	if !strings.Contains(log, "agentchute serve: inject prompt:") {
+		t.Fatalf("injectIfPending did not attempt an injection with a pending malformed file; log:\n%s", log)
+	}
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -620,10 +620,36 @@ func (r *runnerRuntime) injectLoop() {
 			return
 		case <-r.wakeCh:
 			if r.waitForInjectionWindow() {
-				r.injectPrompt()
+				r.injectIfPending()
 			}
 		}
 	}
+}
+
+// injectIfPending re-checks the inbox immediately before injecting (M4,
+// deep-analysis-v2 addendum): a wake can be enqueued for mail that the
+// agent's own `check` — triggered by an earlier cue in the same batch —
+// already claimed (moved inbox -> .claimed) by the time this cue reaches the
+// front of injectLoop, producing a spurious "check inbox" prompt into an
+// already-empty inbox. Single call site (the only caller of injectPrompt).
+func (r *runnerRuntime) injectIfPending() {
+	if !r.hasPendingInboxMail() {
+		return
+	}
+	r.injectPrompt()
+}
+
+// hasPendingInboxMail reports whether the raw inbox (parsed messages or
+// skipped/malformed files — either needs `check` to run) currently has
+// anything in it. On a transient listing error, fails OPEN (reports
+// pending) to preserve the safe failure direction: an extra spurious cue is
+// acceptable, a suppressed real one is not.
+func (r *runnerRuntime) hasPendingInboxMail() bool {
+	msgs, skipped, err := loop.ListInboxMessagesWithSkipped(r.cfg.AgentInboxDir(r.opts.AgentID))
+	if err != nil && !errors.Is(err, loop.ErrInboxMissing) {
+		return true
+	}
+	return len(msgs) > 0 || len(skipped) > 0
 }
 
 func (r *runnerRuntime) waitForInjectionWindow() bool {


### PR DESCRIPTION
## Summary
- M4 (deep-analysis-v2 addendum, part of the v0.10.2 fix list): the runner's `injectLoop` fired `injectPrompt` unconditionally once the injection window opened, with no re-check that the mail triggering the wake was still there. In the claim race, the agent's own `check` (triggered by an earlier cue in the same batch) can claim the mail — moving it out of the raw inbox — before this later cue reaches the front of the loop, producing a spurious "check inbox" prompt into an already-empty inbox and wasting an agent turn.
- Adds `injectIfPending` (`internal/cli/serve.go`): re-lists the inbox immediately before `injectPrompt` and skips injection if nothing is pending (parsed messages OR skipped/malformed files — either needs `check` to run). On a transient listing error, fails **open** (still injects) — preserves the safe failure direction: an extra spurious cue is acceptable, a suppressed real one is not. Single call site (the only caller of `injectPrompt`).

Part of the agreed v0.10.2 "trust boundary + operational honesty" plan (Wave 2 / M4).

## Test plan
- [x] TDD: RED confirmed (compile failure referencing the not-yet-existing `injectIfPending`, i.e. the missing behavior) before the fix; GREEN after.
- [x] `TestInjectIfPendingSkipsWhenInboxAlreadyClaimed` — the load-bearing race test: mail claimed (moved to `.claimed`) before injection fires produces NO injection attempt.
- [x] `TestInjectIfPendingStillInjectsWhenMailPending` — non-regression: mail genuinely still pending still injects.
- [x] `TestInjectIfPendingStillInjectsOnMalformedFile` — mirrors the poll-side rule (`TestRunnerPoll_WakesOnMalformedFile`): a skipped/malformed file still counts as pending (needs `check` to quarantine + notify), so the cue is not suppressed.
- [x] `gofmt -l .` clean, `go vet ./...` clean, `go build ./...` clean.
- [x] `go test ./...` — full suite green.
- [x] `go test -race ./...` — race-clean.
- [x] `conformance` module — green.
- [x] Crown jewels (`TestPromptInjectionBytes*`) — explicitly re-run since this PR touches `serve.go`; byte-identical (`promptInjectionBytes` itself is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)