### PR TITLE
v0.11.8: emit registration v:2 + doctor/status protocol-version reader (GATE-1)

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -184,6 +184,7 @@ func runDoctorChecks(cfg *loop.Config, agentID string, opts doctorOptions) docto
 	checks := []doctorCheck{
 		checkLoopDirScaffold(cfg),
 		checkSpecFreshness(cfg),
+		checkProtocolVersions(cfg),
 		checkStaleTempFiles(cfg, opts.Now),
 		checkBinaryOnPath(),
 		checkHookFilePresence(cfg, agentID),
@@ -251,6 +252,37 @@ func checkSpecFreshness(cfg *loop.Config) doctorCheck {
 func shortSHA256(data []byte) string {
 	sum := sha256.Sum256(data)
 	return fmt.Sprintf("%x", sum[:])[:12]
+}
+
+func checkProtocolVersions(cfg *loop.Config) doctorCheck {
+	regs, errs := loop.ReadRegistrationsLenient(cfg.AgentsDir())
+	if len(errs) > 0 {
+		return doctorCheck{
+			Name:     "protocol_version",
+			Severity: severityWarn,
+			Message:  fmt.Sprintf("registration protocol-version scan skipped %d unreadable registration(s)", len(errs)),
+		}
+	}
+
+	regsMap := make(map[string]*loop.Registration)
+	for _, reg := range regs {
+		regsMap[reg.AgentID] = reg
+	}
+
+	var warnings []string
+	for _, id := range loop.RegistrationsByAgentID(regsMap) {
+		if warning := protocolVersionWarning(regsMap[id]); warning != "" {
+			warnings = append(warnings, warning)
+		}
+	}
+	if len(warnings) == 0 {
+		return doctorCheck{Name: "protocol_version", Severity: severityOK, Message: fmt.Sprintf("no explicit protocol-version mismatches; expected v%d", loop.CurrentProtocolVersion)}
+	}
+	return doctorCheck{
+		Name:     "protocol_version",
+		Severity: severityWarn,
+		Message:  strings.Join(warnings, "; "),
+	}
 }
 
 func checkLoopDirScaffold(cfg *loop.Config) doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -369,6 +369,66 @@ func TestDoctorPerAgentChecksRunWithAgentID(t *testing.T) {
 	// were removed (sender-side wake reachability no longer exists).
 }
 
+func TestDoctorProtocolVersionAbsentIsSilent(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, reg := range []*loop.Registration{
+		{
+			AgentID:         "codex",
+			ProtocolVersion: loop.CurrentProtocolVersion,
+			Vendor:          "openai",
+			ControlRepo:     cfg.ControlRepo,
+			Host:            "doctor-test",
+			LastSeen:        now,
+			Status:          loop.StatusActive,
+		},
+		{
+			AgentID:     "gemini-cli",
+			Vendor:      "google",
+			ControlRepo: cfg.ControlRepo,
+			Host:        "doctor-test",
+			LastSeen:    now,
+			Status:      loop.StatusActive,
+		},
+	} {
+		if err := loop.WriteRegistration(cfg.AgentRegistrationPath(reg.AgentID), reg); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := checkProtocolVersions(cfg)
+	if got.Severity != severityOK {
+		t.Fatalf("protocol_version severity = %q, want OK; msg=%q", got.Severity, got.Message)
+	}
+	if strings.Contains(got.Message, "gemini-cli") {
+		t.Fatalf("absent-v legacy registration must not warn: %q", got.Message)
+	}
+}
+
+func TestDoctorProtocolVersionMismatchWarns(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	reg := &loop.Registration{
+		AgentID:         "future",
+		ProtocolVersion: loop.CurrentProtocolVersion + 1,
+		Vendor:          "test",
+		ControlRepo:     cfg.ControlRepo,
+		Host:            "doctor-test",
+		LastSeen:        time.Now().UTC().Truncate(time.Second),
+		Status:          loop.StatusActive,
+	}
+	if err := loop.WriteRegistration(cfg.AgentRegistrationPath(reg.AgentID), reg); err != nil {
+		t.Fatal(err)
+	}
+
+	got := checkProtocolVersions(cfg)
+	if got.Severity != severityWarn {
+		t.Fatalf("protocol_version severity = %q, want WARN; msg=%q", got.Severity, got.Message)
+	}
+	if !strings.Contains(got.Message, "future reports protocol v3; expected v2") {
+		t.Fatalf("protocol_version warning missing mismatch detail: %q", got.Message)
+	}
+}
+
 // Gate 6a (pull-only): TestDoctorTmuxWakeValidityHonorsProbeSeam was removed
 // along with the checkWakeTargetValidity tmux arm it exercised.
 

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -146,13 +146,14 @@ func publishRegistrationOnce(cfg *loop.Config, opts registerOpts, host string, n
 		}
 
 		reg = &loop.Registration{
-			AgentID:      opts.AgentID,
-			Vendor:       opts.Vendor,
-			ControlRepo:  cfg.ControlRepo,
-			WorkingRepos: opts.WorkingRepos,
-			Host:         host,
-			LastSeen:     now,
-			Status:       loop.StatusActive,
+			AgentID:         opts.AgentID,
+			ProtocolVersion: loop.CurrentProtocolVersion,
+			Vendor:          opts.Vendor,
+			ControlRepo:     cfg.ControlRepo,
+			WorkingRepos:    opts.WorkingRepos,
+			Host:            host,
+			LastSeen:        now,
+			Status:          loop.StatusActive,
 			// WI-E3 launch provenance: a non-empty value from the caller wins (a
 			// fresh runner/hook/manual launch updates how the lane enrolled); empty
 			// values fall back to the existing registration below.

--- a/internal/cli/register_test.go
+++ b/internal/cli/register_test.go
@@ -76,6 +76,33 @@ func TestRegister_RMWUnderAgentLock(t *testing.T) {
 	})
 }
 
+func TestRegisterWritesProtocolVersion(t *testing.T) {
+	root := t.TempDir()
+	withCwd(t, root, func() {
+		mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
+		mustMkdir(t, filepath.Join(root, ".agentchute", "loop"))
+		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := performRegister(cfg, registerOpts{AgentID: "codex", Vendor: "openai"}, time.Now().UTC()); err != nil {
+			t.Fatal(err)
+		}
+		reg, err := loop.ReadRegistration(cfg.AgentRegistrationPath("codex"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reg.ProtocolVersion != loop.CurrentProtocolVersion {
+			t.Fatalf("ProtocolVersion = %d, want %d", reg.ProtocolVersion, loop.CurrentProtocolVersion)
+		}
+		data := string(mustRead(t, cfg.AgentRegistrationPath("codex")))
+		if !strings.Contains(data, "\nv: 2\n") {
+			t.Fatalf("registration missing v: 2:\n%s", data)
+		}
+	})
+}
+
 // TestRegister_NoLostUpdateVsConcurrentUpdateLastSeen asserts that a
 // performRegister merge cannot silently clobber a concurrently-recorded
 // last_active. performRegister preserves existing.LastActive across the

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -149,21 +149,36 @@ func printStatus(w io.Writer, cfg *loop.Config, regs map[string]*loop.Registrati
 	// Pull-only (Gate 6c): registrations carry no wake state and presence is the
 	// `.live` fact. There is no WAKE / REACHABLE / CACHED column; LAST_SEEN/AGE
 	// come from `.live` (loop.LiveLastSeen), absent => "-".
-	fmt.Fprintln(tw, "AGENT\tSTATUS\tINBOX\tLAST_SEEN\tAGE\tHOST")
+	fmt.Fprintln(tw, "AGENT\tSTATUS\tINBOX\tLAST_SEEN\tAGE\tHOST\tPROTO")
 	for _, id := range loop.RegistrationsByAgentID(regs) {
 		reg := regs[id]
 		inboxDepth := countInbox(cfg.AgentInboxDir(id))
 		liveSeen, _ := loop.LiveLastSeen(cfg, reg.AgentID)
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\t%s\n",
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
 			reg.AgentID,
 			reg.Status,
 			inboxDepth,
 			formatMaybeTime(liveSeen),
 			formatAge(now, liveSeen),
 			formatDash(reg.Host),
+			formatProtocolVersion(reg.ProtocolVersion),
 		)
 	}
 	_ = tw.Flush()
+
+	var warnings []string
+	for _, id := range loop.RegistrationsByAgentID(regs) {
+		if warning := protocolVersionWarning(regs[id]); warning != "" {
+			warnings = append(warnings, warning)
+		}
+	}
+	if len(warnings) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "PROTOCOL WARNINGS:")
+		for _, warning := range warnings {
+			fmt.Fprintf(w, "- %s\n", warning)
+		}
+	}
 }
 
 func countInbox(dir string) int {
@@ -223,4 +238,22 @@ func formatDash(value string) string {
 		return "-"
 	}
 	return value
+}
+
+func formatProtocolVersion(version int) string {
+	switch version {
+	case 0:
+		return "legacy"
+	case loop.CurrentProtocolVersion:
+		return fmt.Sprintf("v%d", version)
+	default:
+		return fmt.Sprintf("v%d!", version)
+	}
+}
+
+func protocolVersionWarning(reg *loop.Registration) string {
+	if reg == nil || reg.ProtocolVersion == 0 || reg.ProtocolVersion == loop.CurrentProtocolVersion {
+		return ""
+	}
+	return fmt.Sprintf("%s reports protocol v%d; expected v%d", reg.AgentID, reg.ProtocolVersion, loop.CurrentProtocolVersion)
 }

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -105,6 +105,63 @@ func TestStatus_PresenceFromLive(t *testing.T) {
 	}
 }
 
