### PR TITLE
feat: send --idempotency-key opt-in + stable keys for SendCorrective (F1+N8)

### DIFF
--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -28,7 +28,7 @@ func cmdSend(args []string) error {
 	fs := flag.NewFlagSet("send", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 
-	var fromID, toID, body, replyTo, controlRepo, loopDir string
+	var fromID, toID, body, replyTo, controlRepo, loopDir, idempotencyKey string
 	var ask, jsonOut bool
 	var replyBy time.Duration
 	fs.StringVar(&fromID, "from", "", "sender agent id (or $AGENTCHUTE_AGENT_ID)")
@@ -38,6 +38,7 @@ func cmdSend(args []string) error {
 	fs.BoolVar(&ask, "ask", false, "set reply_required: true and prepend `## ASK` heading to the body")
 	fs.DurationVar(&replyBy, "reply-by", 0, "with --ask: override the owed-reply deadline (e.g. 1h; default 30m)")
 	fs.BoolVar(&jsonOut, "json", false, "structured JSON output")
+	fs.StringVar(&idempotencyKey, "idempotency-key", "", "opt-in: a resend with the same key re-issues the same seq (at-least-once); default (unset) is at-most-once")
 	fs.StringVar(&controlRepo, "control-repo", "", "control repo path (or AGENTCHUTE_CONTROL_REPO)")
 	fs.StringVar(&loopDir, "loop-dir", "", "loop dir path (or AGENTCHUTE_LOOP_DIR)")
 
@@ -156,16 +157,19 @@ func cmdSend(args []string) error {
 	if fi, statErr := os.Stat(inboxDir); statErr != nil || !fi.IsDir() {
 		return fmt.Errorf("write inbox message: recipient %q is not registered; run agentchute register --as %s first (%w)", toID, toID, os.ErrNotExist)
 	}
-	// idempotencyKey is "": send has no stable per-message content key, so a
-	// sender crash between the durable seq commit and the link loses the
-	// allocated seq as a legal gap (at-most-once for this message). The library
-	// re-issue path remains available to callers that supply a stable non-empty
-	// idempotency key. serveToken rides AGENTCHUTE_SERVE_TOKEN: a
+	// idempotencyKey defaults to "": send has no stable per-message content key,
+	// so a sender crash between the durable seq commit and the link loses the
+	// allocated seq as a legal gap (at-most-once for this message) — unchanged
+	// default behavior. --idempotency-key is the opt-in escape hatch (F1): a
+	// caller that supplies a stable non-empty key gets at-least-once, because a
+	// resend with the same key re-issues the SAME seq instead of consuming a new
+	// one (AllocateSeq). No default body-hash key, no retries, no delivery
+	// guarantee beyond the write (C.6). serveToken rides AGENTCHUTE_SERVE_TOKEN: a
 	// send from a child launched under `agentchute serve` carries the runner's
 	// active serve-lease fence, so a write from a fenced (reclaimed) agent fails
 	// closed (AllocateSeq VerifyFence -> ErrFenced). Empty env (no serve lease) =>
 	// intentionally unfenced.
-	id, err := loop.SendSeqMessage(cfg, fromID, toID, content, "", os.Getenv("AGENTCHUTE_SERVE_TOKEN"))
+	id, err := loop.SendSeqMessage(cfg, fromID, toID, content, idempotencyKey, os.Getenv("AGENTCHUTE_SERVE_TOKEN"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("write inbox message: recipient %q is not registered; run agentchute register --as %s first (%w)", toID, toID, err)
@@ -287,7 +291,7 @@ func applyReplyRequiredFrontmatter(content []byte) []byte {
 
 func sendUsage(err error) error {
 	return fmt.Errorf(`%w
-usage: agentchute send --from <sender> --to <recipient> [--reply-to <ref>] [--ask] [--reply-by <dur>] [--body <text>] [--json] [--control-repo <path>] [--loop-dir <path>]
+usage: agentchute send --from <sender> --to <recipient> [--reply-to <ref>] [--ask] [--reply-by <dur>] [--body <text>] [--idempotency-key <key>] [--json] [--control-repo <path>] [--loop-dir <path>]
 
   Ways to provide the body (pick one):
     --body "literal text"             short replies

--- a/internal/cli/send_idempotency_test.go
+++ b/internal/cli/send_idempotency_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// send_idempotency_test.go — F1 (deep-analysis-v2, step-6 adopted): expose the
+// already-built AllocateSeq/SendSeqMessage idempotency-key re-issue machinery
+// via an opt-in `send --idempotency-key <key>` flag. Guardrails (C.6): opt-in
+// only, no default body-hash key, no retries, no delivery guarantee beyond
+// the write.
+
+func setupIdempotencySendFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	withCwd(t, root, func() {
+		mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
+		mustMkdir(t, filepath.Join(root, ".agentchute", "loop"))
+		if err := cmdRegister([]string{"--as", "sender", "--vendor", "test"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := cmdRegister([]string{"--as", "recipient", "--vendor", "test"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	return root
+}
+
+func recipientInboxEntries(t *testing.T, root string) []os.DirEntry {
+	t.Helper()
+	inboxDir := filepath.Join(root, ".agentchute", "loop", "inbox", "recipient")
+	entries, err := os.ReadDir(inboxDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return entries
+}
+
+// TestSendIdempotencyKeySameKeyReissuesSameSeq is the load-bearing F1 test: a
+// resend carrying the SAME --idempotency-key must re-issue the same seq, not
+// consume a new one -- exactly one file must land in the recipient's inbox.
+func TestSendIdempotencyKeySameKeyReissuesSameSeq(t *testing.T) {
+	root := setupIdempotencySendFixture(t)
+	withCwd(t, root, func() {
+		args := []string{"--from", "sender", "--to", "recipient", "--body", "hello", "--idempotency-key", "k1"}
+		if err := cmdSend(args); err != nil {
+			t.Fatalf("first send: %v", err)
+		}
+		if err := cmdSend(args); err != nil {
+			t.Fatalf("resend with same key: %v", err)
+		}
+	})
+	entries := recipientInboxEntries(t, root)
+	if len(entries) != 1 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Fatalf("same --idempotency-key must re-issue the same seq (1 file); got %d: %v", len(entries), names)
+	}
+}
+
+// TestSendIdempotencyKeyDifferentKeyAllocatesNewSeq is the non-regression
+// half: two sends with DIFFERENT keys are two distinct logical messages and
+// must both land.
+func TestSendIdempotencyKeyDifferentKeyAllocatesNewSeq(t *testing.T) {
+	root := setupIdempotencySendFixture(t)
+	withCwd(t, root, func() {
+		if err := cmdSend([]string{"--from", "sender", "--to", "recipient", "--body", "hello", "--idempotency-key", "k1"}); err != nil {
+			t.Fatalf("first send: %v", err)
+		}
+		if err := cmdSend([]string{"--from", "sender", "--to", "recipient", "--body", "hello", "--idempotency-key", "k2"}); err != nil {
+			t.Fatalf("second send: %v", err)
+		}
+	})
+	entries := recipientInboxEntries(t, root)
+	if len(entries) != 2 {
+		t.Fatalf("different --idempotency-key values must allocate distinct seqs (2 files); got %d", len(entries))
+	}
+}
+
+// TestSendWithoutIdempotencyKeyIsUnchangedAtMostOnce pins the unset case:
+// omitting --idempotency-key must keep today's behavior -- two sends allocate
+// two distinct seqs (no re-issue path engaged at all).
+func TestSendWithoutIdempotencyKeyIsUnchangedAtMostOnce(t *testing.T) {
+	root := setupIdempotencySendFixture(t)
+	withCwd(t, root, func() {
+		if err := cmdSend([]string{"--from", "sender", "--to", "recipient", "--body", "hello"}); err != nil {
+			t.Fatalf("first send: %v", err)
+		}
+		if err := cmdSend([]string{"--from", "sender", "--to", "recipient", "--body", "hello"}); err != nil {
+			t.Fatalf("second send: %v", err)
+		}
+	})
+	entries := recipientInboxEntries(t, root)
+	if len(entries) != 2 {
+		t.Fatalf("omitting --idempotency-key must keep at-most-once (2 files for 2 sends); got %d", len(entries))
+	}
+}

--- a/internal/loop/message.go
+++ b/internal/loop/message.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -186,10 +187,15 @@ func SendCorrective(cfg *Config, from, offender, malformedItem, reason, sectionR
 	body := CorrectiveBody(malformedItem, reason, sectionRef)
 	content := ComposeMessage(from, "", body)
 
-	// Deliver under the canonical (to,from,seq) identity. Empty idempotencyKey
-	// means at-most-once across a sender crash between seq allocation and link;
-	// empty serveToken means intentionally unfenced.
-	id, err := SendSeqMessage(cfg, from, offender, content, "", "")
+	// N8: a stable content-derived idempotency key, so a caller retrying
+	// SendCorrective with the identical arguments (a transient send failure,
+	// not a fresh re-quarantine — a re-quarantine of the same original file
+	// produces a NEW timestamped malformedItem path and is correctly treated
+	// as a distinct corrective) re-issues the same seq instead of consuming a
+	// new one. Deterministic function of the call's own inputs only — no
+	// clock, no randomness. Empty serveToken means intentionally unfenced.
+	key := correctiveIdempotencyKey(from, offender, malformedItem, reason, sectionRef)
+	id, err := SendSeqMessage(cfg, from, offender, content, key, "")
 	if err != nil {
 		return Message{}, err
 	}
@@ -202,6 +208,17 @@ func SendCorrective(cfg *Config, from, offender, malformedItem, reason, sectionR
 	// Simple-again Gate 6a (pull-only): the corrective is delivered by the inbox
 	// file write alone; the offender picks it up on its own poll. No wake poke.
 	return msg, nil
+}
+
+// correctiveIdempotencyKey derives a stable idempotency key from
+// SendCorrective's own arguments (N8) — a sha256 hex digest, bounded and
+// filesystem/JSON-safe regardless of how long malformedItem/reason get.
+// Identical arguments always produce the identical key; any difference (a
+// different offender, item, or reason) produces a different key, so distinct
+// correctives never collide.
+func correctiveIdempotencyKey(from, offender, malformedItem, reason, sectionRef string) string {
+	sum := sha256.Sum256([]byte(from + "\x00" + offender + "\x00" + malformedItem + "\x00" + reason + "\x00" + sectionRef))
+	return fmt.Sprintf("corrective-%x", sum[:16])
 }
 
 // announcementBody is the human- and machine-readable payload for an

--- a/internal/loop/message_test.go
+++ b/internal/loop/message_test.go
@@ -145,6 +145,70 @@ func TestSendCorrectiveWritesMessageAndSkipsPokeForEmptyTarget(t *testing.T) {
 	}
 }
 
+// TestSendCorrectiveRetryWithSameItemDedups is N8 (deep-analysis-v2, step-6
+// adopted): a SendCorrective call retried with the IDENTICAL arguments (the
+// realistic retry shape -- a caller re-issuing the same already-computed
+// corrective after a transient failure, not re-quarantining a fresh file)
+// must re-issue the SAME seq, not consume a new one -- exactly one file must
+// land in the offender's inbox.
+func TestSendCorrectiveRetryWithSameItemDedups(t *testing.T) {
+	cfg := setupAnnounceFixture(t)
+	newReg(t, cfg, "claude-code", "anthropic", "", "") // self
+	offender := newReg(t, cfg, "codex", "openai", "", "")
+
+	msg1, err := SendCorrective(cfg, "claude-code", offender.AgentID,
+		".agentchute/loop/malformed/bad.md", "filename does not match §6.1", "§6.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg2, err := SendCorrective(cfg, "claude-code", offender.AgentID,
+		".agentchute/loop/malformed/bad.md", "filename does not match §6.1", "§6.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg1.Filename != msg2.Filename {
+		t.Fatalf("retrying SendCorrective with identical arguments allocated a new seq: %q vs %q", msg1.Filename, msg2.Filename)
+	}
+
+	entries, err := os.ReadDir(cfg.AgentInboxDir(offender.AgentID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 corrective delivered for a same-arguments retry, got %d", len(entries))
+	}
+}
+
+// TestSendCorrectiveDifferentItemAllocatesDistinctSeq is the non-regression
+// half: a DIFFERENT malformed item (different content) must not collide with
+// an unrelated corrective's key.
+func TestSendCorrectiveDifferentItemAllocatesDistinctSeq(t *testing.T) {
+	cfg := setupAnnounceFixture(t)
+	newReg(t, cfg, "claude-code", "anthropic", "", "")
+	offender := newReg(t, cfg, "codex", "openai", "", "")
+
+	msg1, err := SendCorrective(cfg, "claude-code", offender.AgentID,
+		".agentchute/loop/malformed/bad1.md", "filename does not match §6.1", "§6.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg2, err := SendCorrective(cfg, "claude-code", offender.AgentID,
+		".agentchute/loop/malformed/bad2.md", "filename does not match §6.1", "§6.1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if msg1.Filename == msg2.Filename {
+		t.Fatalf("two distinct malformed items collided on the same seq: %q", msg1.Filename)
+	}
+	entries, err := os.ReadDir(cfg.AgentInboxDir(offender.AgentID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("want 2 correctives delivered for 2 distinct items, got %d", len(entries))
+	}
+}
+
 func TestAnnounceEnrollmentNoPeers(t *testing.T) {
 	cfg := setupAnnounceFixture(t)
 	self := newReg(t, cfg, "claude-code", "anthropic", "", "I do synthesis.")


### PR DESCRIPTION
## Summary
- **F1** — exposes the already-built `AllocateSeq`/`SendSeqMessage` idempotency-key re-issue machinery via an opt-in `send --idempotency-key <key>` flag. A resend with the same key re-issues the same seq (at-least-once for callers who opt in); default (unset) is unchanged at-most-once. Spec §6.2 already documents this (merged in #52) — this PR is code-only, wiring `cmdSend`'s hardcoded `""` through to the flag.
- **N8** — `SendCorrective` now derives a stable content-based idempotency key (`sha256(from+offender+malformedItem+reason+sectionRef)`) so a caller retrying `SendCorrective` with identical arguments — the realistic retry shape (a transient send failure, not a fresh re-quarantine of a new file) — re-issues the same seq instead of double-delivering the same correction to the offender.
- **Boot announce** (`AnnounceEnrollment`) deliberately left unchanged — my call per the ask. It's a broadcast to N distinct peers with no single clean retry point (unlike `SendCorrective`'s single already-computed call), and a duplicate informational "I'm here" notice is harmless, unlike a duplicated §11.1 enforcement corrective. Adding a key there would be scope creep beyond what N8 asked for.

Guardrails held (C.6, hard): opt-in only, no default body-hash key, no retries, no delivery guarantee beyond the write.

## Test plan
- [x] TDD throughout — RED confirmed before each implementation (F1: `flag provided but not defined: -idempotency-key`; N8: two `SendCorrective` calls allocated different seqs before the fix).
- [x] `TestSendIdempotencyKeySameKeyReissuesSameSeq` — same key resend produces exactly 1 file in the recipient's inbox.
- [x] `TestSendIdempotencyKeyDifferentKeyAllocatesNewSeq` — different keys produce 2 distinct files.
- [x] `TestSendWithoutIdempotencyKeyIsUnchangedAtMostOnce` — omitting the flag keeps today's at-most-once behavior (2 files for 2 sends).
- [x] `TestSendCorrectiveRetryWithSameItemDedups` — identical `SendCorrective` arguments re-issue the same seq, exactly 1 file delivered.
- [x] `TestSendCorrectiveDifferentItemAllocatesDistinctSeq` — two distinct malformed items don't collide.
- [x] `gofmt -l .` / `go vet ./...` / `go build ./...` — clean.
- [x] `go test ./...` — full suite green.
- [x] `go test -race ./...` — race-clean.
- [x] `conformance` module — green.
- [x] Crown jewels (`TestPromptInjectionBytes*`) + drift (`TestTemplatesMatchRepoWrappers`) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)