### PR TITLE
docs: refresh stale doc/comment references (cleanup stage 2)

### DIFF
--- a/.agentchute/loop/README.md
+++ b/.agentchute/loop/README.md
@@ -6,12 +6,15 @@ Live coordination state for agents working on the agentchute codebase. Follows t
 
 - `README.md` — this file.
 - `agents/` — agent registrations (tracked examples + format reference; live registrations gitignored).
+- `live/` — current presence facts (gitignored).
 - `inbox/<recipient>/` — per-recipient inbox queue (gitignored).
 - `archive/` — consumed messages (gitignored).
+- `state/` — per-agent local runtime state (gitignored).
+- `malformed/` — quarantined malformed items (gitignored).
 
 ## Currently registered agents
 
-Live state is gitignored; check `agents/*.md` (not `.example.md`) locally for who's currently in the loop.
+Live state, runtime state, and loop logs are gitignored; check `agents/*.md` (not `.example.md`) locally for who's currently in the loop.
 
 Example registrations are tracked:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for considering it. Three things up-front:
 
 2. **The binary is intentionally small.** agentchute's pitch is "a few markdown files and a pull-only inbox." If a PR adds a dependency, a config file, a new subcommand category, or a feature that requires explanation, the bar is high. We'd rather ship less.
 
-3. **Test what you change.** If you fix a bug, add a test that fails without the fix. If you add a feature, integration tests > unit tests for v0.1.0. Run the full pre-commit ritual before sending the PR:
+3. **Test what you change.** If you fix a bug, add a test that fails without the fix. If you add a feature, prefer integration tests over deep unit-test scaffolding. Run the full pre-commit ritual before sending the PR:
 
    ```sh
    gofmt -w .
@@ -49,9 +49,9 @@ No new third-party dependencies beyond the existing PTY runner dependency (`gith
 
 ## What's not in scope
 
-For v0.x:
+Outside the reference CLI:
 
-- Non-filesystem inbox transports in the v0.1 reference CLI. Alternate transports (queues, HTTP, object stores) are protocol-compatible per EXTENSIONS.md but don't ship in v0.1. Within the v0.1 CLI, pool participants must share one filesystem — cross-machine over a network mount is in scope, cross-filesystem inside one v0.1 pool is not.
+- Non-filesystem inbox transports. Alternate transports (queues, HTTP, object stores) are protocol-compatible per EXTENSIONS.md but don't ship in the reference CLI. Within one pool, participants must share one filesystem — cross-machine over a network mount is in scope, cross-filesystem inside one pool is not.
 - Wildcard inboxes / broadcast / self-claim mechanisms (deliberately excluded — see `AGENTCHUTE.md` §7 / §12).
 - Capability-based routing (also deliberately excluded).
 - Built-in role/election machinery.

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -127,7 +127,7 @@ pointer file (§4.1). The hazards are what matter:
 
 ## Not extension space
 
-Some things are excluded by design or reserved for a future protocol version.
+Some things are excluded by design and stay outside the core protocol.
 Don't ship a fork that adds these under the agentchute name:
 
 - **Routing / role assignment / wildcard inboxes** (§7, §12) — agents are peers;
@@ -137,7 +137,7 @@ Don't ship a fork that adds these under the agentchute name:
 - **Durable / authenticated audit trail** (§12) — archive is gitignored; use a
   layered protocol for durable transcripts. (The opt-in shared-`log` binding in
   [`conformance/`](conformance/) is the first-class audit profile — a v2 item.)
-- **Coordinator / router agents** (§13) — reserved for v2.
+- **Coordinator / router agents** (§12) — excluded from the core protocol.
 
 Shipping the smallest thing that works is the point. Every adapter the reference
 CLI doesn't carry is one less dependency and one less interpretation of "what

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ What's next lives **around** the stable core, never inside the wire — self-ser
 
 ## Spec, hacking, license
 