+func TestStatusProtocolVersionColumnAndWarnings(t *testing.T) {
+	root := t.TempDir()
+	cfg := &loop.Config{
+		ControlRepo: root,
+		LoopDir:     filepath.Join(root, ".agentchute", "loop"),
+		Vendor:      "agentchute",
+	}
+	mustMkdir(t, cfg.AgentsDir())
+
+	now := time.Date(2026, 5, 9, 16, 40, 0, 0, time.UTC)
+	regs := map[string]*loop.Registration{
+		"codex": {
+			AgentID:         "codex",
+			ProtocolVersion: loop.CurrentProtocolVersion,
+			Vendor:          "openai",
+			ControlRepo:     root,
+			LastSeen:        now,
+			Status:          loop.StatusActive,
+		},
+		"gemini-cli": {
+			AgentID:     "gemini-cli",
+			Vendor:      "google",
+			ControlRepo: root,
+			LastSeen:    now,
+			Status:      loop.StatusActive,
+		},
+		"future": {
+			AgentID:         "future",
+			ProtocolVersion: loop.CurrentProtocolVersion + 1,
+			Vendor:          "test",
+			ControlRepo:     root,
+			LastSeen:        now,
+			Status:          loop.StatusActive,
+		},
+	}
+
+	var out bytes.Buffer
+	printStatus(&out, cfg, regs, now)
+	text := out.String()
+
+	if got := statusColumnValue(t, text, "PROTO", "codex"); got != "v2" {
+		t.Fatalf("codex PROTO = %q, want v2:\n%s", got, text)
+	}
+	if got := statusColumnValue(t, text, "PROTO", "gemini-cli"); got != "legacy" {
+		t.Fatalf("gemini-cli PROTO = %q, want legacy:\n%s", got, text)
+	}
+	if got := statusColumnValue(t, text, "PROTO", "future"); got != "v3!" {
+		t.Fatalf("future PROTO = %q, want v3!:\n%s", got, text)
+	}
+	if !strings.Contains(text, "PROTOCOL WARNINGS:") || !strings.Contains(text, "future reports protocol v3; expected v2") {
+		t.Fatalf("status missing protocol mismatch warning:\n%s", text)
+	}
+	if strings.Contains(text, "gemini-cli reports protocol") {
+		t.Fatalf("absent-v legacy registration must not warn:\n%s", text)
+	}
+}
+
 // Pull-only (Gate 6c): TestStatus_ShowsReachableColumn and
 // TestStatus_ShowsCachedReachableAge were removed. The WAKE / REACHABLE / CACHED
 // columns (and statusReachableProbe) are gone — registrations carry no wake state

