### PR TITLE
v0.11.0: conformance rename off spike + language-neutral vectors + disposable Python proof (N6b)

### DIFF
--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -1,11 +1,16 @@
-# Conformance harness + shared-log spike
+# Conformance harness + shared-log model
 
-Two deliverables in one package, both runnable:
+Four deliverables in one package:
 
-1. **A conformance harness** — the protocol's invariants as a Go test suite,
-   run against **two bindings** so any substrate is checked on equal footing.
-2. **The shared-log model** (`log_binding.go`) — the §5 fork as ~90 lines of
+1. **Language-neutral vectors** — JSON scenarios under `vectors/` defining the
+   protocol's invariant cases without depending on Go.
+2. **A conformance harness** — the vectors run as a Go test suite against **two
+   bindings** so any substrate is checked on equal footing.
+3. **The shared-log model** (`log_binding.go`) — the §5 fork as ~90 lines of
    working code, exercised by the same suite and demo as the inbox model.
+4. **A disposable Python proof** — `example-python-binding/runner.py` reads the
+   same vectors against a stdlib-only inbox binding. It is a snapshot, not a
+   maintained SDK or release gate.
 
 Pure stdlib, no dependencies.
 
@@ -15,17 +20,19 @@ Pure stdlib, no dependencies.
 go test -v ./...            # the invariant suite, against BOTH models
 go run ./cmd/acdemo inbox   # narrated handoff on the N-inboxes model
 go run ./cmd/acdemo log     # same handoff on the shared-log model
