### PR TITLE
docs(code): truth-fix — no receiver-side dedup backstop exists (v2.5 plan A1)

### DIFF
--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -42,14 +42,15 @@ to mean to be more than a claim.
 | **D1** atomic visibility | a mid-delivery message is never observable | readers acting on a half-written message |
 | **D2** no-overwrite | N concurrent deliveries all survive | a clobber silently dropping a message under load |
 | **O1** per-sender FIFO | one sender's order is preserved; cross-sender is advisory | reordering a sender's own messages / claiming a false total order |
-| **C1** at-least-once + idempotent | crash after act re-delivers; `msg_key` dedups | at-most-once consume losing a message on a crash |
+| **C1** consume at-least-once | crash after act re-delivers (handler must be idempotent; no protocol receiver-side dedup backstop) | at-most-once consume losing a message on a crash |
 | **E1** envelope | unknown fields ignored; `From` required | a future field breaking old receivers; an anonymous message |
 | **B1** privacy | inbox keeps bodies private; log does not | — (this one *encodes the fork*, see below) |
 
 `go test -v` shows R1–E1 simply passing on both models. **C1** is the
 load-bearing one: it injects a crash at the worst moment (after the handler
-acts, before the consume commits) and asserts re-delivery, then shows `msg_key`
-collapsing the duplicate.
+acts, before the consume commits) and asserts re-delivery. Any collapse of a
+duplicate effect is the handler's job (idempotency covenant); the suite may demo
+an opt-in key helper, but that is not a protocol receiver-side dedup backstop.
 
 ## Vector format
 

--- a/conformance/inbox_binding.go
+++ b/conformance/inbox_binding.go
@@ -124,11 +124,13 @@ func (b *inboxBinding) Consume(id string, handler func(Msg) error) (int, error) 
 		}
 		// Post-consume the delivery slot is freed, so drop the EEXIST dedup key:
 		// a later resend of the SAME (to,from,seq) must RE-LAND, matching the real
-		// FS where EEXIST-as-no-op holds only pre-consume/pre-archive (once the file
-		// is archived, a re-landed copy relies on receiver-side Key/Deduper to
-		// collapse the duplicate effect — NOT on delivery dedup). Done at COMMIT
-		// only (after handler success + the crash check), so a crash before commit
-		// keeps the slot present and EEXIST remains a no-op (C1 at-least-once holds).
+		// FS where EEXIST-as-no-op holds only pre-consume/pre-archive. Once archived
+		// there is no delivery-side or protocol-level receiver-side dedup backstop;
+		// a re-landed copy is a second delivery and the covenant is handler
+		// idempotency (the optional Key/Deduper helper below is a demo aid only,
+		// not a protocol backstop). Done at COMMIT only (after handler success +
+		// the crash check), so a crash before commit keeps the slot present and
+		// EEXIST remains a no-op (C1 consume at-least-once holds).
 		if msgs[i].Seq > 0 {
 			delete(b.delivered, fmt.Sprintf("%s|%s|%d", id, msgs[i].From, msgs[i].Seq))
 		}

--- a/conformance/inbox_postconsume_test.go
+++ b/conformance/inbox_postconsume_test.go
@@ -2,14 +2,16 @@ package conformance
 
 import "testing"
 
-// TestInbox_PostConsumeResendRelandsThenKeyDedup pins the corrected post-consume
+// TestInbox_PostConsumeResendRelandsThenKeyDedup pins post-consume delivery
 // semantics for the INBOX binding: once a message is consumed+committed the inbox
 // slot is freed, so a later resend of the SAME (to,from,seq) must RE-LAND — it is
 // NOT suppressed by delivery (EEXIST) dedup forever. This matches the real FS,
-// where EEXIST-as-no-op holds only PRE-consume/pre-archive; after the file is
-// archived a re-landed copy relies on the RECEIVER's Key/Deduper to collapse the
-// duplicate EFFECT. (Before the fix the in-memory `delivered` map deduped forever,
-// over-optimistically green-lighting a post-consume dedup the FS does not provide.)
+// where EEXIST-as-no-op holds only PRE-consume/pre-archive. There is no protocol
+// receiver-side dedup backstop after archive; a re-land is a second delivery.
+// The Key/Deduper stanza below only demonstrates an OPT-IN handler-side aid that
+// can collapse effects by key — not a substrate or protocol backstop. (Before a
+// prior fix the in-memory `delivered` map deduped forever, over-optimistically
+// green-lighting a post-consume delivery dedup the FS does not provide.)
 //
 // Inbox-only on purpose: the shared-log binding legitimately retains a committed
 // delivery identity forever (the record stays in the append-only log), so this is
@@ -39,8 +41,9 @@ func TestInbox_PostConsumeResendRelandsThenKeyDedup(t *testing.T) {
 		t.Fatalf("post-consume resend must be visible again (re-land); saw %d — delivery dedup wrongly suppressed it", len(got))
 	}
 
