### PR TITLE
fix(test): eliminate PTY startup-size test flake on macOS CI

### DIFF
--- a/internal/runner/pty/pty_size_test.go
+++ b/internal/runner/pty/pty_size_test.go
@@ -12,6 +12,18 @@ import (
 // The child must observe the inherited window size on its very first read,
 // before any SIGWINCH/resize loop runs. A child started on a 0x0 PTY renders
 // a blank screen in ratatui/Ink TUIs (the "blank boxes" startup race).
+//
+// creack/pty's StartWithAttrs calls Setsize on the new pty and checks its
+// error BEFORE cmd.Start() ever forks the child (run.go) — there is no
+// product-level window where the child can run before the size is applied.
+// What IS racy under CI scheduling is forking/exec'ing "stty size" and
+// getting its output back to us: a single eager Read can lose that race
+// (or observe a spurious empty read) even though the pty was correctly
+// sized from the first instant the child could read it. Poll with a tight
+// budget instead of trusting one Read to land in time. This stays a hard
+// assertion on STARTUP sizing — the budget is short specifically so it
+// cannot be satisfied by the separate SIGWINCH heal path (which this
+// isolated test doesn't even wire up).
 func TestStartInheritSizeChildSeesInitialSize(t *testing.T) {
 	master, slave, err := creackpty.Open()
 	if err != nil {
@@ -32,22 +44,38 @@ func TestStartInheritSizeChildSeesInitialSize(t *testing.T) {
 	}
 	defer ptmx.Close()
 
-	done := make(chan string, 1)
+	chunks := make(chan string, 16)
 	go func() {
 		buf := make([]byte, 256)
-		n, _ := ptmx.Read(buf)
-		done <- string(buf[:n])
+		for {
+			n, err := ptmx.Read(buf)
+			if n > 0 {
+				chunks <- string(buf[:n])
+			}
+			if err != nil {
+				close(chunks)
+				return
+			}
+		}
 	}()
 
-	select {
-	case out := <-done:
-		if !strings.Contains(out, "41 97") {
-			t.Fatalf("child saw winsize %q at startup, want \"41 97\"", strings.TrimSpace(out))
+	deadline := time.After(500 * time.Millisecond)
+	var got strings.Builder
+	for {
+		select {
+		case chunk, ok := <-chunks:
+			if !ok {
+				t.Fatalf("child output ended before showing winsize within 500ms; got %q", got.String())
+			}
+			got.WriteString(chunk)
+			if strings.Contains(got.String(), "41 97") {
+				_ = cmd.Wait()
+				return
+			}
+		case <-deadline:
+			t.Fatalf("child saw winsize %q within 500ms at startup, want \"41 97\"", strings.TrimSpace(got.String()))
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for child output")
 	}
-	_ = cmd.Wait()
 }
 
 // When the source fd has no usable size (not a terminal, or 0x0), fall back


### PR DESCRIPTION
## Summary
`TestStartInheritSizeChildSeesInitialSize` was flaky on macOS CI (P0-adjacent, held v0.11.8): #67's macOS leg passed, #66's failed, same commit and toolchain (go1.26.4), different runner instances.

Verified against creack/pty's actual source (`run.go:StartWithAttrs`) that `Setsize` on the new pty is called and its error checked **before** `cmd.Start()` ever forks the child — there is no product-level race in `StartInheritSize` itself. The bug was in the test's read path: `n, _ := ptmx.Read(buf)` discarded the read error and unconditionally sent `buf[:n]`. Under CI scheduling variance (forking/exec'ing `stty size` has real latency on a loaded runner), that single eager read could return 0 bytes with an error it never checked, reporting a spurious empty winsize even though the pty was sized correctly the entire time.

Fix: replaced the single read with a bounded accumulate-and-poll loop (500ms budget) — keep reading chunks until `"41 97"` appears or the deadline passes. Kept the budget short and the assertion hard on purpose: the isolated test doesn't wire up the SIGWINCH heal path at all, so there's no way for this to pass via "eventually healed" — it can only pass by observing the correct size promptly at startup, which is the actual property this test exists to prove.

Verified the fix isn't a rubber stamp: temporarily broke `StartInheritSize`'s sizing path locally (forced it to always start unsized) and confirmed the new test still fails immediately (`"0 0"` well within the 500ms budget), then reverted.

## Test plan
- [x] `go build ./...`, `gofmt -l .`, `go vet ./...` — clean
- [x] `go test ./internal/runner/pty/... -run TestStartInheritSize -race -count=50 -v` — 50/50 clean
- [x] Deliberately broke `StartInheritSize`'s sizing logic locally — new test fails correctly within budget; reverted before committing
- [x] `go test ./...` and `go test -race ./...` full root suite (env stripped of `AGENTCHUTE_*`) — clean
- [x] `go test ./conformance/...` — clean
- [x] `go test ./internal/cli/... -run TestPromptInjectionBytes` (crown jewel) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)