### PR TITLE
v0.10.2: doctor spec-staleness check (M1) + drop tmux unenrolled_presence noise (M2)

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -182,6 +183,7 @@ type doctorOptions struct {
 func runDoctorChecks(cfg *loop.Config, agentID string, opts doctorOptions) doctorReport {
 	checks := []doctorCheck{
 		checkLoopDirScaffold(cfg),
+		checkSpecFreshness(cfg),
 		checkStaleTempFiles(cfg, opts.Now),
 		checkBinaryOnPath(),
 		checkHookFilePresence(cfg, agentID),
@@ -217,6 +219,39 @@ func runDoctorChecks(cfg *loop.Config, agentID string, opts doctorOptions) docto
 }
 
 // ---------- individual checks ----------
+
+func checkSpecFreshness(cfg *loop.Config) doctorCheck {
+	const name = "spec_freshness"
+	if cfg == nil || cfg.ControlRepo == "" {
+		return doctorCheck{Name: name, Severity: severitySkip, Message: "control repo unavailable; skipping AGENTCHUTE.md freshness check"}
+	}
+	if embeddedSpecContent == "" {
+		return doctorCheck{Name: name, Severity: severitySkip, Message: "embedded AGENTCHUTE.md unavailable; skipping spec freshness check"}
+	}
+	path := filepath.Join(cfg.ControlRepo, "AGENTCHUTE.md")
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return doctorCheck{Name: name, Severity: severitySkip, Message: "AGENTCHUTE.md missing; discovery/scaffold checks own this"}
+		}
+		return doctorCheck{Name: name, Severity: severityWarn, Message: fmt.Sprintf("AGENTCHUTE.md unreadable at %s: %v", path, err)}
+	}
+	embedded := []byte(embeddedSpecContent)
+	if bytes.Equal(onDisk, embedded) {
+		return doctorCheck{Name: name, Severity: severityOK, Message: "AGENTCHUTE.md matches embedded spec"}
+	}
+	return doctorCheck{
+		Name:     name,
+		Severity: severityWarn,
+		Message: fmt.Sprintf("AGENTCHUTE.md differs from this binary's embedded spec (disk sha256=%s, embedded sha256=%s); re-run `agentchute init`/`setup` or update your checkout",
+			shortSHA256(onDisk), shortSHA256(embedded)),
+	}
+}
+
+func shortSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum[:])[:12]
+}
 
 func checkLoopDirScaffold(cfg *loop.Config) doctorCheck {
 	type expected struct {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -120,6 +120,53 @@ func TestDoctorWarnsOnStaleTempFiles(t *testing.T) {
 	}
 }
 
+func TestDoctorSpecFreshnessMatchesEmbeddedSpec(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	if err := os.WriteFile(filepath.Join(cfg.ControlRepo, "AGENTCHUTE.md"), []byte(embeddedSpecContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := checkSpecFreshness(cfg)
+	if got.Severity != severityOK {
+		t.Fatalf("spec_freshness severity = %q, want OK; message=%q", got.Severity, got.Message)
+	}
+	if !strings.Contains(got.Message, "matches embedded spec") {
+		t.Fatalf("spec_freshness message missing match text: %q", got.Message)
+	}
+}
+
+func TestDoctorSpecFreshnessWarnsOnStaleSpec(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	if err := os.WriteFile(filepath.Join(cfg.ControlRepo, "AGENTCHUTE.md"), []byte("# AGENTCHUTE.md\n\nstale copy\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := checkSpecFreshness(cfg)
+	if got.Severity != severityWarn {
+		t.Fatalf("spec_freshness severity = %q, want WARN; message=%q", got.Severity, got.Message)
+	}
+	for _, want := range []string{"differs from this binary's embedded spec", "disk sha256=", "embedded sha256=", "agentchute init"} {
+		if !strings.Contains(got.Message, want) {
+			t.Fatalf("spec_freshness message missing %q: %q", want, got.Message)
+		}
+	}
+}
+
+func TestDoctorSpecFreshnessSkipsWhenEmbeddedSpecUnavailable(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	if err := os.WriteFile(filepath.Join(cfg.ControlRepo, "AGENTCHUTE.md"), []byte("# AGENTCHUTE.md\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prev := embeddedSpecContent
+	embeddedSpecContent = ""
+	t.Cleanup(func() { embeddedSpecContent = prev })
+
+	got := checkSpecFreshness(cfg)
+	if got.Severity != severitySkip {
+		t.Fatalf("spec_freshness severity = %q, want SKIP; message=%q", got.Severity, got.Message)
+	}
+}
+
 func TestDoctorBareAgentchuteCheckInHookBlocks(t *testing.T) {
 	cfg := newDoctorCfg(t)
 	// Drop a hook file that contains the silent-drain antipattern.

--- a/internal/cli/presence_scan.go
+++ b/internal/cli/presence_scan.go
@@ -17,8 +17,8 @@ import (
 // matching live registration. It is the operator answer to "who is running here
 // but never enrolled?" — the read-only slice of the presence daemon (WI-E4).
 type UnenrolledProcess struct {
-	Kind       string // herdr | tmux | runner-socket | process
-	Hint       string // identity hint (herdr name / tmux pane / agent id / pid)
+	Kind       string // herdr | runner-socket | process
+	Hint       string // identity hint (herdr name / agent id / pid)
 	Cwd        string // the process working dir that mapped to this pool
 	Suggestion string // how to enroll it
 }
@@ -151,14 +151,14 @@ func defaultProcessParentPID(pid int) int {
 const presenceProbeTimeout = 500 * time.Millisecond
 
 // scanUnenrolledWrappers enumerates wrapper presences on this host (herdr
-// agents, tmux panes, runner sockets, raw wrapper processes) whose working dir
+// agents, runner sockets, raw wrapper processes) whose working dir
 // maps — via loop.Discover, by cwd alone — to THIS pool's control repo and that
 // have NO matching live registration, returning one UnenrolledProcess per hit.
 //
 // It is STRICTLY READ-ONLY: it reads registrations + per-agent local state and
 // enumerates host state, but never creates or repairs a registration (that is
 // WI-E4's job). The only error it returns is a failure to read the agents
-// directory; every enumerator error is swallowed so a missing herdr/tmux/ps
+// directory; every enumerator error is swallowed so a missing herdr/ps
 // degrades to "that source reported nothing."
 func scanUnenrolledWrappers(cfg *loop.Config) ([]UnenrolledProcess, error) {
 	if cfg == nil {
@@ -170,11 +170,11 @@ func scanUnenrolledWrappers(cfg *loop.Config) ([]UnenrolledProcess, error) {
 		return nil, err
 	}
 
-	// Pull-only (Gate 6c): registrations carry no wake target, so a herdr/tmux
+	// Pull-only (Gate 6c): registrations carry no wake target, so a herdr
 	// presence can no longer be matched to a registration BY wake target. herdr
 	// agents map to an enrolled lane only when the bound name is itself a
-	// registered agent id; tmux panes have no registration link at all, so an
-	// in-pool pane always surfaces as present-but-not-enrolled.
+	// registered agent id. tmux panes have no registration link, so they are not
+	// an actionable unenrolled-presence source.
 	agentIDs := map[string]bool{}
 	enrolledPIDs := map[int]bool{}
 	for id := range regs {
@@ -217,25 +217,6 @@ func scanUnenrolledWrappers(cfg *loop.Config) ([]UnenrolledProcess, error) {
 			Hint:       name,
 			Cwd:        p.Cwd,
 			Suggestion: fmt.Sprintf("herdr agent %q is in this pool but not enrolled; relaunch via the `ac` dispatcher (`ac serve <wrapper>`) or run `agentchute boot --as %s`", name, name),
-		})
-	}
-
-	// tmux panes: detected by enumerating panes and their cwds (`tmux list-panes`).
-	// A pane id has no registration link, so every in-pool pane surfaces as
-	// present-but-not-enrolled.
-	for _, p := range listTmuxSafe() {
-		pane := strings.TrimSpace(p.PaneID)
-		if pane == "" {
-			continue
-		}
-		if !cwdMapsToPool(cfg, p.Cwd) {
-			continue
-		}
-		out = append(out, UnenrolledProcess{
-			Kind:       "tmux",
-			Hint:       pane,
-			Cwd:        p.Cwd,
-			Suggestion: fmt.Sprintf("tmux pane %s is in this pool but not enrolled; relaunch via the `ac` dispatcher (`ac serve <wrapper>`) or run `agentchute boot --as <id>`", pane),
 		})
 	}
 

--- a/internal/cli/presence_scan.go
+++ b/internal/cli/presence_scan.go
@@ -332,14 +332,6 @@ func listHerdrSafe() (r []herdrPresenceEntry) {
 	return
 }
 
-func listTmuxSafe() (r []tmuxPresenceEntry) {
-	defer func() { _ = recover() }()
-	if listTmuxPanes != nil {
-		r = listTmuxPanes()
-	}
-	return
-}
-
 func listRunnerSafe(cfg *loop.Config) (r []runnerPresenceEntry) {
 	defer func() { _ = recover() }()
 	if listRunnerSockets != nil {

--- a/internal/cli/presence_scan_test.go
+++ b/internal/cli/presence_scan_test.go
@@ -43,7 +43,7 @@ func presencePoolCfg(t *testing.T) (*loop.Config, string) {
 	return cfg, root
 }
 
-func TestScanUnenrolledWrappers_FindsUnregisteredPaneInPool(t *testing.T) {
+func TestScanUnenrolledWrappers_IgnoresTmuxPanes(t *testing.T) {
 	cfg, root := presencePoolCfg(t)
 
 	// A plain registration for codex (pull-only: it carries no tmux wake target).
@@ -70,21 +70,11 @@ func TestScanUnenrolledWrappers_FindsUnregisteredPaneInPool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("scanUnenrolledWrappers: %v", err)
 	}
-	// Pull-only (Gate 6c): registrations carry no tmux wake target, so a tmux pane
-	// can no longer be matched to a registration — BOTH in-pool panes surface as
-	// present-but-not-enrolled.
-	if len(got) != 2 {
-		t.Fatalf("want 2 unenrolled tmux panes, got %d: %+v", len(got), got)
-	}
-	panes := map[string]bool{}
-	for _, p := range got {
-		if p.Kind != "tmux" || p.Suggestion == "" {
-			t.Fatalf("unexpected entry: %+v", p)
-		}
-		panes[p.Hint] = true
-	}
-	if !panes["%1"] || !panes["%2"] {
-		t.Fatalf("expected panes %%1 and %%2, got %+v", got)
+	// Pull-only registrations carry no tmux wake target, and a pane id has no
+	// registration link. In-pool tmux panes are therefore not actionable
+	// unenrolled-presence evidence.
+	if len(got) != 0 {
+		t.Fatalf("tmux panes must not surface as unenrolled presence; got %+v", got)
 	}
 }
 
@@ -169,8 +159,8 @@ func TestScanUnenrolledWrappers_IgnoresOutOfPoolCwd(t *testing.T) {
 	outOfPool := t.TempDir() // no AGENTCHUTE.md -> Discover fails -> not in pool
 
 	stubPresenceListers(t)
-	listTmuxPanes = func() []tmuxPresenceEntry {
-		return []tmuxPresenceEntry{{PaneID: "%7", Cwd: outOfPool}}
+	listProcesses = func() []processPresenceEntry {
+		return []processPresenceEntry{{PID: 99, Command: "codex", Cwd: outOfPool}}
 	}
 
 	got, err := scanUnenrolledWrappers(cfg)
@@ -465,6 +455,20 @@ func TestDoctor_UnenrolledPresenceWarnsNeverBlocks(t *testing.T) {
 	}
 	if got.Severity != severityWarn {
 		t.Fatalf("severity = %q, want WARN (presence is advisory, never a blocker)", got.Severity)
+	}
+}
+
+func TestDoctor_UnenrolledPresenceIgnoresTmuxPanes(t *testing.T) {
+	cfg, root := presencePoolCfg(t)
+
+	stubPresenceListers(t)
+	listTmuxPanes = func() []tmuxPresenceEntry {
+		return []tmuxPresenceEntry{{PaneID: "%1", Cwd: root}}
+	}
+
+	got := checkUnenrolledPresence(cfg)
+	if got.Severity != severityOK {
+		t.Fatalf("severity = %q, want OK for tmux-only presence; message=%q", got.Severity, got.Message)
 	}
 }
 


### PR DESCRIPTION
PR — doctor bundle (M1 + M2). Authored by codex (pushed by claude as integrator; codex was push-blocked by the inbox-task safety rule).

**M1 — `spec_freshness` check:** compares on-disk `AGENTCHUTE.md` against the binary's `embeddedSpecContent` via `bytes.Equal`; WARN with short sha256 of each side on mismatch ("re-run `init`/`setup` or update your checkout"); skips cleanly when `embeddedSpecContent==""` (sonnet's guard, mirrors other pre-setup skips); WARN (not crash) on unreadable spec. Prevents tonight's stale-spec split-brain — detects it, doesn't compare a version token (which would false-WARN every patch).

**M2 — drop tmux panes as an `unenrolled_presence` source:** pull-only (Gate 6c) removed the pane→registration correlation, so every in-pool pane was a false WARN (incl. plain shells/editors). codex chose option (a) drop; herdr, runner-socket, and raw-process signals remain. Net −33 lines.

Verification: gofmt/vet/build; `go test ./...` + `-race`; conformance; crown-jewel `TestPromptInjectionBytes*` + drift `TestTemplatesMatchRepoWrappers` green. Doctor + presence tests updated.

Gates: claude + sonnet (codex authored).