-	// The RECEIVER's Key/Deduper is what collapses the duplicate EFFECT across the
-	// original consume and the re-landed resend (both Key k1) -> exactly one effect.
+	// OPT-IN handler aid only (not a protocol backstop): Key/Deduper can collapse
+	// the duplicate EFFECT across the original consume and the re-landed resend
+	// (both Key k1) -> exactly one effect when the handler chooses to use it.
 	d := NewDeduper()
 	effects := 0
 	apply := func(m Msg) error {
@@ -50,6 +53,6 @@ func TestInbox_PostConsumeResendRelandsThenKeyDedup(t *testing.T) {
 	_, cerr := b.Consume("bob", apply)
 	must(t, cerr) // the re-landed resend
 	if effects != 1 {
-		t.Fatalf("receiver Key dedup must collapse original + post-consume resend to ONE effect; got %d", effects)
+		t.Fatalf("opt-in Key/Deduper must collapse original + post-consume resend to ONE effect; got %d", effects)
 	}
 }

--- a/conformance/log_binding.go
+++ b/conformance/log_binding.go
@@ -99,7 +99,9 @@ func (b *logBinding) Deliver(to string, m Msg) error {
 		return fmt.Errorf("unknown recipient %q (mailbox dead / not registered)", to)
 	}
 	if m.Seq > 0 {
-		// Same EEXIST-idempotency as the inbox binding, keyed (to,from,seq).
+		// Delivery-side EEXIST-style idempotency only, keyed (to,from,seq).
+		// This is not a receiver-side dedup backstop; post-delivery handler
+		// duplicates (if any) are the handler's problem (idempotency covenant).
 		k := fmt.Sprintf("%s|%s|%d", to, m.From, m.Seq)
 		if b.delivered[k] {
 			return nil

--- a/internal/loop/seq.go
+++ b/internal/loop/seq.go
@@ -31,9 +31,11 @@ import (
 // consumes last_issued+1, never an occupied seq. link()-EEXIST on the canonical
 // path means "this exact (to,from,seq) is STILL PRESENT in the inbox", so a
 // crash-uncertain resend is a no-op ONLY while the message remains UNCONSUMED.
-// Once consumed (archived) the file is gone, link no longer EEXISTs, and
-// post-consume idempotency relies on receiver-side Key dedup. (Pre-consume, this
-// folds the delivery-dedup half of C1 into the substrate.)
+// Once consumed (archived) the file is gone, link no longer EEXISTs, so a later
+// resend of the same (to,from,seq) RE-LANDS as a new delivery — it is NOT
+// deduplicated by the protocol. There is no receiver-side dedup backstop; the
+// covenant is handler idempotency. (Pre-consume, EEXIST folds the delivery-dedup
+// half of C1 into the substrate.)
 
 // MsgID is the committed protocol-v2 delivery key. It is the shared, load-bearing
 // identity used by seq.go (writer/parser) and owed.go (obligation key).
@@ -142,8 +144,9 @@ func ParseSeqFilename(name string) (from string, seq uint64, ok bool) {
 // const) ONLY so tests can shrink it to exercise the pruning path; production
 // keeps the larger window. A crash-resend whose key was pruned out of the
 // window (only on a very delayed resume) allocates a FRESH seq and lands a
-// duplicate copy — relying on receiver-side Key dedup as the backstop. The
-// window is sized for immediate post-crash resume.
+// duplicate copy. There is no receiver-side dedup backstop for that duplicate;
+// the covenant is handler idempotency. The window is sized for immediate
+// post-crash resume.
 var seqRecentWindow uint64 = 256
 
 // MaxSeqStateBytes caps the per-(from,to) seq state file. Bounded by the recent
@@ -369,7 +372,8 @@ func writeSeqMessage(inboxDir string, id MsgID, content []byte) (alreadyLanded b
 	if err := linkNoClobber(tempPath, finalPath); err != nil {
 		if errors.Is(err, os.ErrExist) {
 			// This exact (to,from,seq) is still present in the inbox — safe no-op
-			// success (pre-consume; post-consume relies on receiver Key dedup).
+			// success while unconsumed. Post-consume the path is free again, so a
+			// resend re-lands; there is no receiver-side dedup backstop.
 			return true, nil
 		}
 		return false, fmt.Errorf("link to %s: %w", finalPath, err)


### PR DESCRIPTION
## Summary

v2.5 plan slice **A1**: rewrite comments/docs that claimed a receiver-side Key/Deduper dedup backstop exists. It never did.

- Post-consume, a resend of the same `(to,from,seq)` **re-lands** (delivery EEXIST is pre-consume only).
- The covenant is **handler idempotency**, not a protocol receiver-side backstop.
- Optional Key/Deduper in the conformance suite is an opt-in demo aid only.

## Files (exactly the A1 list)

- `internal/loop/seq.go` (3 comment sites)
- `conformance/inbox_binding.go`
- `conformance/log_binding.go`
- `conformance/inbox_postconsume_test.go` (doc comments only; assertions unchanged)
- `conformance/CONFORMANCE.md` (C1 row + prose)

## Behavior

None. Comments/docs only. `AGENTCHUTE.md` untouched.

## Test plan

- [x] `env -u AGENTCHUTE_* go test ./...` green
- [x] `cd conformance && go test ./...` green
- [x] `rg -n receiver-side internal/ conformance/` — only honest “no backstop / opt-in aid” wording in the edited sites

## Reviewers (requested)

claude-code, sonnet — do **not** merge from this PR author.