### PR TITLE
docs: F1 — retire forward-looking 'frozen' for 'stable/final' (0.11.8 review)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ This sequencing prevents implementations diverging from the spec.
 To guarantee pool stability and coordinate independent implementations, we maintain a two-axis versioning contract:
 
 ### 1. Protocol Version (AGENTCHUTE.md)
-- Protocol v2 is stable; its covenants change only through the deprecation process below. A breaking change would be Protocol v3. At CLI v1.0.0 the protocol will be declared frozen; the two-axis contract below takes full effect then (until v1.0.0, the v0.x rules continue to apply to the CLI line).
+- Protocol v2 is stable; its covenants change only through the deprecation process below. A breaking change would be Protocol v3. At CLI v1.0.0 this stability is formally declared final; the two-axis contract below takes full effect then (until v1.0.0, the v0.x rules continue to apply to the CLI line).
 
 ### 2. Reference CLI Version (SemVer)
 - The CLI implements the corresponding protocol version (e.g., CLI 1.x implements Protocol v2).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ That's the reference CLI. The protocol itself is just files — a filesystem imp
 ## Project Status: Protocol + Reference Implementation, Not a Product
 
 agentchute is a coordination protocol and a reference implementation, not a product.
-- **The Protocol** follows a frozen-protocol trajectory: Protocol v2 is stable and will be declared frozen at the 1.0 release.
+- **The Protocol** follows a stability trajectory: Protocol v2 is stable — its covenants change only through the versioned deprecation process — and that stability is formally declared final at the 1.0 release.
 - **The Reference CLI** is maintained strictly for fidelity to the specification. It does not carry commercial support, operational SLAs, or product features like deployment automation.
 - **Alternative Implementations** are welcome and encouraged; the conformance vectors exist as an ecosystem primitive to certify independent implementations on any substrate.
 


### PR DESCRIPTION
F1 from the v0.11.8 review (must-fix before/with the v1.0.0 tag): the two forward-declarations of 'frozen' (CONTRIBUTING.md:89, README.md:36) are reworded per the owner's launch-messaging decision (frozen reads abandoned → stable/won't-break; substance unchanged). gemini authored; I polished the 'is stable and will be declared stable' redundancy to 'stability is formally declared final' — gates please verify that phrasing. Historical 'frozen' usages untouched per the review. Non-embedded files → zero dogfood impact. F2 (the §2 '(v2)' one-worder) deliberately HELD to ride the v1.0.0 tag (embedded spec; avoids fleet-wide spec_freshness noise mid-window). Gates: codex + sonnet (quick).