### PR TITLE
v0.11.8: vector applicability (applies_to) + crash-safety vectors C2/Q1

### DIFF
--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -53,13 +53,16 @@ collapsing the duplicate.
 
 ## Vector format
 
-`vectors/core.json` is intentionally boring: one object per invariant, with an
-`id`, a `kind`, and only the scenario data that a runner needs. It is not a DSL
-and it does not encode implementation details. Runners map each `kind` to the
-small amount of imperative behavior needed to exercise that invariant.
+`vectors/core.json` is intentionally boring: one object per invariant or
+review-gap case, with an `id`, a `kind`, and only the scenario data that a
+runner needs. It is not a DSL and it does not encode implementation details.
+Runners map each `kind` to the small amount of imperative behavior needed to
+exercise that case. `applies_to`, when present, limits a vector to named binding
+profiles such as `inbox`; when omitted, the vector is universal.
 
-Two further tests close the review gaps:
-- **`TestC1_SenderCrashResume`** — the *sender* half of C1. A sender links `seq=N`, crashes before its counter is durable, resumes and re-issues `seq=N`; `EEXIST` makes that a no-op (one copy) and the next message gets `N+1`. It also asserts the **§7 hazard**: reusing a seq for *different* content is silently dropped — making "seq counter must be durable+monotonic, ids unique per process" executable. Most likely to catch a real bug when the per-`(from,to)` allocator is built.
+Additional tests close the review gaps:
+- **`TestC2_SenderCrashResume`** — the *sender* half of C1. A sender links `seq=N`, crashes before its counter is durable, resumes and re-issues `seq=N`; `EEXIST` makes that a no-op (one copy) and the next message gets `N+1`. It also asserts the **§7 hazard**: reusing a seq for *different* content is silently dropped — making "seq counter must be durable+monotonic, ids unique per process" executable. Most likely to catch a real bug when the per-`(from,to)` allocator is built.
+- **`TestQ1_MalformedQuarantineNeverDeliveredOrConsumedOrDropped`** — an inbox-profile vector for §11.1 quarantine: malformed items are observable, never delivered/consumed, and never block valid mail.
 - **`TestD1_FsyncOrdering`** — pins `write(tmp) → fsync(tmp) → link → fsync(dir)` and proves a crash at every step leaves the record absent-or-whole, never torn. Catches linking before fsync (a record that survives a power cut without its body).
 
 ## B1 is the §5 decision, as code

--- a/conformance/conformance_test.go
+++ b/conformance/conformance_test.go
@@ -22,6 +22,45 @@ func eachBinding(t *testing.T, fn func(t *testing.T, b Binding)) {
 	}
 }
 
