### PR TITLE
v0.11.8 freeze-prep hardening: macOS CI, PTY resize test, gemini-hook removal

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,14 +7,19 @@ on:
 
 jobs:
   go:
-    name: go test + vet + build
-    runs-on: ubuntu-latest
+    name: go test + vet + build (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version: '1.21'
       - name: gofmt
+        if: matrix.os == 'ubuntu-latest'
         run: |
           out=$(gofmt -l .)
           if [ -n "$out" ]; then

--- a/internal/cli/gate.go
+++ b/internal/cli/gate.go
@@ -43,7 +43,7 @@ func cmdGate(args []string) error {
 	fs := flag.NewFlagSet("gate", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 
-	var agentID, vendor, before, controlRepo, loopDir, codexHook, geminiHook string
+	var agentID, vendor, before, controlRepo, loopDir, codexHook string
 	var jsonOut, requireConfirm, ackStaleReg bool
 	fs.StringVar(&agentID, "as", "", "agent id (or $AGENTCHUTE_AGENT_ID)")
 	fs.StringVar(&vendor, "vendor", "", "vendor or origin (anthropic, openai, google, xai)")
@@ -52,7 +52,6 @@ func cmdGate(args []string) error {
 	fs.StringVar(&loopDir, "loop-dir", "", "loop dir path (or $AGENTCHUTE_LOOP_DIR)")
 	fs.BoolVar(&jsonOut, "json", false, "structured JSON output")
 	fs.StringVar(&codexHook, "codex-hook", "", "codex hook JSON shape for the named event (Stop)")
-	fs.StringVar(&geminiHook, "gemini-hook", "", "legacy gemini-cli decision JSON shape (AfterAgent); current Gemini hooks use BeforeAgent + --json")
 	fs.BoolVar(&requireConfirm, "require-confirm", false, "refuse unless warn-level conditions are explicitly acknowledged")
 	fs.BoolVar(&ackStaleReg, "ack-stale-reg", false, "acknowledge that the registration is stale (for --require-confirm)")
 
@@ -106,12 +105,6 @@ func cmdGate(args []string) error {
 		// On clear: no output, exit 0. On block: emit {"decision":"block",...}
 		// JSON, exit 0 (codex's preferred shape; main.go won't see errBlocked).
 		return emitGateCodexStop(status)
-	case geminiHook == "AfterAgent":
-		// Legacy/experimental gemini-cli AfterAgent decision envelope:
-		// {"decision":"deny","reason":"..."} on block, {"decision":"allow"}
-		// on clear. Always exits 0 (the JSON is the signal). Current shipped
-		// Gemini hooks use BeforeAgent + --json exit-code blocking instead.
-		return emitGateGeminiAfterAgent(status)
 	case jsonOut:
 		if err := emitGateJSON(status); err != nil {
 			return err
@@ -395,28 +388,6 @@ func emitGateCodexStop(s gateStatus) error {
 	return enc.Encode(out)
 }
 
-// emitGateGeminiAfterAgent emits the legacy/experimental gemini-cli AfterAgent
-// decision JSON. Current shipped Gemini hooks use BeforeAgent + --json.
-// On block: `{"decision":"deny","reason":"..."}` forces another turn.
-// On clear: `{"decision":"allow"}` lets the session end. Always exits 0
-// (the JSON is the signal). This is the in-session continuation surface for
-// gemini-cli without an external scheduler; typically paired with
-// `--before continue`.
-func emitGateGeminiAfterAgent(s gateStatus) error {
-	if !s.Blocked {
-		out := map[string]any{"decision": "allow"}
-		enc := json.NewEncoder(os.Stdout)
-		return enc.Encode(out)
-	}
-	reason := fmt.Sprintf("agentchute gate --before %s: %s", s.Phase, strings.Join(s.Reasons, "; "))
-	out := map[string]any{
-		"decision": "deny",
-		"reason":   reason,
-	}
-	enc := json.NewEncoder(os.Stdout)
-	return enc.Encode(out)
-}
-
 func gateUsage(err error) error {
 	if err == flag.ErrHelp {
 		return gateHelpErr()
@@ -458,7 +429,7 @@ All phases block if this agent is not registered.
 
 Exit codes:
   0  clear to proceed; also used by hook-envelope modes whose JSON is the signal
-     (--codex-hook Stop, --gemini-hook AfterAgent)
+     (--codex-hook Stop)
   2  blocked in text/--json modes (including shipped Claude/Gemini finish hooks)
   1  command failure (binary error, filesystem error, etc.)
 
@@ -470,8 +441,6 @@ Flags:
   --loop-dir <p>        loop dir path (or $AGENTCHUTE_LOOP_DIR)
   --json                structured JSON output (blocked still exits 2)
   --codex-hook <event>  codex hook JSON shape (Stop)
-  --gemini-hook <event> legacy gemini-cli decision JSON shape (AfterAgent);
-                        current Gemini templates use BeforeAgent + --json
   --require-confirm     refuse unless warn-level conditions are acknowledged
   --ack-stale-reg       acknowledge stale registration (for --require-confirm)
 `)

--- a/internal/cli/gate_test.go
+++ b/internal/cli/gate_test.go
@@ -24,8 +24,6 @@ func TestGateHelpDocumentsBlockersAndHookExitCodes(t *testing.T) {
 		"asker-owned only",
 		"blocked in text/--json modes",
 		"--codex-hook Stop",
-		"--gemini-hook AfterAgent",
-		"current Gemini templates use BeforeAgent + --json",
 	} {
 		if !strings.Contains(help, want) {
 			t.Fatalf("gate help missing %q:\n%s", want, help)
@@ -453,71 +451,6 @@ func TestGateContinuePhaseSamePredicateAsFinish(t *testing.T) {
 		}
 		if !errors.Is(errContinue, errBlocked) {
 			t.Fatalf("continue err = %v, want errBlocked", errContinue)
-		}
-	})
-}
-
-// Legacy/experimental --gemini-hook AfterAgent emits decision:deny on block,
-// decision:allow on clear. Always exit 0 — the JSON is the signal. The shipped
-// Gemini hook template uses BeforeAgent + --json instead.
-func TestGateGeminiHookAfterAgentBlockedShape(t *testing.T) {
-	root := setupBootFixture(t)
-	withCwd(t, root, func() {
-		t.Setenv("TMUX_PANE", "%1")
-		if _, err := captureStdout(t, func() error { return cmdBoot(bootArgs()) }); err != nil {
-			t.Fatal(err)
-		}
-		inboxDir := filepath.Join(root, ".agentchute", "loop", "inbox", "claude-code")
-		mustWriteSeqInbox(t, inboxDir, "codex", 1,
-			[]byte("---\nfrom: codex\nto: claude-code\ntask: x\n---\n\nb\n"))
-		out, err := captureStdout(t, func() error {
-			return cmdGate(gateArgs("continue", "--gemini-hook", "AfterAgent"))
-		})
-		if err != nil {
-			t.Errorf("err = %v, want nil (gemini hook exit 0)", err)
-		}
-		var wrap struct {
-			Decision string `json:"decision"`
-			Reason   string `json:"reason"`
-		}
-		if jerr := json.Unmarshal([]byte(out), &wrap); jerr != nil {
-			t.Fatalf("unmarshal: %v\n%s", jerr, out)
-		}
-		if wrap.Decision != "deny" {
-			t.Errorf("decision = %q, want deny", wrap.Decision)
-		}
-		if !strings.Contains(wrap.Reason, "unread") {
-			t.Errorf("reason missing 'unread': %q", wrap.Reason)
-		}
-	})
-}
-
-func TestGateGeminiHookAfterAgentClearShape(t *testing.T) {
-	root := setupBootFixture(t)
-	withCwd(t, root, func() {
-		t.Setenv("TMUX_PANE", "%1")
-		if _, err := captureStdout(t, func() error { return cmdBoot(bootArgs()) }); err != nil {
-			t.Fatal(err)
-		}
-		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
-		if err != nil {
-			t.Fatal(err)
-		}
-		mustWriteFreshPollerHeartbeat(t, cfg, "claude-code")
-		out, err := captureStdout(t, func() error {
-			return cmdGate(gateArgs("continue", "--gemini-hook", "AfterAgent"))
-		})
-		if err != nil {
-			t.Errorf("err = %v, want nil", err)
-		}
-		var wrap struct {
-			Decision string `json:"decision"`
-		}
-		if jerr := json.Unmarshal([]byte(out), &wrap); jerr != nil {
-			t.Fatalf("unmarshal: %v\n%s", jerr, out)
-		}
-		if wrap.Decision != "allow" {
-			t.Errorf("decision = %q, want allow on clear inbox", wrap.Decision)
 		}
 	})
 }

--- a/internal/cli/run_resize_unix_test.go
+++ b/internal/cli/run_resize_unix_test.go
@@ -1,0 +1,113 @@
+//go:build !windows
+
+package cli
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	creackpty "github.com/creack/pty"
+)
+
+// Only startup sizing (StartInheritSize, pty_size_test.go) had coverage
+// before this: a resize arriving mid-session — the common case of a human
+// resizing their terminal window while a wrapper is running — was untested.
+// This drives resizeLoop's real SIGWINCH path end-to-end: a size change on
+// the runner's own terminal must propagate to the child PTY, and the
+// session (the data channel to the child) must remain usable afterward.
+func TestResizeLoopPropagatesSIGWINCHAndSessionSurvives(t *testing.T) {
+	// "the runner's own terminal" that resizeLoop reads size from (os.Stdin).
+	stdinMaster, stdinSlave, err := creackpty.Open()
+	if err != nil {
+		t.Fatalf("open stdin pty pair: %v", err)
+	}
+	defer stdinMaster.Close()
+	defer stdinSlave.Close()
+	if err := creackpty.Setsize(stdinMaster, &creackpty.Winsize{Rows: 24, Cols: 80}); err != nil {
+		t.Fatalf("setsize initial: %v", err)
+	}
+
+	// "the child PTY" that resizeLoop copies the size onto.
+	childMaster, childSlave, err := creackpty.Open()
+	if err != nil {
+		t.Fatalf("open child pty pair: %v", err)
+	}
+	defer childMaster.Close()
+	defer childSlave.Close()
+
+	origStdin := os.Stdin
+	os.Stdin = stdinSlave
+	defer func() { os.Stdin = origStdin }()
+
+	rt := &runnerRuntime{ptmx: childMaster, stopCh: make(chan struct{})}
+	loopDone := make(chan struct{})
+	go func() {
+		rt.resizeLoop()
+		close(loopDone)
+	}()
+	defer func() {
+		close(rt.stopCh)
+		<-loopDone
+	}()
+
+	assertSessionAlive := func(marker byte) {
+		t.Helper()
+		if _, err := childSlave.Write([]byte{marker}); err != nil {
+			t.Fatalf("write to child slave: %v", err)
+		}
+		got := make(chan byte, 1)
+		readErr := make(chan error, 1)
+		go func() {
+			buf := make([]byte, 1)
+			if _, err := childMaster.Read(buf); err != nil {
+				readErr <- err
+				return
+			}
+			got <- buf[0]
+		}()
+		select {
+		case b := <-got:
+			if b != marker {
+				t.Fatalf("session echoed %q, want %q", b, marker)
+			}
+		case err := <-readErr:
+			t.Fatalf("read from child pty: %v", err)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out reading from child pty — session did not survive")
+		}
+	}
+
+	// Prove the channel works before touching size at all.
+	assertSessionAlive('a')
+
+	// Let resizeLoop finish its startup InheritSize call and register its
+	// SIGWINCH handler before we resize and signal.
+	time.Sleep(50 * time.Millisecond)
+
+	if err := creackpty.Setsize(stdinMaster, &creackpty.Winsize{Rows: 41, Cols: 97}); err != nil {
+		t.Fatalf("setsize resize: %v", err)
+	}
+	if err := syscall.Kill(os.Getpid(), syscall.SIGWINCH); err != nil {
+		t.Fatalf("send SIGWINCH: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		got, err := creackpty.GetsizeFull(childMaster)
+		if err != nil {
+			t.Fatalf("getsize child pty: %v", err)
+		}
+		if got.Rows == 41 && got.Cols == 97 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("child pty winsize = %dx%d after SIGWINCH, want 41x97", got.Rows, got.Cols)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The resize must not have disrupted the data channel.
+	assertSessionAlive('b')
+}


### PR DESCRIPTION
## Summary
- **macOS CI**: `ci.yaml`'s go job now runs test/vet/build/conformance on a `[ubuntu-latest, macos-latest]` matrix. goreleaser ships darwin/amd64+arm64 binaries that had zero automated coverage; gofmt stays ubuntu-only since it's an OS-independent check. Per Alex's go: findings on darwin are the gate working, not flakes to paper over.
- **PTY resize/SIGWINCH regression test**: `internal/cli/run_resize_unix_test.go` drives `resizeLoop`'s real SIGWINCH path end-to-end — sets an initial size on a fake "runner terminal" pty, starts `resizeLoop` against a fake "child" pty, resizes the terminal, sends a real `SIGWINCH` to the test process, and asserts the child pty's winsize converges. Also proves the data channel survives the resize (write/read through the child pty before and after). Only startup sizing (`StartInheritSize`) had coverage before this; mid-session resize — the common case of someone resizing their terminal while a wrapper runs — was untested. 10/10 clean under `-race -count=10`.
- **`gate --gemini-hook AfterAgent` removal**: one-time deprecation exception per Alex's go (normally removal waits a full minor; this soaks during the v0.12.0 dogfood window instead). Removed the flag, its help text, `emitGateGeminiAfterAgent`, and the two tests that exercised it. Re-verified `TestGeminiHookTemplateUsesBeforeAgentJSONGate` still passes and is kept as the standing guard that the shipped Gemini hook template never regresses to the legacy shape. Swept the whole repo for any other reference — none remain outside that guard test. CHANGELOG entry for the exception is being logged separately (per the assignment).

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` — clean
- [x] `go test ./...` and `go test -race ./...` (env stripped of `AGENTCHUTE_*` per the known test-env-leak footgun) — all pass
- [x] `go test ./conformance/...` — pass
- [x] `go test ./internal/cli/... -run TestPromptInjectionBytes -v` (crown jewel) — pass
- [x] `go test ./internal/cli/... -run TestResizeLoopPropagatesSIGWINCHAndSessionSurvives -race -count=10 -v` — 10/10 pass
- [x] `go test ./internal/cli/... -run "TestGate|TestGeminiHookTemplate"` — all pass, including the retained template guard
- [x] Repo-wide grep for `gemini-hook`/`geminiHook`/`AfterAgent` — only the guard test's own literal-string assertions remain
- [x] `ci.yaml` validated as well-formed YAML (`ruby -ryaml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)