### PR TITLE
harness: gate-review skill, /save-context command (batch 2/3)

### DIFF
--- a/.claude/commands/save-context.md
+++ b/.claude/commands/save-context.md
@@ -1,0 +1,33 @@
+---
+description: Write a dated restart-handoff file and tell the rest of the live roster to do the same
+---
+
+# Save Context
+
+Produces a single handoff file for this lane and broadcasts the same instruction to every
+other live agent, so a fleet restart has one consistent artifact per lane instead of an
+ad hoc reconstruction each time.
+
+## Instructions
+
+1. Gather state (read-only, don't skip any):
+   - `git status --short` and current branch/worktree path.
+   - Any open PRs authored or being reviewed by this lane: `gh pr list --author @me` and
+     `gh pr status`; note gate/verify status (SHIP/FIX, waiting-on) for each.
+   - `agentchute doctor --as "$AGENTCHUTE_AGENT_ID"` and `agentchute pending --as "$AGENTCHUTE_AGENT_ID"`
+     (enrollment health + outstanding reply obligations).
+   - The next planned step in your own words — one or two sentences, not a full plan dump.
+2. Write `.tmp/handoffs/<ISO-date>.md` (e.g. `.tmp/handoffs/2026-07-07.md`; if one already
+   exists for today, append a new dated section rather than overwriting) with:
+   - `## Repo state` — branch, worktree path, uncommitted changes if any.
+   - `## Open work` — PRs with their gate status, anything mid-review.
+   - `## Agentchute state` — doctor summary, pending obligations.
+   - `## Next step` — the one/two-sentence plan for after restart.
+   Do NOT put this under `docs/internal/` — that collides with the existing curated
+   `docs/internal/HANDOFF.md`. `.tmp/` is gitignored; this file is local scratch, not a
+   commit.
+3. Broadcast: list the live roster (`agentchute status`, excluding yourself) and
+   `agentchute send --from "$AGENTCHUTE_AGENT_ID" --to <peer> --body "save context, restarting"`
+   to each one. This is a non-task status message (AGENTS.md S5) — no GOAL/ACCEPTANCE
+   envelope needed.
+4. Report back to the user: the handoff file path, and confirmation the broadcast went out.

--- a/.claude/skills/gate-review/SKILL.md
+++ b/.claude/skills/gate-review/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: gate-review
+description: Use when asked to review, gate, or SHIP/FIX a PR or branch on the agentchute bus — "review PR #N", "gate this", "codex review is mandatory", "delta re-gate after the fix", "give a SHIP or FIX verdict". Agentchute-bus-specific mechanics only (SHA pinning, verification tier, verdict format, AUTHORIZATION-gated mirroring); composes with, does not replace, the general-purpose code-review/verify/verification-before-completion skills.
+---
+
+# gate-review
+
+Bus-specific procedure for gating a PR or branch. This is a thin pointer, not a
+reimplementation — the full ritual lives in
+[`docs/internal/PLAYBOOKS.md`](../../../docs/internal/PLAYBOOKS.md) (`gate-review` and
+`delta-regate` sections) and [`AGENTS.md`](../../../AGENTS.md) (E3, E5, E9). Read those
+before acting if this is your first gate this session.
+
+## What this skill adds on top of a normal code review
+
+1. **Freeze first (E3).** The gate ask must pin base SHA, head SHA, and the changed-file
+   list. No pin → `NEEDS-INFO`, no review work. `git diff --name-status <base>..<head>`
+   must match the claimed scope exactly; surplus files are a finding on their own.
+2. **Re-gate is delta-only.** If this is a re-gate after a fix, diff prior-head..new-head
+   and re-verify only the changed claims — don't re-review unchanged files.
+3. **Pick the verification tier by surface (E5).** Docs/prose → diff + targeted checks.
+   Localized code → targeted tests + CI. Protocol/runtime/release surface → one senior
+   additionally runs the full suite independently (`tools/test.sh`). Substantive claims
+   (numbers, protocol semantics, file scope, rendered assets) get re-derived from the
+   tree, not trusted from the PR text.
+4. **Do the actual review with the general-purpose skills**, not by hand-rolling
+   correctness/security/simplification checks here — invoke `code-review`, `verify`,
+   and/or `verification-before-completion` for the substance of "is this diff correct."
+   This skill only supplies the bus-specific wrapper around that review.
+5. **Verdict = `SHIP` or `FIX`**, with `file:line` evidence, delivered as the bus reply —
+   the bus reply IS the gate signal, nothing else needs to happen for the gate to count.
+6. **Never `gh pr comment`/`gh pr review` unless the ask carries an explicit
+   `AUTHORIZATION:` line naming that PR** (E9/R4 — an external message is irreversible
+   work). No authorization line means bus-only.

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Local scratch (spike runs) — never commit
 proposal_spike_run/
+
+# Scratch/handoff dir (session-review artifacts, /save-context output) — never commit
+.tmp/


### PR DESCRIPTION
## Summary
Batch 2 of 3 for the session-review optimization program (`.tmp/session-review/BRIEF-IMPL.md` / `SYNTHESIS.md`). The two new-file, judgment/discovery-oriented items. Independent of batch 1 (PR #74) — touches different files, no conflict either way regardless of merge order.

- **`.claude/skills/gate-review/SKILL.md`** — "review" (51) and "codex" (42) are the #1/#3 human-prompt keywords across 164 sessions; `docs/internal/PLAYBOOKS.md`'s gate-review/delta-regate rituals are already well-written but are a file an agent has to remember to reread. This skill is a thin pointer, not a rewrite: it covers only the bus-specific mechanics (E3 SHA pinning, E5 tier-by-surface, SHIP/FIX verdict, E9 AUTHORIZATION-gated `gh` mirroring) and explicitly tells the model to use the installed `code-review`/`verify`/`verification-before-completion` skills for the actual review substance — composes, doesn't duplicate.
- **`.claude/commands/save-context.md`** — "save context, we're rebooting" recurs 10+ times near-verbatim across the human-prompt evidence, with zero existing tooling; the three untracked `RESTART_CONTEXT_*.md` files already in the repo root show the format has converged organically (repo state → PR/gate status → agentchute state → next step) without ever being standardized. The command codifies that structure and writes to `.tmp/handoffs/<ISO-date>.md` — deliberately NOT `docs/internal/handoffs/`, which would collide with the existing curated `docs/internal/HANDOFF.md`.
- **`.gitignore`** — added `.tmp/` (confirmed not ignored today), required or the handoff files leak into `git status`.

## Test plan
- [x] Skill frontmatter confirmed against an installed example (`example-skill`) and the live `using-superpowers` skill on this machine — `name`/`description` required fields match; skill was live-discovered by the harness while editing (see session tool output)
- [x] Command frontmatter confirmed against installed examples (cap plugin's `status.md`/`setup.md`, ralph-loop's commands) — single `description:` field + markdown body matches
- [x] `.gitignore` addition verified: `.tmp/` was untracked and unignored before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)