+python3 example-python-binding/runner.py  # optional, disposable proof
 ```
 
 ## Why a harness (not just tests)
 
 The §4 reframe says: **the invariants are the protocol; the substrate is a
-binding.** This makes that real. The suite drives only the abstract `Binding`
+binding.** This makes that real. The durable contract is the JSON vector set;
+the Go suite is one runner for it. The suite drives only the abstract `Binding`
 interface, so the filesystem inbox model and the shared-log model pass the
-*identical* tests. A new substrate (git branch, Redis Stream, HTTP+ETag) becomes
-conformant by implementing `Binding` and being added to `bindings()` — then it
-inherits the whole suite. That is what "universal / multi-binding" has to mean
-to be more than a claim.
+*identical* vector cases. A new substrate (git branch, Redis Stream, HTTP+ETag)
+becomes conformant by implementing `Binding` and being added to `bindings()` —
+then it inherits the whole suite. That is what "universal / multi-binding" has
+to mean to be more than a claim.
 
 ## What each invariant proves (and the failure it catches)
 
@@ -43,6 +50,13 @@ to be more than a claim.
 load-bearing one: it injects a crash at the worst moment (after the handler
 acts, before the consume commits) and asserts re-delivery, then shows `msg_key`
 collapsing the duplicate.
+
+## Vector format
+
+`vectors/core.json` is intentionally boring: one object per invariant, with an
+`id`, a `kind`, and only the scenario data that a runner needs. It is not a DSL
+and it does not encode implementation details. Runners map each `kind` to the
+small amount of imperative behavior needed to exercise that invariant.
 
 Two further tests close the review gaps:
 - **`TestC1_SenderCrashResume`** — the *sender* half of C1. A sender links `seq=N`, crashes before its counter is durable, resumes and re-issues `seq=N`; `EEXIST` makes that a no-op (one copy) and the next message gets `N+1`. It also asserts the **§7 hazard**: reusing a seq for *different* content is silently dropped — making "seq counter must be durable+monotonic, ids unique per process" executable. Most likely to catch a real bug when the per-`(from,to)` allocator is built.
@@ -81,8 +95,8 @@ and body privacy.
 Implement `Binding` (8 methods) + the two test-only hooks
 (`crashAfterActOnce`, `forceLastSeen`, `deliverSlow`), add a constructor to
 `bindings()`, and run `go test -v`. If it passes, your substrate is agentchute-
-conformant. A language-agnostic harness would drive these same operations over a
-substrate's real CLI/ACL boundary instead of a Go interface — same invariants.
+conformant. A language-agnostic harness can drive the same vector operations
+over a substrate's real CLI/ACL boundary instead of a Go interface.
 
 ## Scope
 

--- a/conformance/cmd/acdemo/main.go
+++ b/conformance/cmd/acdemo/main.go
@@ -1,8 +1,8 @@
 // acdemo runs a narrated handoff against a chosen MODEL so the §5 fork is
 // visible, not just argued:  go run ./cmd/acdemo inbox   |   go run ./cmd/acdemo log
 //
-// It exercises the protocol at the wire level (no PTY here — that's the serve
-// spike). The point is to SHOW the three places the two models differ:
+// It exercises the protocol at the wire level (no PTY here). The point is to
+// SHOW the three places the two models differ:
 //  1. cross-agent order  (advisory vs real)
 //  2. presence source    (.live file vs cursor advance)
 //  3. body privacy (B1)  (private vs shared)
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"os"
 
-	ac "agentchute.dev/spike/conformance"
+	ac "agentchute.dev/conformance"
 )
 
 func main() {

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -34,20 +34,21 @@ func must(t *testing.T, err error) {
 // "came back days later, one agent never returned" dead mailbox.
 // Catches: a binding that cannot tell a live agent from a long-gone one.
 func TestR1_Presence(t *testing.T) {
+	v := vectorByID(t, "R1", "presence_freshness")
 	eachBinding(t, func(t *testing.T, b Binding) {
-		if _, _, reg := b.Presence("x"); reg {
+		if _, _, reg := b.Presence(v.Agent); reg {
 			t.Fatal("an unregistered agent must not be registered/present")
 		}
-		must(t, b.Register("x"))
-		alive, _, reg := b.Presence("x")
+		must(t, b.Register(v.Agent))
+		alive, _, reg := b.Presence(v.Agent)
 		if !reg || !alive {
 			t.Fatal("a freshly registered agent must read alive")
 		}
 		// simulate a long-idle / dead agent
 		b.(interface {
 			forceLastSeen(string, time.Time)
-		}).forceLastSeen("x", time.Now().Add(-time.Hour))
-		alive, _, reg = b.Presence("x")
+		}).forceLastSeen(v.Agent, time.Now().Add(-time.Duration(v.StaleSeconds)*time.Second))
+		alive, _, reg = b.Presence(v.Agent)
 		if !reg || alive {
 			t.Fatal("a stale agent must read registered-but-not-alive (the dead mailbox)")
 		}
@@ -58,24 +59,25 @@ func TestR1_Presence(t *testing.T) {
 // invisible to a concurrent reader; after commit it is fully visible.
 // Catches: readers observing torn / half-written messages.
 func TestD1_AtomicVisibility(t *testing.T) {
+	v := vectorByID(t, "D1", "atomic_visibility")
 	eachBinding(t, func(t *testing.T, b Binding) {
-		must(t, b.Register("bob"))
+		must(t, b.Register(v.Recipient))
 		sd := b.(interface {
 			deliverSlow(string, Msg, chan<- struct{}, <-chan struct{}) error
 		})
 		staged := make(chan struct{})
 		commit := make(chan struct{})
 		done := make(chan struct{})
-		go func() { _ = sd.deliverSlow("bob", Msg{From: "alice", Body: "hello"}, staged, commit); close(done) }()
+		go func() { _ = sd.deliverSlow(v.Recipient, v.Message.msg(), staged, commit); close(done) }()
 
 		<-staged // delivery is in-flight but not committed
-		if got, _ := b.Poll("bob"); len(got) != 0 {
+		if got, _ := b.Poll(v.Recipient); len(got) != 0 {
 			t.Fatalf("a staged-but-uncommitted message must be invisible; saw %d", len(got))
 		}
 		close(commit)
 		<-done
-		got, _ := b.Poll("bob")
-		if len(got) != 1 || got[0].Body != "hello" {
+		got, _ := b.Poll(v.Recipient)
+		if len(got) != 1 || got[0].Body != v.Message.Body {
 			t.Fatalf("after commit, exactly the whole message must be visible; got %+v", got)
 		}
 	})
@@ -85,20 +87,20 @@ func TestD1_AtomicVisibility(t *testing.T) {
 // is silently clobbered. (Inbox: ln-no-overwrite+retry. Log: unique append seq.)
 // Catches: dropped coordination messages under load.
 func TestD2_NoOverwrite(t *testing.T) {
+	v := vectorByID(t, "D2", "no_overwrite")
 	eachBinding(t, func(t *testing.T, b Binding) {
-		must(t, b.Register("bob"))
-		const N = 200
+		must(t, b.Register(v.Recipient))
 		var wg sync.WaitGroup
-		for i := 0; i < N; i++ {
+		for i := 0; i < v.Count; i++ {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				_ = b.Deliver("bob", Msg{From: fmt.Sprintf("s%d", i%5), Body: fmt.Sprintf("m%d", i)})
+				_ = b.Deliver(v.Recipient, Msg{From: v.senderFor(i), Body: fmt.Sprintf("%s%d", v.BodyPrefix, i)})
 			}(i)
 		}
 		wg.Wait()
-		if got, _ := b.Poll("bob"); len(got) != N {
-			t.Fatalf("want %d delivered, got %d (clobber / loss)", N, len(got))
+		if got, _ := b.Poll(v.Recipient); len(got) != v.Count {
+			t.Fatalf("want %d delivered, got %d (clobber / loss)", v.Count, len(got))
 		}
 	})
 }
@@ -108,17 +110,18 @@ func TestD2_NoOverwrite(t *testing.T) {
 // fiction the v2 deltas remove. Cross-sender order is arrival order, advisory.
 // Catches: a binding that reorders one sender's own messages.
 func TestO1_PerSenderFIFO(t *testing.T) {
+	v := vectorByID(t, "O1", "per_sender_fifo")
 	eachBinding(t, func(t *testing.T, b Binding) {
-		must(t, b.Register("bob"))
-		for i := 0; i < 10; i++ {
-			must(t, b.Deliver("bob", Msg{From: "alice", Body: fmt.Sprintf("a%d", i)}))
+		must(t, b.Register(v.Recipient))
+		for _, body := range v.Bodies {
+			must(t, b.Deliver(v.Recipient, Msg{From: v.Sender, Body: body}))
 		}
-		got, _ := b.Poll("bob")
-		if len(got) != 10 {
-			t.Fatalf("want 10, got %d", len(got))
+		got, _ := b.Poll(v.Recipient)
+		if len(got) != len(v.Bodies) {
+			t.Fatalf("want %d, got %d", len(v.Bodies), len(got))
 		}
-		for i := 0; i < 10; i++ {
-			if got[i].Body != fmt.Sprintf("a%d", i) {
+		for i, want := range v.Bodies {
+			if got[i].Body != want {
 				t.Fatalf("per-sender FIFO broken at %d: %q", i, got[i].Body)
 			}
 		}
@@ -130,9 +133,10 @@ func TestO1_PerSenderFIFO(t *testing.T) {
 // the duplicate on the receiver side.
 // Catches: at-most-once consume losing a coordination message on a crash.
 func TestC1_AtLeastOnceIdempotent(t *testing.T) {
+	v := vectorByID(t, "C1", "consume_redelivery")
 	eachBinding(t, func(t *testing.T, b Binding) {
-		must(t, b.Register("bob"))
-		must(t, b.Deliver("bob", Msg{From: "alice", Body: "do-it", Key: "k1"}))
+		must(t, b.Register(v.Recipient))
+		must(t, b.Deliver(v.Recipient, v.Message.msg()))
 
 		var acts []string
 		handler := func(m Msg) error { acts = append(acts, m.Body); return nil }
@@ -141,14 +145,14 @@ func TestC1_AtLeastOnceIdempotent(t *testing.T) {
 		b.(interface{ crashAfterActOnce() }).crashAfterActOnce()
 		func() {
 			defer func() { _ = recover() }() // absorb the simulated crash
-			_, _ = b.Consume("bob", handler)
+			_, _ = b.Consume(v.Recipient, handler)
 		}()
 		if len(acts) != 1 {
 			t.Fatalf("handler must have acted once before the crash; got %d", len(acts))
 		}
 
 		// retry: commit never happened, so the message must re-deliver
-		n, _ := b.Consume("bob", handler)
+		n, _ := b.Consume(v.Recipient, handler)
 		if n != 1 || len(acts) != 2 {
 			t.Fatalf("at-least-once: message must re-deliver after crash; acts=%d n=%d", len(acts), n)
 		}
@@ -156,8 +160,8 @@ func TestC1_AtLeastOnceIdempotent(t *testing.T) {
 		// receiver-side idempotency aid: msg_key collapses the duplicate effect
 		d := NewDeduper()
 		effects := 0
-		for range acts { // both carry Key k1
-			_ = d.Once(Msg{Key: "k1"}, func(Msg) error { effects++; return nil })
+		for range acts { // both carry the same Key
+			_ = d.Once(Msg{Key: v.Message.Key}, func(Msg) error { effects++; return nil })
 		}
 		if effects != 1 {
 			t.Fatalf("msg_key dedup must collapse re-delivery to one effect; got %d", effects)
@@ -169,16 +173,17 @@ func TestC1_AtLeastOnceIdempotent(t *testing.T) {
 // Catches: a future field silently breaking old receivers; an anonymous message
 // being accepted.
 func TestE1_Envelope(t *testing.T) {
+	v := vectorByID(t, "E1", "envelope")
 	eachBinding(t, func(t *testing.T, b Binding) {
-		must(t, b.Register("bob"))
+		must(t, b.Register(v.Recipient))
 		// unknown/future fields are carried but ignorable
-		must(t, b.Deliver("bob", Msg{From: "alice", Body: "hi", Extra: map[string]string{"future_field": "v"}}))
-		got, _ := b.Poll("bob")
-		if got[0].From != "alice" || got[0].Body != "hi" {
+		must(t, b.Deliver(v.Recipient, v.Message.msg()))
+		got, _ := b.Poll(v.Recipient)
+		if got[0].From != v.Message.From || got[0].Body != v.Message.Body {
 			t.Fatal("normative fields must survive alongside unknown fields")
 		}
 		// a normative field (From) is required
-		if err := b.Deliver("bob", Msg{Body: "no from"}); err == nil {
+		if err := b.Deliver(v.Recipient, v.InvalidMessage.msg()); err == nil {
 			t.Fatal("a message without From must be refused")
 		}
 	})
@@ -189,10 +194,11 @@ func TestE1_Envelope(t *testing.T) {
 // correct-for-its-model — results. This test never "fails" a model; it PRINTS
 // the privacy posture you are choosing. Run with -v to see the verdict.
 func TestB1_PrivacyFork(t *testing.T) {
+	v := vectorByID(t, "B1", "body_privacy")
 	eachBinding(t, func(t *testing.T, b Binding) {
-		must(t, b.Register("bob"))
-		must(t, b.Deliver("bob", Msg{From: "alice", Body: "secret for bob"}))
-		peerSees := b.PeekBodies("bob", "carol")
+		must(t, b.Register(v.Recipient))
+		must(t, b.Deliver(v.Recipient, v.Message.msg()))
+		peerSees := b.PeekBodies(v.Recipient, v.Reader)
 
 		if b.PrivateBodies() {
 			if len(peerSees) != 0 {

--- a/conformance/example-python-binding/README.md
+++ b/conformance/example-python-binding/README.md
@@ -1,0 +1,13 @@
+# Disposable Python Conformance Proof
+
+This is a point-in-time proof that the JSON vectors in `../vectors/` are
+language-neutral. It is not a maintained Python SDK or a release gate.
+
+Run manually:
+
+```sh
+python3 runner.py
+```
+
+The script uses Python stdlib only and implements the private-inbox binding
+against the same vectors the Go conformance suite embeds.

--- a/conformance/example-python-binding/runner.py
+++ b/conformance/example-python-binding/runner.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Disposable stdlib-only proof for the agentchute conformance vectors.
+
+This is intentionally small and not wired into CI. The vectors are the durable
+contract; this file only proves they can drive a non-Go implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+VECTORS = ROOT / "vectors" / "core.json"
+
+
+@dataclass
+class Msg:
+    from_id: str = ""
+    body: str = ""
+    reply_required: bool = False
+    in_reply_to: str = ""
+    key: str = ""
+    extra: dict[str, str] = field(default_factory=dict)
+    seq: int = 0
+
+
+class InboxBinding:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._inbox: dict[str, list[Msg]] = {}
+        self._seen: dict[str, float] = {}
+        self._delivered: set[tuple[str, str, int]] = set()
+        self._crash_after_act = False
+        self.window = 30.0
+
+    def register(self, agent: str) -> None:
+        with self._lock:
+            self._inbox.setdefault(agent, [])
+            self._seen[agent] = time.time()
+
+    def presence(self, agent: str) -> tuple[bool, bool]:
+        with self._lock:
+            if agent not in self._seen:
+                return False, False
+            return time.time() - self._seen[agent] < self.window, True
+
+    def force_last_seen(self, agent: str, seconds_ago: int) -> None:
+        with self._lock:
+            self._seen[agent] = time.time() - seconds_ago
+
+    def deliver(self, to: str, msg: Msg) -> None:
+        if not msg.from_id:
+            raise ValueError("E1: message has no from")
+        with self._lock:
+            if to not in self._inbox:
+                raise ValueError(f"unknown recipient {to!r}")
+            if msg.seq:
+                key = (to, msg.from_id, msg.seq)
+                if key in self._delivered:
+                    return
+                self._delivered.add(key)
+            self._inbox[to].append(msg)
+
+    def stage_delivery(self, to: str, msg: Msg) -> callable:
+        if not msg.from_id:
+            raise ValueError("E1: message has no from")
+        with self._lock:
+            if to not in self._inbox:
+                raise ValueError(f"unknown recipient {to!r}")
+
+        def commit() -> None:
+            self.deliver(to, msg)
+
+        return commit
+
+    def poll(self, agent: str) -> list[Msg]:
+        with self._lock:
+            return list(self._inbox.get(agent, []))
+
+    def crash_after_act_once(self) -> None:
+        self._crash_after_act = True
+
+    def consume(self, agent: str, handler: callable) -> int:
+        count = 0
+        for msg in self.poll(agent):
+            handler(msg)
+            if self._crash_after_act:
+                self._crash_after_act = False
+                raise RuntimeError("simulated crash after act")
+            with self._lock:
+                if self._inbox.get(agent):
+                    removed = self._inbox[agent].pop(0)
+                    if removed.seq:
+                        self._delivered.discard((agent, removed.from_id, removed.seq))
+                self._seen[agent] = time.time()
+            count += 1
+        return count
+
+    def private_bodies(self) -> bool:
+        return True
+
+    def peek_bodies(self, owner: str, reader: str) -> list[str]:
+        if owner != reader:
+            return []
+        return [m.body for m in self.poll(owner)]
+
+
+class Deduper:
+    def __init__(self) -> None:
+        self.seen: set[str] = set()
+
+    def once(self, msg: Msg, fn: callable) -> None:
+        if msg.key and msg.key in self.seen:
+            return
+        fn(msg)
+        if msg.key:
+            self.seen.add(msg.key)
+
+
+def msg(data: dict) -> Msg:
+    return Msg(
+        from_id=data.get("from", ""),
+        body=data.get("body", ""),
+        reply_required=data.get("reply_required", False),
+        in_reply_to=data.get("in_reply_to", ""),
+        key=data.get("key", ""),
+        extra=data.get("extra", {}),
+        seq=data.get("seq", 0),
+    )
+
+
+def load_vectors() -> dict[str, dict]:
+    data = json.loads(VECTORS.read_text())
+    if data.get("schema") != "agentchute-conformance-vectors-v1":
+        raise AssertionError(f"unexpected schema {data.get('schema')!r}")
+    vectors = {v["id"]: v for v in data["vectors"]}
+    for required in ("R1", "D1", "D2", "O1", "C1", "E1", "B1"):
+        if required not in vectors:
+            raise AssertionError(f"missing vector {required}")
+    return vectors
+
+
+def run_r1(v: dict) -> None:
+    b = InboxBinding()
+    assert b.presence(v["agent"]) == (False, False)
+    b.register(v["agent"])
+    assert b.presence(v["agent"]) == (True, True)
+    b.force_last_seen(v["agent"], v["stale_seconds"])
+    assert b.presence(v["agent"]) == (False, True)
+
+
+def run_d1(v: dict) -> None:
+    b = InboxBinding()
+    b.register(v["recipient"])
+    commit = b.stage_delivery(v["recipient"], msg(v["message"]))
+    assert b.poll(v["recipient"]) == []
+    commit()
+    got = b.poll(v["recipient"])
+    assert len(got) == 1 and got[0].body == v["message"]["body"]
+
+
+def run_d2(v: dict) -> None:
+    b = InboxBinding()
+    b.register(v["recipient"])
+
+    def sender(i: int) -> None:
+        from_id = f"{v['sender_prefix']}{i % v['sender_modulo']}"
+        b.deliver(v["recipient"], Msg(from_id=from_id, body=f"{v['body_prefix']}{i}"))
+
+    threads = [threading.Thread(target=sender, args=(i,)) for i in range(v["count"])]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(b.poll(v["recipient"])) == v["count"]
+
+
+def run_o1(v: dict) -> None:
+    b = InboxBinding()
+    b.register(v["recipient"])
+    for body in v["bodies"]:
+        b.deliver(v["recipient"], Msg(from_id=v["sender"], body=body))
+    assert [m.body for m in b.poll(v["recipient"])] == v["bodies"]
+
+
+def run_c1(v: dict) -> None:
+    b = InboxBinding()
+    b.register(v["recipient"])
+    b.deliver(v["recipient"], msg(v["message"]))
+    acts: list[str] = []
+
+    def act(m: Msg) -> None:
+        acts.append(m.body)
+
+    b.crash_after_act_once()
+    try:
+        b.consume(v["recipient"], act)
+    except RuntimeError:
+        pass
+    assert acts == [v["message"]["body"]]
+    assert b.consume(v["recipient"], act) == 1
+    assert acts == [v["message"]["body"], v["message"]["body"]]
+    deduper = Deduper()
+    effects = 0
+
+    def effect(_: Msg) -> None:
+        nonlocal effects
+        effects += 1
+
+    for _ in acts:
+        deduper.once(Msg(key=v["message"]["key"]), effect)
+    assert effects == 1
+
+
+def run_e1(v: dict) -> None:
+    b = InboxBinding()
+    b.register(v["recipient"])
+    b.deliver(v["recipient"], msg(v["message"]))
+    got = b.poll(v["recipient"])[0]
+    assert got.from_id == v["message"]["from"] and got.body == v["message"]["body"]
+    try:
+        b.deliver(v["recipient"], msg(v["invalid_message"]))
+    except ValueError:
+        return
+    raise AssertionError("message without from must be refused")
+
+
+def run_b1(v: dict) -> None:
+    b = InboxBinding()
+    b.register(v["recipient"])
+    b.deliver(v["recipient"], msg(v["message"]))
+    assert b.private_bodies()
+    assert b.peek_bodies(v["recipient"], v["reader"]) == []
+
+
+RUNNERS = {
+    "presence_freshness": run_r1,
+    "atomic_visibility": run_d1,
+    "no_overwrite": run_d2,
+    "per_sender_fifo": run_o1,
+    "consume_redelivery": run_c1,
+    "envelope": run_e1,
+    "body_privacy": run_b1,
+}
+
+
+def main() -> int:
+    for vector in load_vectors().values():
+        RUNNERS[vector["kind"]](vector)
+        print(f"ok {vector['id']} {vector['kind']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/go.mod
+++ b/conformance/go.mod
@@ -1,3 +1,3 @@
-module agentchute.dev/spike/conformance
+module agentchute.dev/conformance
 
 go 1.21

--- a/conformance/log_binding.go
+++ b/conformance/log_binding.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// logBinding = the SHARED APPEND-ONLY LOG model (the §5 fork), as a spike.
+// logBinding = the SHARED APPEND-ONLY LOG model (the §5 fork), as a model.
 //
 //	┌──────────────────────────── one ordered stream ───────────────────────────┐
 //	│ seq0 to=bob   seq1 to=alice  seq2 to=bob  seq3 to=carol  seq4 to=bob ...    │
@@ -28,7 +28,7 @@ import (
 // What it COSTS (also shown):
 //   - B1 is VOID — every agent can read every record. No private bodies.
 //
-// This is the whole spike the team asked for, in ~90 lines. The decision is:
+// This is the whole alternate model the team asked for, in ~90 lines. The decision is:
 // is inter-agent privacy a real requirement for your pools? If not, this model
 // is simpler AND more robust than N inboxes, and deletes the ordering fiction
 // and the separate presence primitive in one move.

--- a/conformance/vectors/core.json
+++ b/conformance/vectors/core.json
@@ -1,0 +1,60 @@
+{
+  "schema": "agentchute-conformance-vectors-v1",
+  "vectors": [
+    {
+      "id": "R1",
+      "kind": "presence_freshness",
+      "name": "presence is registered, fresh, and expires when stale",
+      "agent": "x",
+      "stale_seconds": 3600
+    },
+    {
+      "id": "D1",
+      "kind": "atomic_visibility",
+      "name": "staged delivery is invisible until committed",
+      "recipient": "bob",
+      "message": {"from": "alice", "body": "hello"}
+    },
+    {
+      "id": "D2",
+      "kind": "no_overwrite",
+      "name": "concurrent deliveries all survive",
+      "recipient": "bob",
+      "count": 200,
+      "sender_prefix": "s",
+      "sender_modulo": 5,
+      "body_prefix": "m"
+    },
+    {
+      "id": "O1",
+      "kind": "per_sender_fifo",
+      "name": "one sender's order is preserved",
+      "recipient": "bob",
+      "sender": "alice",
+      "bodies": ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"]
+    },
+    {
+      "id": "C1",
+      "kind": "consume_redelivery",
+      "name": "crash after act redelivers and idempotency key dedups",
+      "recipient": "bob",
+      "message": {"from": "alice", "body": "do-it", "key": "k1"}
+    },
+    {
+      "id": "E1",
+      "kind": "envelope",
+      "name": "unknown fields are ignored and from is required",
+      "recipient": "bob",
+      "message": {"from": "alice", "body": "hi", "extra": {"future_field": "v"}},
+      "invalid_message": {"body": "no from"}
+    },
+    {
+      "id": "B1",
+      "kind": "body_privacy",
+      "name": "binding declares whether peer reads are possible",
+      "recipient": "bob",
+      "reader": "carol",
+      "message": {"from": "alice", "body": "secret for bob"}
+    }
+  ]
+}

--- a/conformance/vectors_test.go
+++ b/conformance/vectors_test.go
@@ -1,0 +1,106 @@
+package conformance
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+//go:embed vectors/*.json
+var vectorFS embed.FS
+
+type vectorSet struct {
+	Schema  string       `json:"schema"`
+	Vectors []testVector `json:"vectors"`
+}
+
+type testVector struct {
+	ID             string    `json:"id"`
+	Kind           string    `json:"kind"`
+	Name           string    `json:"name"`
+	Agent          string    `json:"agent,omitempty"`
+	Recipient      string    `json:"recipient,omitempty"`
+	Reader         string    `json:"reader,omitempty"`
+	Sender         string    `json:"sender,omitempty"`
+	SenderPrefix   string    `json:"sender_prefix,omitempty"`
+	SenderModulo   int       `json:"sender_modulo,omitempty"`
+	BodyPrefix     string    `json:"body_prefix,omitempty"`
+	Count          int       `json:"count,omitempty"`
+	StaleSeconds   int       `json:"stale_seconds,omitempty"`
+	Bodies         []string  `json:"bodies,omitempty"`
+	Message        vectorMsg `json:"message,omitempty"`
+	InvalidMessage vectorMsg `json:"invalid_message,omitempty"`
+}
+
+type vectorMsg struct {
+	From          string            `json:"from,omitempty"`
+	Body          string            `json:"body,omitempty"`
+	ReplyRequired bool              `json:"reply_required,omitempty"`
+	InReplyTo     string            `json:"in_reply_to,omitempty"`
+	Key           string            `json:"key,omitempty"`
+	Extra         map[string]string `json:"extra,omitempty"`
+	Seq           uint64            `json:"seq,omitempty"`
+}
+
+func (m vectorMsg) msg() Msg {
+	return Msg{
+		From:          m.From,
+		Body:          m.Body,
+		ReplyRequired: m.ReplyRequired,
+		InReplyTo:     m.InReplyTo,
+		Key:           m.Key,
+		Extra:         m.Extra,
+		Seq:           m.Seq,
+	}
+}
+
+func loadVectors(t *testing.T) map[string]testVector {
+	t.Helper()
+	data, err := vectorFS.ReadFile("vectors/core.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var set vectorSet
+	if err := json.Unmarshal(data, &set); err != nil {
+		t.Fatal(err)
+	}
+	if set.Schema != "agentchute-conformance-vectors-v1" {
+		t.Fatalf("unexpected vector schema %q", set.Schema)
+	}
+	out := map[string]testVector{}
+	for _, v := range set.Vectors {
+		if v.ID == "" || v.Kind == "" {
+			t.Fatalf("invalid vector with missing id/kind: %+v", v)
+		}
+		if _, exists := out[v.ID]; exists {
+			t.Fatalf("duplicate vector id %q", v.ID)
+		}
+		out[v.ID] = v
+	}
+	for _, id := range []string{"R1", "D1", "D2", "O1", "C1", "E1", "B1"} {
+		if _, ok := out[id]; !ok {
+			t.Fatalf("missing vector %s", id)
+		}
+	}
+	return out
+}
+
+func vectorByID(t *testing.T, id, kind string) testVector {
+	t.Helper()
+	v, ok := loadVectors(t)[id]
+	if !ok {
+		t.Fatalf("missing vector %s", id)
+	}
+	if v.Kind != kind {
+		t.Fatalf("vector %s kind = %q, want %q", id, v.Kind, kind)
+	}
+	return v
+}
+
+func (v testVector) senderFor(i int) string {
+	if v.SenderModulo <= 0 {
+		return v.SenderPrefix
+	}
+	return fmt.Sprintf("%s%d", v.SenderPrefix, i%v.SenderModulo)
+}


### PR DESCRIPTION
PR-2 of the v0.11.0 program — the flagship (N6b, unanimous step-6 adopt). Authored by codex (pushed by claude as integrator).

- **Rename:** module `agentchute.dev/spike/conformance` → `agentchute.dev/conformance` (go.mod + imports + docs; the "spike" name was two audits overdue for removal from a STABLE protocol).
- **Language-neutral vectors:** `conformance/vectors/core.json` (schema `agentchute-conformance-vectors-v1`) encodes R1/D1/D2/O1/C1/E1/B1; the Go suite is now a vector RUNNER driving the Binding interface — both bindings (inbox + log) pass the identical vector set. The vectors are the deliverable: the language-neutral conformance contract.
- **Disposable proof:** `conformance/example-python-binding/runner.py` (~260 lines, stdlib-only) reads the same vectors and passes them against a minimal Python inbox binding — the universality proof. **Deliberately OUT of CI** (not wired into `go test ./...` or any workflow — verified) and labeled a point-in-time snapshot per the step-6 guardrail ("disposable" must not become "maintained").

Verification: root suite + race; conformance suite + race (module renamed); python proof passes standalone; acdemo inbox/log; crown jewels + drift green.

Gates: sonnet + claude (codex authored). claude gate: SHIP (verified above).