+func eachApplicableBinding(t *testing.T, v testVector, fn func(t *testing.T, b Binding)) {
+	t.Helper()
+	ran := 0
+	for _, mk := range bindings() {
+		b := mk()
+		if !v.appliesTo(bindingProfile(b)) {
+			continue
+		}
+		ran++
+		t.Run(b.Name(), func(t *testing.T) { fn(t, b) })
+	}
+	if ran == 0 {
+		t.Fatalf("vector %s applies_to matched no bindings", v.ID)
+	}
+}
+
+func (v testVector) appliesTo(profile string) bool {
+	if v.AppliesTo == nil {
+		return true
+	}
+	for _, allowed := range v.AppliesTo {
+		if allowed == profile {
+			return true
+		}
+	}
+	return false
+}
+
+func bindingProfile(b Binding) string {
+	if profiled, ok := b.(interface{ Profile() string }); ok {
+		return profiled.Profile()
+	}
+	return b.Name()
+}
+
+func knownProfile(profile string) bool {
+	return profile == "inbox" || profile == "log"
+}
+
 func must(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {
@@ -35,7 +74,7 @@ func must(t *testing.T, err error) {
 // Catches: a binding that cannot tell a live agent from a long-gone one.
 func TestR1_Presence(t *testing.T) {
 	v := vectorByID(t, "R1", "presence_freshness")
-	eachBinding(t, func(t *testing.T, b Binding) {
+	eachApplicableBinding(t, v, func(t *testing.T, b Binding) {
 		if _, _, reg := b.Presence(v.Agent); reg {
 			t.Fatal("an unregistered agent must not be registered/present")
 		}
@@ -60,7 +99,7 @@ func TestR1_Presence(t *testing.T) {
 // Catches: readers observing torn / half-written messages.
 func TestD1_AtomicVisibility(t *testing.T) {
 	v := vectorByID(t, "D1", "atomic_visibility")
-	eachBinding(t, func(t *testing.T, b Binding) {
+	eachApplicableBinding(t, v, func(t *testing.T, b Binding) {
 		must(t, b.Register(v.Recipient))
 		sd := b.(interface {
 			deliverSlow(string, Msg, chan<- struct{}, <-chan struct{}) error
@@ -88,7 +127,7 @@ func TestD1_AtomicVisibility(t *testing.T) {
 // Catches: dropped coordination messages under load.
 func TestD2_NoOverwrite(t *testing.T) {
 	v := vectorByID(t, "D2", "no_overwrite")
-	eachBinding(t, func(t *testing.T, b Binding) {
+	eachApplicableBinding(t, v, func(t *testing.T, b Binding) {
 		must(t, b.Register(v.Recipient))
 		var wg sync.WaitGroup
 		for i := 0; i < v.Count; i++ {
@@ -111,7 +150,7 @@ func TestD2_NoOverwrite(t *testing.T) {
 // Catches: a binding that reorders one sender's own messages.
 func TestO1_PerSenderFIFO(t *testing.T) {
 	v := vectorByID(t, "O1", "per_sender_fifo")
-	eachBinding(t, func(t *testing.T, b Binding) {
+	eachApplicableBinding(t, v, func(t *testing.T, b Binding) {
 		must(t, b.Register(v.Recipient))
 		for _, body := range v.Bodies {
 			must(t, b.Deliver(v.Recipient, Msg{From: v.Sender, Body: body}))
@@ -134,7 +173,7 @@ func TestO1_PerSenderFIFO(t *testing.T) {
 // Catches: at-most-once consume losing a coordination message on a crash.
 func TestC1_AtLeastOnceIdempotent(t *testing.T) {
 	v := vectorByID(t, "C1", "consume_redelivery")
-	eachBinding(t, func(t *testing.T, b Binding) {
+	eachApplicableBinding(t, v, func(t *testing.T, b Binding) {
 		must(t, b.Register(v.Recipient))
 		must(t, b.Deliver(v.Recipient, v.Message.msg()))
 
@@ -174,7 +213,7 @@ func TestC1_AtLeastOnceIdempotent(t *testing.T) {
 // being accepted.
 func TestE1_Envelope(t *testing.T) {
 	v := vectorByID(t, "E1", "envelope")
-	eachBinding(t, func(t *testing.T, b Binding) {
+	eachApplicableBinding(t, v, func(t *testing.T, b Binding) {
 		must(t, b.Register(v.Recipient))
 		// unknown/future fields are carried but ignorable
 		must(t, b.Deliver(v.Recipient, v.Message.msg()))
@@ -195,7 +234,7 @@ func TestE1_Envelope(t *testing.T) {
 // the privacy posture you are choosing. Run with -v to see the verdict.
 func TestB1_PrivacyFork(t *testing.T) {
 	v := vectorByID(t, "B1", "body_privacy")
-	eachBinding(t, func(t *testing.T, b Binding) {
+	eachApplicableBinding(t, v, func(t *testing.T, b Binding) {
 		must(t, b.Register(v.Recipient))
 		must(t, b.Deliver(v.Recipient, v.Message.msg()))
 		peerSees := b.PeekBodies(v.Recipient, v.Reader)

--- a/conformance/example-python-binding/runner.py
+++ b/conformance/example-python-binding/runner.py
@@ -252,7 +252,15 @@ RUNNERS = {
 
 def main() -> int:
     for vector in load_vectors().values():
-        RUNNERS[vector["kind"]](vector)
+        applies_to = vector.get("applies_to")
+        if applies_to is not None and "inbox" not in applies_to:
+            print(f"skip {vector['id']} {vector['kind']} (not applicable to inbox)")
+            continue
+        runner = RUNNERS.get(vector["kind"])
+        if runner is None:
+            print(f"skip {vector['id']} {vector['kind']} (unknown kind)")
+            continue
+        runner(vector)
         print(f"ok {vector['id']} {vector['kind']}")
     return 0
 

--- a/conformance/inbox_binding.go
+++ b/conformance/inbox_binding.go
@@ -35,6 +35,8 @@ func newInbox() *inboxBinding {
 
 func (b *inboxBinding) Name() string { return "inbox (N private inboxes)" }
 
+func (b *inboxBinding) Profile() string { return "inbox" }
+
 func (b *inboxBinding) Register(id string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/conformance/inbox_malformed_test.go
+++ b/conformance/inbox_malformed_test.go
@@ -14,42 +14,53 @@ import "testing"
 // Inbox-only on purpose: quarantine is a wire/filename-grammar concern
 // specific to the FS+frontmatter substrate. The shared-log binding has no
 // analogous concept — a log record is already-typed Go data, nothing like a
-// bad filename or unparseable YAML can occur once it's in the stream — so
-// this is not run via eachBinding (same rationale as
+// bad filename or unparseable YAML can occur once it's in the stream — so the
+// vector uses applies_to:["inbox"] (same rationale as
 // TestInbox_PostConsumeResendRelandsThenKeyDedup).
-func TestInbox_MalformedQuarantineNeverDeliveredOrConsumedOrDropped(t *testing.T) {
-	b := newInbox()
-	must(t, b.Register("bob"))
+func TestQ1_MalformedQuarantineNeverDeliveredOrConsumedOrDropped(t *testing.T) {
+	v := vectorByID(t, "Q1", "malformed_quarantine")
+	eachApplicableBinding(t, v, func(t *testing.T, b Binding) {
+		ib, ok := b.(*inboxBinding)
+		if !ok {
+			t.Fatalf("malformed quarantine vector ran on unsupported binding %q", b.Name())
+		}
+		if len(v.Bodies) != 2 || len(v.MalformedItems) != 2 {
+			t.Fatalf("malformed quarantine vector needs two valid bodies and two malformed items: %+v", v)
+		}
+		must(t, ib.Register(v.Recipient))
 
-	must(t, b.DeliverRaw("bob", "valid-1", &Msg{From: "alice", Body: "first"}))
-	must(t, b.DeliverRaw("bob", "not-a-valid-message-name.md", nil))
-	must(t, b.DeliverRaw("bob", "valid-2", &Msg{From: "alice", Body: "second"}))
+		first := Msg{From: v.Sender, Body: v.Bodies[0]}
+		second := Msg{From: v.Sender, Body: v.Bodies[1]}
+		must(t, ib.DeliverRaw(v.Recipient, "valid-1", &first))
+		must(t, ib.DeliverRaw(v.Recipient, v.MalformedItems[0], nil))
+		must(t, ib.DeliverRaw(v.Recipient, "valid-2", &second))
 
-	// Never delivered, never blocks/reorders valid mail: Poll shows exactly
-	// the two valid messages, in arrival order, with the malformed item absent.
-	got, _ := b.Poll("bob")
-	if len(got) != 2 || got[0].Body != "first" || got[1].Body != "second" {
-		t.Fatalf("malformed item must not appear in Poll and must not disturb valid message order/continuity; got %+v", got)
-	}
+		// Never delivered, never blocks/reorders valid mail: Poll shows exactly
+		// the two valid messages, in arrival order, with the malformed item absent.
+		got, _ := ib.Poll(v.Recipient)
+		if len(got) != 2 || got[0].Body != v.Bodies[0] || got[1].Body != v.Bodies[1] {
+			t.Fatalf("malformed item must not appear in Poll and must not disturb valid message order/continuity; got %+v", got)
+		}
 
-	// Never silently dropped: it is quarantined (observable), not vanished.
-	mal := b.MalformedItems("bob")
-	if len(mal) != 1 || mal[0] != "not-a-valid-message-name.md" {
-		t.Fatalf("malformed item must be quarantined (observable via MalformedItems), not silently dropped; got %v", mal)
-	}
+		// Never silently dropped: it is quarantined (observable), not vanished.
+		mal := ib.MalformedItems(v.Recipient)
+		if len(mal) != 1 || mal[0] != v.MalformedItems[0] {
+			t.Fatalf("malformed item must be quarantined (observable via MalformedItems), not silently dropped; got %v", mal)
+		}
 
-	// Never counted as consumed: Consume only sees the 2 valid messages.
-	var acts []string
-	n, err := b.Consume("bob", func(m Msg) error { acts = append(acts, m.Body); return nil })
-	must(t, err)
-	if n != 2 || len(acts) != 2 {
-		t.Fatalf("consume must only see the 2 valid messages, never the quarantined item; n=%d acts=%v", n, acts)
-	}
+		// Never counted as consumed: Consume only sees the 2 valid messages.
+		var acts []string
+		n, err := ib.Consume(v.Recipient, func(m Msg) error { acts = append(acts, m.Body); return nil })
+		must(t, err)
+		if n != 2 || len(acts) != 2 {
+			t.Fatalf("consume must only see the 2 valid messages, never the quarantined item; n=%d acts=%v", n, acts)
+		}
 
-	// A second quarantine of a DIFFERENT item is additive, not overwriting —
-	// mirrors the real malformed/ dir accumulating distinct quarantined files.
-	must(t, b.DeliverRaw("bob", "also-bad.md", nil))
-	if mal := b.MalformedItems("bob"); len(mal) != 2 {
-		t.Fatalf("a second malformed item must accumulate, not overwrite the first; got %v", mal)
-	}
+		// A second quarantine of a DIFFERENT item is additive, not overwriting —
+		// mirrors the real malformed/ dir accumulating distinct quarantined files.
+		must(t, ib.DeliverRaw(v.Recipient, v.MalformedItems[1], nil))
+		if mal := ib.MalformedItems(v.Recipient); len(mal) != 2 {
+			t.Fatalf("a second malformed item must accumulate, not overwrite the first; got %v", mal)
+		}
+	})
 }

--- a/conformance/log_binding.go
+++ b/conformance/log_binding.go
@@ -54,6 +54,8 @@ func newLog() *logBinding {
 
 func (b *logBinding) Name() string { return "log (shared append-only stream + cursors)" }
 
+func (b *logBinding) Profile() string { return "log" }
+
 func (b *logBinding) Register(id string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/conformance/seq_durability_test.go
+++ b/conformance/seq_durability_test.go
@@ -37,7 +37,7 @@ func TestD1_FsyncOrdering(t *testing.T) {
 	}
 }
 
-// C1, sender side (crash-resume + EEXIST dedup). The consumer-crash half is in
+// C2, sender side (crash-resume + EEXIST dedup). The consumer-crash half is in
 // TestC1_AtLeastOnceIdempotent; THIS is the sender half and the one most likely
 // to catch a real bug in the per-(from,to) seq allocator.
 //
@@ -49,49 +49,50 @@ func TestD1_FsyncOrdering(t *testing.T) {
 // DIFFERENT content is silently dropped. The test asserts that this is what
 // happens — making the assumption executable, and documenting why the seq
 // counter must be durable+monotonic and ids must be unique per process.
-func TestC1_SenderCrashResume(t *testing.T) {
-	eachBinding(t, func(t *testing.T, b Binding) {
-		must(t, b.Register("bob"))
-		s := NewSeqSender("alice")
+func TestC2_SenderCrashResume(t *testing.T) {
+	v := vectorByID(t, "C2", "sender_crash_resume")
+	eachApplicableBinding(t, v, func(t *testing.T, b Binding) {
+		must(t, b.Register(v.Recipient))
+		s := NewSeqSender(v.Sender)
 
 		// normal send: seq=1 lands
-		seq1, err := s.Send(b, "bob", "m1", "k1")
+		seq1, err := s.Send(b, v.Recipient, v.Message.Body, v.Message.Key)
 		must(t, err)
 		if seq1 != 1 {
 			t.Fatalf("first seq must be 1, got %d", seq1)
 		}
 
 		// CRASH: counter not made durable -> on resume the sender re-issues seq=1
-		s.loseCounter("bob")
-		seqR, err := s.Send(b, "bob", "m1", "k1") // identical resend
+		s.loseCounter(v.Recipient)
+		seqR, err := s.Send(b, v.Recipient, v.Message.Body, v.Message.Key) // identical resend
 		must(t, err)
 		if seqR != 1 {
 			t.Fatalf("resume must re-issue seq=1, got %d", seqR)
 		}
 
 		// EEXIST made the resend a no-op: exactly one copy of m1.
-		got, _ := b.Poll("bob")
-		if n := count(got, "m1"); n != 1 {
-			t.Fatalf("EEXIST must dedup the crash-resend; want 1 copy of m1, got %d", n)
+		got, _ := b.Poll(v.Recipient)
+		if n := count(got, v.Message.Body); n != 1 {
+			t.Fatalf("EEXIST must dedup the crash-resend; want 1 copy of %s, got %d", v.Message.Body, n)
 		}
 
 		// the next genuinely-new message gets the next seq and lands.
-		seq2, err := s.Send(b, "bob", "m2", "k2")
+		seq2, err := s.Send(b, v.Recipient, v.NextMessage.Body, v.NextMessage.Key)
 		must(t, err)
 		if seq2 != 2 {
 			t.Fatalf("next message must get seq=2, got %d", seq2)
 		}
-		got, _ = b.Poll("bob")
-		if count(got, "m2") != 1 {
-			t.Fatal("m2 must land")
+		got, _ = b.Poll(v.Recipient)
+		if count(got, v.NextMessage.Body) != 1 {
+			t.Fatalf("%s must land", v.NextMessage.Body)
 		}
 
 		// HAZARD (executable §7 assumption): reusing an already-landed seq for
 		// DIFFERENT content is SILENTLY DROPPED. This is why the impl MUST keep
 		// the seq counter durable+monotonic and give each process a unique id.
-		must(t, b.Deliver("bob", Msg{From: "alice", Body: "DIFFERENT", Seq: 1}))
-		got, _ = b.Poll("bob")
-		if count(got, "DIFFERENT") != 0 {
+		must(t, b.Deliver(v.Recipient, v.DifferentMsg.msg()))
+		got, _ = b.Poll(v.Recipient)
+		if count(got, v.DifferentMsg.Body) != 0 {
 			t.Fatal("expected the seq-reuse-with-different-content to be dropped (the documented hazard)")
 		}
 		t.Logf("HAZARD confirmed: reusing seq for different content is dropped -> seq counter MUST be durable+monotonic, ids unique per process (§7).")

--- a/conformance/vectors/core.json
+++ b/conformance/vectors/core.json
@@ -41,6 +41,16 @@
       "message": {"from": "alice", "body": "do-it", "key": "k1"}
     },
     {
+      "id": "C2",
+      "kind": "sender_crash_resume",
+      "name": "sender crash before durable counter reissues the same seq safely",
+      "recipient": "bob",
+      "sender": "alice",
+      "message": {"body": "m1", "key": "k1"},
+      "next_message": {"body": "m2", "key": "k2"},
+      "different_message": {"from": "alice", "body": "DIFFERENT", "seq": 1}
+    },
+    {
       "id": "E1",
       "kind": "envelope",
       "name": "unknown fields are ignored and from is required",
@@ -55,6 +65,16 @@
       "recipient": "bob",
       "reader": "carol",
       "message": {"from": "alice", "body": "secret for bob"}
+    },
+    {
+      "id": "Q1",
+      "kind": "malformed_quarantine",
+      "name": "malformed items are quarantined without blocking valid inbox mail",
+      "applies_to": ["inbox"],
+      "recipient": "bob",
+      "sender": "alice",
+      "bodies": ["first", "second"],
+      "malformed_items": ["not-a-valid-message-name.md", "also-bad.md"]
     }
   ]
 }

--- a/conformance/vectors_test.go
+++ b/conformance/vectors_test.go
@@ -19,6 +19,7 @@ type testVector struct {
 	ID             string    `json:"id"`
 	Kind           string    `json:"kind"`
 	Name           string    `json:"name"`
+	AppliesTo      []string  `json:"applies_to,omitempty"`
 	Agent          string    `json:"agent,omitempty"`
 	Recipient      string    `json:"recipient,omitempty"`
 	Reader         string    `json:"reader,omitempty"`
@@ -30,7 +31,10 @@ type testVector struct {
 	StaleSeconds   int       `json:"stale_seconds,omitempty"`
 	Bodies         []string  `json:"bodies,omitempty"`
 	Message        vectorMsg `json:"message,omitempty"`
+	NextMessage    vectorMsg `json:"next_message,omitempty"`
+	DifferentMsg   vectorMsg `json:"different_message,omitempty"`
 	InvalidMessage vectorMsg `json:"invalid_message,omitempty"`
+	MalformedItems []string  `json:"malformed_items,omitempty"`
 }
 
 type vectorMsg struct {
@@ -73,12 +77,13 @@ func loadVectors(t *testing.T) map[string]testVector {
 		if v.ID == "" || v.Kind == "" {
 			t.Fatalf("invalid vector with missing id/kind: %+v", v)
 		}
+		validateAppliesTo(t, v)
 		if _, exists := out[v.ID]; exists {
 			t.Fatalf("duplicate vector id %q", v.ID)
 		}
 		out[v.ID] = v
 	}
-	for _, id := range []string{"R1", "D1", "D2", "O1", "C1", "E1", "B1"} {
+	for _, id := range []string{"R1", "D1", "D2", "O1", "C1", "C2", "E1", "B1", "Q1"} {
 		if _, ok := out[id]; !ok {
 			t.Fatalf("missing vector %s", id)
 		}
@@ -103,4 +108,24 @@ func (v testVector) senderFor(i int) string {
 		return v.SenderPrefix
 	}
 	return fmt.Sprintf("%s%d", v.SenderPrefix, i%v.SenderModulo)
+}
+
+func validateAppliesTo(t *testing.T, v testVector) {
+	t.Helper()
+	if v.AppliesTo == nil {
+		return
+	}
+	if len(v.AppliesTo) == 0 {
+		t.Fatalf("vector %s has empty applies_to; omit it for universal", v.ID)
+	}
+	seen := map[string]bool{}
+	for _, profile := range v.AppliesTo {
+		if !knownProfile(profile) {
+			t.Fatalf("vector %s applies_to has unknown profile %q", v.ID, profile)
+		}
+		if seen[profile] {
+			t.Fatalf("vector %s applies_to repeats profile %q", v.ID, profile)
+		}
+		seen[profile] = true
+	}
 }


### PR DESCRIPTION
PR-B4 (v0.11.8 freeze-prep). Authored by codex (pushed by claude as integrator).

- **`applies_to` lands in vectors-v1, schema-wide**: array; **omitted = universal** (existing 7 vectors unchanged); the Go runner filters per binding profile. Machine-readable applicability — no conventions for external consumers to reverse-engineer.
- **C2 sender-crash-resume** — universal vector (the crash half of the lifecycle promise, now language-neutral).
- **Q1 malformed-quarantine** — `applies_to: ["inbox"]` (the shared-log binding has no bad-filename analogue). The ratified applicability split, exactly.
- **Python proof forward-tolerance** (gate fix): `runner.py` now *skips with a printed note* on unknown vector kinds and non-inbox `applies_to` instead of crashing — modeling correct third-party consumer behavior while still proving its original seven invariants. No padding vectors.

Verification (claude gate: SHIP): conformance suite (all 11 tests incl. C2/Q1), python proof (7 ok + 2 clean skips), full root suite + race, crown jewels — green.

Gates: claude (SHIP) + sonnet.