### PR TITLE
v0.11.1: mark pre-0.8 blog posts historical (D1)

### DIFF
--- a/web/blog/index.html
+++ b/web/blog/index.html
@@ -65,7 +65,7 @@
             loading="lazy"
             width="240" height="135">
           <div class="featured-post-text">
-            <p class="featured-post-meta">June 8, 2026</p>
+            <p class="featured-post-meta">June 8, 2026 · Historical (Legacy Mechanics)</p>
             <p class="featured-post-title">v0.3.5: tmux teams, worktrees, and contextual identity <span class="featured-post-arrow" aria-hidden="true">→</span></p>
             <p class="featured-post-excerpt">The tmux reference path now handles worktrees and same-folder agents with contextual IDs, safer enrollment refreshes, and hook templates that no longer hardcode identities.</p>
           </div>
@@ -83,7 +83,7 @@
       <li>
         <a href="v0-3-2-setup-and-shims.html" class="featured-post-link">
           <div class="featured-post-text">
-            <p class="featured-post-meta">May 21, 2026</p>
+            <p class="featured-post-meta">May 21, 2026 · Historical (Legacy Mechanics)</p>
             <p class="featured-post-title">v0.3.2: one-line setup and transparent coordination <span class="featured-post-arrow" aria-hidden="true">→</span></p>
             <p class="featured-post-excerpt">Install + repo wiring collapses into a single command. Launcher shims route claude/codex/gemini through the runner so the wrapper commands you already use start coordinating. Wake events become visibly machine-typed.</p>
           </div>
@@ -98,7 +98,7 @@
             loading="lazy"
             width="240" height="160">
           <div class="featured-post-text">
-            <p class="featured-post-meta">May 20, 2026</p>
+            <p class="featured-post-meta">May 20, 2026 · Historical (Legacy Mechanics)</p>
             <p class="featured-post-title">v0.2: recipient polling, by hand and by hook <span class="featured-post-arrow" aria-hidden="true">→</span></p>
             <p class="featured-post-excerpt">tmux made the first agentchute demos feel immediate. It also blurred the protocol boundary. v0.2 fixes that — self-poll and doctor --generate-service (both removed in v0.9.0), gate --before continue, and a §8.2 spec clarification that recipient polling is canonical.</p>
           </div>
@@ -123,9 +123,9 @@
 
     <h2 style="margin-top:3rem;font-size:1rem;color:var(--fg-dim);">Archive</h2>
     <ul class="post-list" style="opacity:0.75;">
-      <li><a href="v0-2-1-enrollment-enforced.html">v0.2.1: enrollment, enforced</a> · May 20, 2026 — operational deep-dive on the v0.2.1 enforcement gap.</li>
-      <li><a href="v0-1-2-doctor-watch-no-tmux.html">v0.1.2: doctor, watch, and the no-tmux path</a> · May 20, 2026 — superseded by v0.2 recipient polling.</li>
-      <li><a href="v0-1-1-the-agents-shipped-it-themselves.html">v0.1.1: the agents shipped it themselves</a> · May 20, 2026 — three agents shipping v0.1.1 using v0.1.0.</li>
+      <li><a href="v0-2-1-enrollment-enforced.html">v0.2.1: enrollment, enforced</a> · May 20, 2026 · Historical — operational deep-dive on the v0.2.1 enforcement gap.</li>
+      <li><a href="v0-1-2-doctor-watch-no-tmux.html">v0.1.2: doctor, watch, and the no-tmux path</a> · May 20, 2026 · Historical — superseded by v0.2 recipient polling.</li>
+      <li><a href="v0-1-1-the-agents-shipped-it-themselves.html">v0.1.1: the agents shipped it themselves</a> · May 20, 2026 · Historical — three agents shipping v0.1.1 using v0.1.0.</li>
     </ul>
   </div>
 </section>

--- a/web/blog/v0-1-1-the-agents-shipped-it-themselves.html
+++ b/web/blog/v0-1-1-the-agents-shipped-it-themselves.html
@@ -42,6 +42,9 @@
 
 <section class="hero">
   <div class="wrap">
+    <div style="background: var(--bg-alt); border-left: 4px solid var(--accent); padding: 16px; margin-bottom: 24px; font-size: 14px; color: var(--fg-dim);">
+      <strong>Historical Note:</strong> This post describes early agentchute mechanics (such as push-based wakes, watchdogs, or recipient-side service polling) that were deleted in the v0.8.0 pull-only redesign. For the current stable specification, see the <a href="../spec.html">AGENTCHUTE.md Protocol Specification</a>.
+    </div>
     <p class="blog-meta">May 20, 2026 · agentchute team</p>
     <h1>v0.1.1: the agents shipped it themselves</h1>
     <p class="lede" style="font-style: italic; color: var(--fg-dim);">

--- a/web/blog/v0-1-2-doctor-watch-no-tmux.html
+++ b/web/blog/v0-1-2-doctor-watch-no-tmux.html
@@ -42,6 +42,9 @@
 
 <section class="hero">
   <div class="wrap">
+    <div style="background: var(--bg-alt); border-left: 4px solid var(--accent); padding: 16px; margin-bottom: 24px; font-size: 14px; color: var(--fg-dim);">
+      <strong>Historical Note:</strong> This post describes early agentchute mechanics (such as push-based wakes, watchdogs, or recipient-side service polling) that were deleted in the v0.8.0 pull-only redesign. For the current stable specification, see the <a href="../spec.html">AGENTCHUTE.md Protocol Specification</a>.
+    </div>
     <p class="blog-meta">May 20, 2026 · agentchute team</p>
     <h1>v0.1.2: doctor, watch, and the no-tmux path</h1>
     <p class="lede" style="font-style: italic; color: var(--fg-dim);">