--- a/internal/loop/registration.go
+++ b/internal/loop/registration.go
@@ -17,6 +17,8 @@ import (
 const (
 	MaxRegistrationBytes = 1 << 20 // 1 MiB — registrations are tiny in practice.
 	MaxInboxMessageBytes = 4 << 20 // 4 MiB — free-form markdown bodies.
+
+	CurrentProtocolVersion = 2
 )
 
 // ReadFileLimit reads up to max bytes from path, returning ErrFileTooLarge
@@ -60,15 +62,16 @@ const (
 // recipient's own `.live` file (loop.IsLive). There is no wake_method/wake_target
 // and no reachability cache — every consumer reads `.live` for presence.
 type Registration struct {
-	AgentID      string
-	Vendor       string
-	ControlRepo  string
-	WorkingRepos []string
-	Host         string
-	LastSeen     time.Time
-	Status       Status
-	RestartAt    *time.Time
-	LastActive   *time.Time
+	AgentID         string
+	ProtocolVersion int
+	Vendor          string
+	ControlRepo     string
+	WorkingRepos    []string
+	Host            string
+	LastSeen        time.Time
+	Status          Status
+	RestartAt       *time.Time
+	LastActive      *time.Time
 
 	// WI-E3 launch provenance (AGENTCHUTE.md §5.1). Advisory and
 	// backward-compatible: records HOW this lane enrolled so verify views (E1)
@@ -105,13 +108,14 @@ func ReadRegistration(path string) (*Registration, error) {
 	}
 
 	reg := &Registration{
-		AgentID:      fields.scalar("agent_id"),
-		Vendor:       fields.scalar("vendor"),
-		ControlRepo:  fields.scalar("control_repo"),
-		WorkingRepos: fields.list("working_repos"),
-		Host:         fields.scalar("host"),
-		Status:       Status(fields.scalar("status")),
-		Body:         body,
+		AgentID:         fields.scalar("agent_id"),
+		ProtocolVersion: parseProtocolVersion(fields.scalar("v")),
+		Vendor:          fields.scalar("vendor"),
+		ControlRepo:     fields.scalar("control_repo"),
+		WorkingRepos:    fields.list("working_repos"),
+		Host:            fields.scalar("host"),
+		Status:          Status(fields.scalar("status")),
+		Body:            body,
 	}
 	if reg.Status == "" {
 		reg.Status = StatusActive
@@ -381,6 +385,9 @@ func formatRegistration(r *Registration) string {
 	var b strings.Builder
 	b.WriteString("---\n")
 	writeScalar(&b, "agent_id", r.AgentID)
+	if r.ProtocolVersion != 0 {
+		writeScalar(&b, "v", strconv.Itoa(r.ProtocolVersion))
+	}
 	writeScalar(&b, "vendor", r.Vendor)
 	writeScalar(&b, "control_repo", r.ControlRepo)
 	if len(r.WorkingRepos) > 0 {
@@ -422,6 +429,18 @@ func formatRegistration(r *Registration) string {
 		}
 	}
 	return b.String()
+}
+
+func parseProtocolVersion(value string) int {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return -1
+	}
+	return n
 }
 
 func writeScalar(b *strings.Builder, key, value string) {


### PR DESCRIPTION
PR-B2 (v0.11.8 freeze-prep, GATE-1). Authored by codex (pushed by claude as integrator). Merges after #59 (spec) — done; wording matched.

- Registration writer emits `v: 2`; parser reads it (absent tolerated).
- **Absent `v:` = silent legacy state** — no warning (mixed fleets are the dogfood plan). Only an explicit non-2 `v:` triggers a `doctor`/`status` warning (`protocol_version` check) — diagnostic only, never delivery-blocking.
- The version field ships with its first readers, satisfying the deferral trigger ("first reader or free restamp window" — this release is both).
- Tests: TestRegisterWritesProtocolVersion, TestDoctorProtocolVersionAbsentIsSilent, TestDoctorProtocolVersionMismatchWarns, status-side equivalents. No enrollment-marker bump (no marked-block text changed).

Verification (claude gate: SHIP): full suite + race, crown jewels, drift, conformance — green.

Gates: claude (SHIP) + sonnet.