### PR TITLE
chore(gitignore): harden against runtime/scratch ballast (cleanup stage 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,12 @@
 # --- manual (survives agentchute init) ---
 .agentchute/loop/live/
 .agentchute/loop/*.log
-/.tmp/
-/.claude/
+# .codex/ and .gemini/ hold only local hook wiring (0 tracked files); .claude/ is
+# NOT blanket-ignored — it tracks settings.json + skills/ + commands/ (PR #74/#75),
+# so ignore only its local override. .tmp/ is already covered above.
 /.codex/
 /.gemini/
+.claude/settings.local.json
 *.bak
 
 # Local scratch (spike runs) — never commit

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,15 @@
 .agentchute/loop/scratch-*
 # agentchute-gitignore v3 end
 
+# --- manual (survives agentchute init) ---
+.agentchute/loop/live/
+.agentchute/loop/*.log
+/.tmp/
+/.claude/
+/.codex/
+/.gemini/
+*.bak
+
 # Local scratch (spike runs) — never commit
 proposal_spike_run/
 


### PR DESCRIPTION
Cleanup **Stage 1** tracked change (3-way agreed plan `CLEANUP-PLAN-3way.md` §F). The untracked-ballast deletion + worktree prune/remove of Stage 1 were operational (no PR); this PR is only the `.gitignore` hardening.

## What
Adds a manual block below the `agentchute-gitignore v3` marker (survives `agentchute init`) covering paths that were **NOT** ignored and could be swept in by a stray `git add -A`:
- `.agentchute/loop/live/` + `.agentchute/loop/*.log` — live bus presence + the removed-watchdog log (contradicted `loop/README.md`'s "live is gitignored")
- `/.codex/` `/.gemini/` — local hook wiring (0 tracked files)
- `.claude/settings.local.json` — the local override only
- `*.bak`

## Deviations from plan §F (caught at execution — for gate attention)
§F literally listed `/.tmp/ /.claude/ /.codex/ /.gemini/`. Corrected:
- **Dropped `/.tmp/`** — already ignored on `main` (PR #75 added `.tmp/`). Redundant.
- **Dropped `/.claude/`** — post-#74/#75, `.claude/` tracks `settings.json` + `skills/gate-review/` + `commands/save-context.md`. A blanket `/.claude/` would silently ignore any *future* skill/command added there. Narrowed to `.claude/settings.local.json`. Verified: `git check-ignore` does NOT match the 3 tracked `.claude/` files.

## Gate
claude + sonnet 2-senior gated the Stage-1 command list. This `.gitignore` deviation is a claude execution-time correction; sonnet to concur on the narrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)