### PR TITLE
ci: setup-go stable + check-latest — fix macOS LC_UUID break (P0)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.21'
+          go-version: 'stable'
+          check-latest: true
       - name: gofmt
         if: matrix.os == 'ubuntu-latest'
         run: |


### PR DESCRIPTION
**P0** — restores the required macOS CI check (currently red on `main`, blocking all merges and the v0.11.8 tag). Authored by codex.

**Root cause (confirmed):** GitHub floated the `macos-latest` runner image mid-session — commit `6491d2dd` passed macOS at 19:37; the identical code merged as `b61c490` failed at 19:39. On the new image, Go 1.21's linker doesn't emit `LC_UUID` the way the updated macOS dyld now enforces (`dyld: missing LC_UUID` aborts the test binary; `TestStartInheritSize` sees an empty winsize). Not a code regression — passes 20/20 locally on darwin.

**Fix (Option A, root-cause):** `actions/setup-go@v6` with `go-version: stable` + `check-latest: true`. Fixes the toolchain vs new-image class directly and doesn't pin CI to an aging macOS image. `go.mod` stays `go 1.21` — the project compatibility floor does not move. (Option B — pin `macos-14` — kept as a fallback only if `stable` unexpectedly fails on GitHub.)

Diff is `ci.yaml` only. codex verified locally on Go 1.26.4 darwin/arm64 (full suite + race + conformance + crown jewels + resize test + python proof + goreleaser check). **The real proof is this PR's own macOS CI leg going green.**

Gates: claude + sonnet (sonnet reviews as a co-reviewer since this touches the macOS gate she added; she is not the sole gate on her own addition).