-The protocol is [`AGENTCHUTE.md`](AGENTCHUTE.md); the binary is one reference implementation. Behavior changes start with the spec and the [conformance vectors](conformance/). Tested targets and operational assumptions are in the support matrix in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+The protocol is [`AGENTCHUTE.md`](AGENTCHUTE.md); the binary is one reference implementation. Behavior changes start with the spec and the [conformance vectors](conformance/). Tested targets and operational assumptions are in [`AGENTCHUTE.md` §2](AGENTCHUTE.md#2-scope).
 
 ```sh
 git clone https://github.com/agentchute/agentchute

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -6,7 +6,7 @@ Four deliverables in one package:
    protocol's invariant cases without depending on Go.
 2. **A conformance harness** — the vectors run as a Go test suite against **two
    bindings** so any substrate is checked on equal footing.
-3. **The shared-log model** (`log_binding.go`) — the §5 fork as ~90 lines of
+3. **The shared-log model** (`log_binding.go`) — the §5 fork as
    working code, exercised by the same suite and demo as the inbox model.
 4. **A disposable Python proof** — `example-python-binding/runner.py` reads the
    same vectors against a stdlib-only inbox binding. It is a snapshot, not a
@@ -105,6 +105,6 @@ over a substrate's real CLI/ACL boundary instead of a Go interface.
 
 Tested on Linux (Go 1.22, clean container): suite + both demos pass as shown.
 The bindings are modeled in-memory for deterministic concurrency/crash tests;
-the SEMANTICS match the real substrates (filesystem inbox = `../ach`; the log =
+the SEMANTICS match the real substrates (filesystem inbox = `internal/loop`; the log =
 an append file / git branch / Redis Stream / Kafka). This proves the model
 behavior and the invariant set — not a production storage layer.

--- a/conformance/inbox_binding.go
+++ b/conformance/inbox_binding.go
@@ -9,7 +9,7 @@ import (
 // inboxBinding = the N-PRIVATE-INBOXES model (today's agentchute).
 //
 // Reference storage is the filesystem: one directory per agent, files as
-// messages, `ln` for no-overwrite, tmp+rename for atomic visibility (see ../ach).
+// messages, `ln` for no-overwrite, tmp+rename for atomic visibility (see internal/loop).
 // Modeled in-memory here ONLY so the suite can drive concurrency and crashes
 // deterministically — the semantics are identical to the FS binding.
 //

--- a/conformance/log_binding.go
+++ b/conformance/log_binding.go
@@ -28,7 +28,7 @@ import (
 // What it COSTS (also shown):
 //   - B1 is VOID — every agent can read every record. No private bodies.
 //
-// This is the whole alternate model the team asked for, in ~90 lines. The decision is:
+// This is the whole alternate model the team asked for. The decision is:
 // is inter-agent privacy a real requirement for your pools? If not, this model
 // is simpler AND more robust than N inboxes, and deletes the ordering fiction
 // and the separate presence primitive in one move.

--- a/docs/internal/PLAYBOOKS.md
+++ b/docs/internal/PLAYBOOKS.md
@@ -1,6 +1,6 @@
 # Playbooks — the recurring bus rituals
 
-Companion to the **Working efficiently on this bus** rules in [`AGENTS.md`](../../AGENTS.md) (E1–E9). Each playbook is the step sequence; the E-rules say when it's mandatory. `$ID` is your pinned lane id.
+Companion to the **Working efficiently on this bus** rules in [`AGENTS.md`](../../AGENTS.md) (E1–E10). Each playbook is the step sequence; the E-rules say when it's mandatory. `$ID` is your pinned lane id.
 
 ## bus-turn (per wake cue — E8)
 

--- a/internal/loop/inbox.go
+++ b/internal/loop/inbox.go
@@ -261,12 +261,10 @@ func parseAnyInboxName(name string, modTime time.Time) (Message, bool) {
 // The move is atomic via os.Rename when source and destination share a
 // filesystem (the normal case for in-repo state).
 // ArchiveMessageDest returns the absolute archive path ArchiveMessage will
-// write for the given message and consumedAt time, WITHOUT touching the
-// filesystem. It is deterministic in (consumedAt, recipient, msg.Filename), so
-// `check` can record the pending-reply obligation with the correct archive_path
-// BEFORE the message is moved out of the inbox (record-before-archive). The
-// returned path stays valid as long as ArchiveMessage is called with the same
-// arguments.
+// write for the given message and consumedAt time, without touching the
+// filesystem. It is deterministic in (consumedAt, recipient, msg.Filename);
+// the returned path stays valid as long as ArchiveMessage is called with the
+// same arguments.
 func ArchiveMessageDest(msg Message, archiveDir, recipient string, consumedAt time.Time) string {
 	archivedName := fmt.Sprintf("%s_to-%s_%s", formatArchiveTimestamp(consumedAt), recipient, msg.Filename)
 	return filepath.Join(archiveDir, archivedName)

--- a/internal/loop/message_test.go
+++ b/internal/loop/message_test.go
@@ -119,8 +119,8 @@ func TestCorrectiveBodyFormat(t *testing.T) {
 
 func TestSendCorrectiveWritesMessageAndSkipsPokeForEmptyTarget(t *testing.T) {
 	cfg := setupAnnounceFixture(t)
-	newReg(t, cfg, "claude-code", "anthropic", "", "")    // self
-	offender := newReg(t, cfg, "codex", "openai", "", "") // offender (pull-only: delivery is inbox-write only, no poke)
+	newReg(t, cfg, "claude-code", "anthropic", "")    // self
+	offender := newReg(t, cfg, "codex", "openai", "") // offender (pull-only: delivery is inbox-write only, no poke)
 
 	msg, err := SendCorrective(cfg, "claude-code", offender.AgentID,
 		".agentchute/loop/malformed/bad.md", "filename does not match §6.1", "§6.1")
@@ -153,8 +153,8 @@ func TestSendCorrectiveWritesMessageAndSkipsPokeForEmptyTarget(t *testing.T) {
 // land in the offender's inbox.
 func TestSendCorrectiveRetryWithSameItemDedups(t *testing.T) {
 	cfg := setupAnnounceFixture(t)
-	newReg(t, cfg, "claude-code", "anthropic", "", "") // self
-	offender := newReg(t, cfg, "codex", "openai", "", "")
+	newReg(t, cfg, "claude-code", "anthropic", "") // self
+	offender := newReg(t, cfg, "codex", "openai", "")
 
 	msg1, err := SendCorrective(cfg, "claude-code", offender.AgentID,
 		".agentchute/loop/malformed/bad.md", "filename does not match §6.1", "§6.1")
@@ -184,8 +184,8 @@ func TestSendCorrectiveRetryWithSameItemDedups(t *testing.T) {
 // an unrelated corrective's key.
 func TestSendCorrectiveDifferentItemAllocatesDistinctSeq(t *testing.T) {
 	cfg := setupAnnounceFixture(t)
-	newReg(t, cfg, "claude-code", "anthropic", "", "")
-	offender := newReg(t, cfg, "codex", "openai", "", "")
+	newReg(t, cfg, "claude-code", "anthropic", "")
+	offender := newReg(t, cfg, "codex", "openai", "")
 
 	msg1, err := SendCorrective(cfg, "claude-code", offender.AgentID,
 		".agentchute/loop/malformed/bad1.md", "filename does not match §6.1", "§6.1")
@@ -211,7 +211,7 @@ func TestSendCorrectiveDifferentItemAllocatesDistinctSeq(t *testing.T) {
 
 func TestAnnounceEnrollmentNoPeers(t *testing.T) {
 	cfg := setupAnnounceFixture(t)
-	self := newReg(t, cfg, "claude-code", "anthropic", "", "I do synthesis.")
+	self := newReg(t, cfg, "claude-code", "anthropic", "I do synthesis.")
 
 	result, err := AnnounceEnrollment(cfg, self)
 	if err != nil {
@@ -227,9 +227,9 @@ func TestAnnounceEnrollmentNoPeers(t *testing.T) {
 
 func TestAnnounceEnrollmentSendsToPeersSkipsSelfAndExamples(t *testing.T) {
 	cfg := setupAnnounceFixture(t)
-	self := newReg(t, cfg, "claude-code", "anthropic", "", "synthesis")
-	newReg(t, cfg, "codex", "openai", "", "review")
-	newReg(t, cfg, "gemini-cli", "google", "", "external review")
+	self := newReg(t, cfg, "claude-code", "anthropic", "synthesis")
+	newReg(t, cfg, "codex", "openai", "review")
+	newReg(t, cfg, "gemini-cli", "google", "external review")
 
 	// .example.md files exist alongside live registrations; must be skipped.
 	mustWrite(t, filepath.Join(cfg.AgentsDir(), "codex.example.md"), []byte("---\nagent_id: codex\nvendor: openai\ncontrol_repo: "+cfg.ControlRepo+"\nlast_seen: 2026-05-09T16:08:36Z\nstatus: active\n---\n"))
@@ -277,8 +277,8 @@ func TestAnnounceEnrollmentSendsToPeersSkipsSelfAndExamples(t *testing.T) {
 
 func TestAnnounceEnrollmentMissingInboxIsWarningNotFatal(t *testing.T) {
 	cfg := setupAnnounceFixture(t)
-	self := newReg(t, cfg, "claude-code", "anthropic", "", "synthesis")
-	peer := newReg(t, cfg, "codex", "openai", "", "review")
+	self := newReg(t, cfg, "claude-code", "anthropic", "synthesis")
+	peer := newReg(t, cfg, "codex", "openai", "review")
 
 	// Remove the peer's inbox dir to simulate a busted registration.
 	if err := os.RemoveAll(cfg.AgentInboxDir(peer.AgentID)); err != nil {
@@ -341,9 +341,8 @@ func setupAnnounceFixture(t *testing.T) *Config {
 	return cfg
 }
 
-func newReg(t *testing.T, cfg *Config, agentID, vendor, wakeTarget, body string) *Registration {
+func newReg(t *testing.T, cfg *Config, agentID, vendor, body string) *Registration {
 	t.Helper()
-	_ = wakeTarget // pull-only (Gate 6c): registrations carry no wake target
 	reg := &Registration{
 		AgentID:     agentID,
 		Vendor:      vendor,

--- a/internal/loop/readfile_windows.go
+++ b/internal/loop/readfile_windows.go
@@ -7,10 +7,9 @@ import (
 	"os"
 )
 
-// openRegularNoFollow is the Windows fallback. There is no portable O_NOFOLLOW
-// here without golang.org/x/sys/windows (not a dependency), so this preserves
-// the prior behavior: Lstat to reject a symlink leaf, then Open, then re-check
-// the opened fd is a regular file. The Lstat→Open TOCTOU window is therefore
+// openRegularNoFollow is the Windows fallback. It preserves the prior behavior:
+// Lstat to reject a symlink leaf, then Open, then re-check the opened fd is a
+// regular file. The Lstat→Open TOCTOU window is therefore
 // only PARTIALLY closed on Windows (the post-open fstat catches a swap to a
 // non-regular object, but a swap between two regular files is not detected).
 // agentchute's loop dirs are owner-only, so an untrusted peer cannot reach the

--- a/internal/loop/registration_test.go
+++ b/internal/loop/registration_test.go
@@ -17,8 +17,6 @@ control_repo: /tmp/repo
 working_repos:
   - /tmp/repo
   - "/tmp/other repo"
-wake_method: tmux
-wake_target: "%1"
 last_seen: 2026-05-09T16:08:36Z
 status: exhausted
 restart_at: 2026-05-09T18:00:00Z
@@ -149,8 +147,6 @@ func TestUpdateLastSeenPreservesBody(t *testing.T) {
 agent_id: codex
 vendor: openai
 control_repo: /tmp/repo
-wake_method: tmux
-wake_target: "%1"
 last_seen: 2026-05-09T16:08:36Z
 status: active
 ---
@@ -181,8 +177,6 @@ func TestUpdateLastActivePreservesBody(t *testing.T) {
 agent_id: codex
 vendor: openai
 control_repo: /tmp/repo
-wake_method: tmux
-wake_target: "%1"
 last_seen: 2026-05-09T16:08:36Z
 status: active
 ---
@@ -214,8 +208,6 @@ agent_id: codex
 vendor: openai
 control_repo: /tmp/repo
 custom_field: preserved-by-line-edit-only
-wake_method: tmux
-wake_target: "%1"
 last_seen: 2026-05-09T16:08:36Z
 status: active
 ---
@@ -245,8 +237,6 @@ func TestUpdateLastSeenWritesLive(t *testing.T) {
 agent_id: codex
 vendor: openai
 control_repo: /tmp/repo
-wake_method: tmux
-wake_target: "%1"
 last_seen: 2026-05-09T16:08:36Z
 status: active
 ---
@@ -280,8 +270,6 @@ agent_id: codex
 vendor: openai
 vendor: local
 control_repo: /tmp/repo
-wake_method: tmux
-wake_target: "%1"
 last_seen: 2026-05-09T16:08:36Z
 status: active
 ---
@@ -421,8 +409,6 @@ func TestReadRegistrationRejectsSymlink(t *testing.T) {
 agent_id: codex
 vendor: openai
 control_repo: /tmp/repo
-wake_method: tmux
-wake_target: "%1"
 last_seen: 2026-05-09T16:08:36Z
 status: active
 ---

--- a/internal/loop/runner_socketdir_windows.go
+++ b/internal/loop/runner_socketdir_windows.go
@@ -24,11 +24,10 @@ func currentUID() string {
 }
 
 // ensureOwnedRunnerSocketDir creates dir (0700) if needed and verifies it is a
-// real directory (not a symlink). Windows lacks a portable POSIX uid/owner
-// check via os.FileInfo.Sys() without golang.org/x/sys/windows (not a
-// dependency here), so ownership is approximated by the per-user (SID-suffixed)
-// directory name; the symlink and directory checks still apply. Unix runners
-// get the full uid ownership verification.
+// real directory (not a symlink). This fallback does not perform a Windows
+// ACL/SID owner check; ownership is approximated by the per-user
+// (SID-suffixed) directory name, and the symlink and directory checks still
+// apply. Unix runners get the full uid ownership verification.
 func ensureOwnedRunnerSocketDir(dir string) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err

--- a/tools/fact-sweep.sh
+++ b/tools/fact-sweep.sh
@@ -21,7 +21,7 @@ say "python proof: runner.py=${actual_lines} lines; claims found: $(printf '%s '
 
 # 2. Vector-count claims ("9 vectors", badge '9%20vectors') must equal core.json's vector count.
 actual_vectors=$(grep -c '"id"' conformance/vectors/core.json)
-vclaims=$(grep -rhoE '[0-9]+ vectors|[0-9]+%20vectors' $SURFACES 2>/dev/null | grep -oE '^[0-9]+' | sort -u)
+vclaims=$(grep -rhoE '[0-9]+ vectors|[0-9]+%20vectors' $SURFACES CHANGELOG.md 2>/dev/null | grep -oE '^[0-9]+' | sort -u)
 for n in $vclaims; do
   [ "$n" = "$actual_vectors" ] || bad "a '${n} vectors' claim exists but core.json has ${actual_vectors}"
 done

--- a/web/spec.html
+++ b/web/spec.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>agentchute spec — AGENTCHUTE.md</title>
-<meta name="description" content="The agentchute protocol spec. Working draft v1. Pull-only, inbox-based agent coordination — senders write a Markdown message; recipients read their own inbox.">
+<meta name="description" content="The agentchute Protocol v2 stable spec. Pull-only, inbox-based agent coordination — senders write a Markdown message; recipients read their own inbox.">
 <meta property="og:title" content="agentchute spec">
 <meta property="og:description" content="The agentchute protocol spec. Pull-only, inbox-based agent coordination — senders write; recipients read their own inbox.">
 <meta property="og:url" content="https://agentchute.dev/spec.html">
@@ -32,7 +32,7 @@
   <div class="wrap">
     <h1>The protocol spec</h1>
     <p class="lede">
-      Working draft v1. The canonical version is
+      Protocol v2 is stable and final. The canonical version is
       <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md"><code>AGENTCHUTE.md</code> in the repo</a>
       — it renders cleanly on GitHub with the right anchor links, table of contents, and code highlighting.
       The summary below is a reading guide for what's in each section.


### PR DESCRIPTION
Cleanup **Stage 2** — the ~12 stale-doc/comment fixes from `CLEANUP-PLAN-3way.md` §C. **Authored by codex**, gated by claude (verifications below), sonnet co-gating. Net **+42/−58** across 15 files. No behavior/API changes — comments, docs, and dead test-fixtures only.

## Changes (§C)
CONTRIBUTING v0.x→neutral · EXTENSIONS (§13)→(§12) + drop "reserved for v2" · README support-matrix link →AGENTCHUTE.md §2 · PLAYBOOKS E1-E9→E1-E10 · loop/README layout (adds live/state/malformed, aligns with #77's gitignore) · web/spec "Working draft v1"→Protocol v2 stable · conformance drop "~90 lines" + `../ach`→`internal/loop` · inbox.go comment →deterministic-path only · windows files drop false "not a dependency" · registration_test strip wake fixtures · message_test drop dead `wakeTarget` param · fact-sweep CHANGELOG consistency.

## claude gate (re-derived, not trusted)
- Scope: exactly the 15 §C files, zero surplus.
- All 5 Go non-test files: **comment-only** (verified line-by-line, no logic change).
- Test edits: ran `go test ./internal/loop` independently → **PASS**; `wakeTarget` param removal is clean.
- EXTENSIONS: §13 fully gone (all refs §12); "excluded from the core protocol" matches §12 Non-goals — a sound refinement over the plan's suggested wording.
- `tools/test.sh` green (codex) + my internal/loop re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)