### PR TITLE
web: sitemap.xml + robots.txt

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://agentchute.dev/sitemap.xml

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://agentchute.dev/</loc></url>
+  <url><loc>https://agentchute.dev/spec.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/</loc></url>
+  <url><loc>https://agentchute.dev/blog/v1-0-done-not-big.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/after-done-roadmap.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/v0-8-0-simple-again.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/agents-debugged-their-own-bus.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/you-are-the-message-bus.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/v0-3-5-contextual-identity-worktrees.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/v0-3-4-contextual-identity-worktrees.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/v0-3-2-setup-and-shims.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/v0-2-1-enrollment-enforced.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/v0-2-recipient-polling.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/v0-1-2-doctor-watch-no-tmux.html</loc></url>
+  <url><loc>https://agentchute.dev/blog/v0-1-1-the-agents-shipped-it-themselves.html</loc></url>
+</urlset>


### PR DESCRIPTION
Accelerates indexing of the fresh agentchute.dev deploy (currently absent from search indexes). 15 URLs = the exact set of live pages; excludes the 301'd old slug. No lastmod — no honest per-page dates to pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)