### PR TITLE
fix: v0.10.2-review fixes — remove ghost priority field, fix spec_freshness wording, pin filename-identity test

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -117,7 +117,6 @@ func cmdBoot(args []string) error {
 			Timestamp: msg.Timestamp.UTC().Format(time.RFC3339Nano),
 		}
 		if fm, _, ferr := readFrontmatter(msg.Path); ferr == nil {
-			entry.Priority = fm["priority"]
 			if v := strings.ToLower(strings.TrimSpace(fm["reply_required"])); v == "true" {
 				entry.ReplyRequired = true
 			}

--- a/internal/cli/consume_boundary_test.go
+++ b/internal/cli/consume_boundary_test.go
@@ -347,3 +347,87 @@ func TestOwedFlip_ThirdPartyReplyDoesNotClear(t *testing.T) {
 		t.Fatalf("alice .owed has %d entries after bob's reply; want 0", n)
 	}
 }
+
+// TestOwedFlip_UsesFilenameSenderNotFrontmatter pins the exact refactor
+// hazard the N1 fix's safety rests on: the discharge guard at check.go:259
+// must key off msg.Sender (filename-derived, validated by seqFilenameRE) and
+// never off the body frontmatter's `from:` field (unvalidated free text). A
+// hand-crafted message can disagree between the two -- `cmdSend` cannot
+// produce such a message (ComposeMessage always keeps them in sync), so both
+// variants are hand-planted directly, bypassing send.
+func TestOwedFlip_UsesFilenameSenderNotFrontmatter(t *testing.T) {
+	root, cfg := setupConsumeFixture(t)
+	withCwd(t, root, func() {
+		if err := cmdRegister([]string{"--as", "carol", "--vendor", "google", "--host", "third-host"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// alice asks bob; alice is owed a reply specifically by bob.
+	arm := func() loop.MsgID {
+		withCwd(t, root, func() {
+			if err := cmdSend([]string{"--from", "alice", "--to", "bob",
+				"--ask", "--body", "please review"}); err != nil {
+				t.Fatal(err)
+			}
+		})
+		owed, err := loop.LoadOwedLedger(cfg, "alice")
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := owed.OutstandingOwed()
+		if len(out) != 1 {
+			t.Fatalf("alice .owed has %d entries after --ask; want 1", len(out))
+		}
+		return out[0].Key()
+	}
+
+	// Variant 1: filename says bob (the true owing agent); frontmatter
+	// falsely claims carol. Discharge trusts the FILENAME, so this MUST
+	// clear -- proving fm["from"] is never consulted by the guard.
+	key1 := arm()
+	withCwd(t, root, func() {
+		body := "---\nfrom: carol\nin_reply_to: " + key1.RefString() + "\n---\n\nspoofed-frontmatter-real-bob-filename\n"
+		mustWriteSeqInbox(t, cfg.AgentInboxDir("alice"), "bob", 1, []byte(body))
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := captureStdout(t, func() error { return cmdAck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+	})
+	owed, err := loop.LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := len(owed.OutstandingOwed()); n != 0 {
+		t.Fatalf("variant 1 (filename=bob, frontmatter from=carol) did not clear; alice .owed has %d entries, want 0 -- filename identity must win", n)
+	}
+
+	// Variant 2: filename says carol (NOT the owing agent); frontmatter
+	// falsely claims bob. Discharge must NOT clear -- proving a forged
+	// frontmatter from: cannot impersonate the filename identity. This is
+	// the exact hazard: switching the guard to fm["from"] would flip this.
+	key2 := arm()
+	withCwd(t, root, func() {
+		body := "---\nfrom: bob\nin_reply_to: " + key2.RefString() + "\n---\n\nreal-carol-filename-spoofed-frontmatter\n"
+		mustWriteSeqInbox(t, cfg.AgentInboxDir("alice"), "carol", 1, []byte(body))
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := captureStdout(t, func() error { return cmdAck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+	})
+	owed, err = loop.LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := owed.OutstandingOwed()
+	if len(out) != 1 {
+		t.Fatalf("variant 2 (filename=carol, frontmatter from=bob) incorrectly cleared; alice .owed has %d entries, want 1", len(out))
+	}
+	if got := out[0].Key(); !got.Equal(key2) {
+		t.Fatalf("remaining owed key after variant 2 = %+v; want %+v", got, key2)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -243,7 +243,7 @@ func checkSpecFreshness(cfg *loop.Config) doctorCheck {
 	return doctorCheck{
 		Name:     name,
 		Severity: severityWarn,
-		Message: fmt.Sprintf("AGENTCHUTE.md differs from this binary's embedded spec (disk sha256=%s, embedded sha256=%s); re-run `agentchute init`/`setup` or update your checkout",
+		Message: fmt.Sprintf("AGENTCHUTE.md differs from this binary's embedded spec (disk sha256=%s, embedded sha256=%s); if the disk copy is stale, update your checkout; if it is deliberately newer or locally edited, this is expected — update the binary instead (`agentchute update`)",
 			shortSHA256(onDisk), shortSHA256(embedded)),
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -145,10 +145,13 @@ func TestDoctorSpecFreshnessWarnsOnStaleSpec(t *testing.T) {
 	if got.Severity != severityWarn {
 		t.Fatalf("spec_freshness severity = %q, want WARN; message=%q", got.Severity, got.Message)
 	}
-	for _, want := range []string{"differs from this binary's embedded spec", "disk sha256=", "embedded sha256=", "agentchute init"} {
+	for _, want := range []string{"differs from this binary's embedded spec", "disk sha256=", "embedded sha256=", "update your checkout", "agentchute update"} {
 		if !strings.Contains(got.Message, want) {
 			t.Fatalf("spec_freshness message missing %q: %q", want, got.Message)
 		}
+	}
+	if strings.Contains(got.Message, "agentchute init") {
+		t.Fatalf("spec_freshness message still recommends `agentchute init`, which never fixes divergence (init.go skip-if-present): %q", got.Message)
 	}
 }
 

--- a/internal/cli/n3_sanitize_test.go
+++ b/internal/cli/n3_sanitize_test.go
@@ -62,45 +62,8 @@ func TestCheckSanitizesControlBytesInConsumedBody(t *testing.T) {
 	}
 }
 
-// TestPendingTextSanitizesPriorityControlBytes covers the secondary N3
-// exposure (codex's gate-review catch): pending's text-mode `[priority:...]`
-// flag prints e.Priority raw, and e.Priority is sourced from the UNVALIDATED
-// frontmatter peek path (readFrontmatter -> loop.ParseMessageFrontmatter,
-// with no loop.ValidateMessageFrontmatter gate in front of it, unlike
-// check.go's consume path) — so a sender-controlled `priority:` value can
-// carry ANSI/OSC/C0 bytes straight into `agentchute pending`'s text output.
-// e.From/e.Timestamp are filename-derived (constrained by the seq-filename
-// regex) and intentionally NOT covered here.
-func TestPendingTextSanitizesPriorityControlBytes(t *testing.T) {
-	root, cfg := setupSendFixture(t)
-	inbox := cfg.AgentInboxDir("claude-code")
-
-	evilPriority := "\x1b[31murgent\x1b[0m\x9b"
-	body := "---\n" +
-		"from: codex\n" +
-		"to: claude-code\n" +
-		"priority: " + evilPriority + "\n" +
-		"---\n\nbody\n"
-	mustWriteSeqInbox(t, inbox, "codex", 1, []byte(body))
-
-	withCwd(t, root, func() {
-		out, err := captureStdout(t, func() error { return cmdPending(pendingArgs()) })
-		if err != nil {
-			t.Fatal(err)
-		}
-		for _, bad := range []string{"\x1b", "\x9b"} {
-			if strings.Contains(out, bad) {
-				t.Fatalf("pending text output still contains raw control byte %q; got:\n%q", bad, out)
-			}
-		}
-		if !strings.Contains(out, "urgent") {
-			t.Fatalf("sanitization dropped legitimate priority text; got:\n%q", out)
-		}
-	})
-}
-
 // TestSanitizeControlBytes pins the exact keep/drop boundary of the helper
-// underlying both tests above: \n and \t are the only control code points
+// underlying the test above: \n and \t are the only control code points
 // kept; all other C0, DEL, and C1 code points are dropped; ordinary text
 // (including multi-byte UTF-8 and invalid UTF-8) passes through unchanged
 // or degrades safely.

--- a/internal/cli/pending.go
+++ b/internal/cli/pending.go
@@ -124,11 +124,10 @@ func cmdPending(args []string) error {
 			Filename:  msg.Filename,
 			Timestamp: msg.Timestamp.UTC().Format(time.RFC3339Nano),
 		}
-		// Parse frontmatter for reply_required / priority.
+		// Parse frontmatter for reply_required.
 		// Body intentionally not read unless --show-body.
 		fm, body, ferr := readFrontmatter(msg.Path)
 		if ferr == nil {
-			entry.Priority = fm["priority"]
 			if v := strings.ToLower(strings.TrimSpace(fm["reply_required"])); v == "true" {
 				entry.ReplyRequired = true
 			}
@@ -184,7 +183,6 @@ type pendingEntry struct {
 	From          string `json:"from"`
 	Filename      string `json:"filename"`
 	Timestamp     string `json:"timestamp"`
-	Priority      string `json:"priority,omitempty"`
 	ReplyRequired bool   `json:"reply_required,omitempty"`
 	Stale         bool   `json:"stale,omitempty"`
 	Body          string `json:"body,omitempty"`
@@ -215,13 +213,6 @@ func emitPendingText(entries []pendingEntry, owed []loop.OwedEntry, malformed in
 			flags := ""
 			if e.ReplyRequired {
 				flags += " [REPLY-REQUIRED]"
-			}
-			if e.Priority != "" && e.Priority != "normal" {
-				// e.Priority is sourced from the unvalidated frontmatter peek
-				// path (readFrontmatter), so it must be sanitized before
-				// reaching a raw terminal here (N3, deep-analysis-v2) — see
-				// sanitizeControlBytes in check.go.
-				flags += " [priority:" + sanitizeControlBytes(e.Priority) + "]"
 			}
 			if e.Stale {
 				flags += " [stale]"


### PR DESCRIPTION
## Summary
Three small fixes from the v0.10.2 code review (B1 + C1 + P2-test), all review-only findings, no wire/behavior additions.

- **B1 — delete the ghost `priority` field.** It was read (`pending.go`, `boot.go`) and rendered (`pending.go`) but had no producer anywhere (`send.go`/`message.go`) and is absent from `AGENTCHUTE.md` §6.4 — spec drift in the opposite direction from the task/status cleanup (removed from spec, but the reader survived). Deletes `pendingEntry.Priority`, both reads, and the render branch. Also deletes `TestPendingTextSanitizesPriorityControlBytes` outright — after removal, `pending`'s text output renders zero frontmatter-derived strings, so there's no replacement attack surface for that test to cover. N3's real security coverage (`check.go`'s body-sanitize path) is untouched.
- **C1 — fix misleading `spec_freshness` WARN wording.** The message recommended `agentchute init`/`setup`, but that never fixes divergence (`init.go`'s `planSpecFile` is skip-if-present) — and for a maintainer intentionally editing the spec locally, it read as a threat to their edit even though re-running init/setup is actually a safe no-op. Reworded to name both divergence directions and point at the real remedy (`agentchute update` for a stale binary).
- **P2-test — pin the filename-vs-frontmatter-identity assumption N1 rests on.** `TestOwedFlip_UsesFilenameSenderNotFrontmatter` hand-plants two variants (filename=bob/frontmatter-from=carol, and the inverse) proving the discharge guard keys off `msg.Sender` (filename-derived) and never `fm["from"]` (unvalidated). Verified the test actually catches the hazard by temporarily flipping the guard to `fm["from"]` and confirming it fails, then reverting.

## Test plan
- [x] B1: grepped the whole repo post-removal — zero remaining references to `Priority`/`priority` in production or test code. `go build` clean.
- [x] C1: TDD — updated `doctor_test.go`'s pinned substrings first (confirmed RED against the old wording), then reworded the message (GREEN). New assertion also confirms `agentchute init` is no longer recommended.
- [x] P2-test: confirmed the test passes against current code, then **deliberately broke it** (swapped the guard to `fm["from"] == key.To`) to prove it actually catches the refactor hazard — failed exactly as expected on variant 1, then reverted and confirmed green again.
- [x] `gofmt -l .` / `go vet ./...` / `go build ./...` — clean.
- [x] `go test ./...` — full suite green.
- [x] `go test -race ./...` — race-clean.
- [x] `conformance` module — green.
- [x] Crown jewels (`TestPromptInjectionBytes*`) + drift (`TestTemplatesMatchRepoWrappers`) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)