--- a/web/blog/v0-2-1-enrollment-enforced.html
+++ b/web/blog/v0-2-1-enrollment-enforced.html
@@ -37,6 +37,9 @@
 
 <section class="hero">
   <div class="wrap">
+    <div style="background: var(--bg-alt); border-left: 4px solid var(--accent); padding: 16px; margin-bottom: 24px; font-size: 14px; color: var(--fg-dim);">
+      <strong>Historical Note:</strong> This post describes early agentchute mechanics (such as push-based wakes, watchdogs, or recipient-side service polling) that were deleted in the v0.8.0 pull-only redesign. For the current stable specification, see the <a href="../spec.html">AGENTCHUTE.md Protocol Specification</a>.
+    </div>
     <p class="blog-meta">May 20, 2026 · agentchute team</p>
     <h1>v0.2.1: enrollment, enforced</h1>
     <p class="lede" style="font-style: italic; color: var(--fg-dim);">

--- a/web/blog/v0-2-recipient-polling.html
+++ b/web/blog/v0-2-recipient-polling.html
@@ -42,6 +42,9 @@
 
 <section class="hero">
   <div class="wrap">
+    <div style="background: var(--bg-alt); border-left: 4px solid var(--accent); padding: 16px; margin-bottom: 24px; font-size: 14px; color: var(--fg-dim);">
+      <strong>Historical Note:</strong> This post describes early agentchute mechanics (such as push-based wakes, watchdogs, or recipient-side service polling) that were deleted in the v0.8.0 pull-only redesign. For the current stable specification, see the <a href="../spec.html">AGENTCHUTE.md Protocol Specification</a>.
+    </div>
     <p class="blog-meta">May 20, 2026 · agentchute team</p>
     <h1>v0.2: recipient polling, by hand and by hook</h1>
     <p class="lede" style="font-style: italic; color: var(--fg-dim);">

--- a/web/blog/v0-3-2-setup-and-shims.html
+++ b/web/blog/v0-3-2-setup-and-shims.html
@@ -37,6 +37,9 @@
 
 <section class="hero">
   <div class="wrap">
+    <div style="background: var(--bg-alt); border-left: 4px solid var(--accent); padding: 16px; margin-bottom: 24px; font-size: 14px; color: var(--fg-dim);">
+      <strong>Historical Note:</strong> This post describes early agentchute mechanics (such as push-based wakes, watchdogs, or recipient-side service polling) that were deleted in the v0.8.0 pull-only redesign. For the current stable specification, see the <a href="../spec.html">AGENTCHUTE.md Protocol Specification</a>.
+    </div>
     <p class="blog-meta">May 21, 2026 · agentchute team</p>
     <h1>v0.3.2: one-line setup and transparent coordination</h1>
     <p class="lede" style="font-style: italic; color: var(--fg-dim);">

--- a/web/blog/v0-3-4-contextual-identity-worktrees.html
+++ b/web/blog/v0-3-4-contextual-identity-worktrees.html
@@ -6,8 +6,12 @@
 <meta http-equiv="refresh" content="0; url=v0-3-5-contextual-identity-worktrees.html">
 <title>Moved — agentchute</title>
 <link rel="canonical" href="https://agentchute.dev/blog/v0-3-5-contextual-identity-worktrees.html">
+<link rel="stylesheet" href="../style.css">
 </head>
 <body>
+<div style="background: var(--bg-alt); border-left: 4px solid var(--accent); padding: 16px; margin-bottom: 24px; font-size: 14px; color: var(--fg-dim);">
+  <strong>Historical Note:</strong> This post describes early agentchute mechanics (such as push-based wakes, watchdogs, or recipient-side service polling) that were deleted in the v0.8.0 pull-only redesign. For the current stable specification, see the <a href="../spec.html">AGENTCHUTE.md Protocol Specification</a>.
+</div>
 <p>This article moved to <a href="v0-3-5-contextual-identity-worktrees.html">v0.3.5: tmux teams, worktrees, and contextual identity</a>.</p>
 </body>
 </html>

--- a/web/blog/v0-3-5-contextual-identity-worktrees.html
+++ b/web/blog/v0-3-5-contextual-identity-worktrees.html
@@ -39,6 +39,9 @@
 
 <section class="hero">
   <div class="wrap">
+    <div style="background: var(--bg-alt); border-left: 4px solid var(--accent); padding: 16px; margin-bottom: 24px; font-size: 14px; color: var(--fg-dim);">
+      <strong>Historical Note:</strong> This post describes early agentchute mechanics (such as push-based wakes, watchdogs, or recipient-side service polling) that were deleted in the v0.8.0 pull-only redesign. For the current stable specification, see the <a href="../spec.html">AGENTCHUTE.md Protocol Specification</a>.
+    </div>
     <p class="blog-meta">June 8, 2026 · agentchute team</p>
     <h1>v0.3.5: tmux teams, worktrees, and contextual identity</h1>
     <p class="lede" style="font-style: italic; color: var(--fg-dim);">


### PR DESCRIPTION
PR-A2 (v0.11.1). Authored by gemini. Historical banners on all 7 pre-0.8 posts (incl. the v0-3-4 duplicate) + index annotations. Closes the D1 'blog misdescribes current mechanics' finding pending the 1.0 arc post (which lands as the freeze-release announcement). Gates: codex + claude.