### PR TITLE
fix(test): make PTY startup size check deterministic

### DIFF
--- a/internal/runner/pty/pty_size_test.go
+++ b/internal/runner/pty/pty_size_test.go
@@ -2,9 +2,7 @@ package pty
 
 import (
 	"os/exec"
-	"strings"
 	"testing"
-	"time"
 
 	creackpty "github.com/creack/pty"
 )
@@ -13,17 +11,10 @@ import (
 // before any SIGWINCH/resize loop runs. A child started on a 0x0 PTY renders
 // a blank screen in ratatui/Ink TUIs (the "blank boxes" startup race).
 //
-// creack/pty's StartWithAttrs calls Setsize on the new pty and checks its
-// error BEFORE cmd.Start() ever forks the child (run.go) — there is no
-// product-level window where the child can run before the size is applied.
-// What IS racy under CI scheduling is forking/exec'ing "stty size" and
-// getting its output back to us: a single eager Read can lose that race
-// (or observe a spurious empty read) even though the pty was correctly
-// sized from the first instant the child could read it. Poll with a tight
-// budget instead of trusting one Read to land in time. This stays a hard
-// assertion on STARTUP sizing — the budget is short specifically so it
-// cannot be satisfied by the separate SIGWINCH heal path (which this
-// isolated test doesn't even wire up).
+// The window size is a kernel property shared by the returned PTY master and
+// the child's slave. Read it directly from the new PTY instead of depending on
+// a short-lived `stty` child to emit output before its slave closes. There is no
+// resize loop in this test, so the observed size can only be the startup size.
 func TestStartInheritSizeChildSeesInitialSize(t *testing.T) {
 	master, slave, err := creackpty.Open()
 	if err != nil {
@@ -37,44 +28,23 @@ func TestStartInheritSizeChildSeesInitialSize(t *testing.T) {
 		t.Fatalf("setsize: %v", err)
 	}
 
-	cmd := exec.Command("stty", "size")
+	cmd := exec.Command("sleep", "10")
 	ptmx, err := StartInheritSize(cmd, slave)
 	if err != nil {
 		t.Fatalf("StartInheritSize: %v", err)
 	}
 	defer ptmx.Close()
-
-	chunks := make(chan string, 16)
-	go func() {
-		buf := make([]byte, 256)
-		for {
-			n, err := ptmx.Read(buf)
-			if n > 0 {
-				chunks <- string(buf[:n])
-			}
-			if err != nil {
-				close(chunks)
-				return
-			}
-		}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
 	}()
 
-	deadline := time.After(500 * time.Millisecond)
-	var got strings.Builder
-	for {
-		select {
-		case chunk, ok := <-chunks:
-			if !ok {
-				t.Fatalf("child output ended before showing winsize within 500ms; got %q", got.String())
-			}
-			got.WriteString(chunk)
-			if strings.Contains(got.String(), "41 97") {
-				_ = cmd.Wait()
-				return
-			}
-		case <-deadline:
-			t.Fatalf("child saw winsize %q within 500ms at startup, want \"41 97\"", strings.TrimSpace(got.String()))
-		}
+	got, err := creackpty.GetsizeFull(ptmx)
+	if err != nil {
+		t.Fatalf("get child PTY size: %v", err)
+	}
+	if got.Rows != want.Rows || got.Cols != want.Cols {
+		t.Fatalf("child PTY startup size = %dx%d, want %dx%d", got.Rows, got.Cols, want.Rows, want.Cols)
 	}
 }
 


### PR DESCRIPTION
## Summary

- replace the flaky short-lived stty output probe with a direct read of the child PTY shared kernel window state
- keep the child alive during the assertion and change no product code

## Verification

- focused test: 1,000 consecutive passes
- focused race test: 100 consecutive passes
- gofmt -l .
- go vet ./...
- go test ./...
- go test ./... -race
- go build ./...
- sh tests/install_test.sh
- conformance go test ./...
- shellcheck -s sh install.sh tests/install_test.sh
- goreleaser check