### PR TITLE
feat(loop): dual-read old and new message identities (v2.5 plan B6)

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -151,6 +151,8 @@ The committed identity is the full delivery key `(to, from, seq)`:
 
 The reference encoding is the canonical filename `from-<from>_seq-<020d>.md` (`seq` zero-padded to 20 digits). A plain lexicographic sort of one sender's files is therefore **exact per-sender FIFO with no clock**. Cross-sender order is **advisory arrival order** (non-normative) — the protocol does not promise a global total order (a real total order would need a freshness CAS the mount can't cheaply give, and is unneeded).
 
+During the v2.5 dual-read migration, the reference implementation preserves per-sender FIFO for the one-way, pool-at-once cutover by sorting legacy seq messages before timestamp-format messages, then sorting each grammar by its own monotonic key. Known migration-window limitation: if a pool writes timestamp-format messages, rolls back and writes new legacy messages, then rolls forward again, the old-first grammar rank can place those rollback writes before earlier timestamp writes. Using file mtime as a cross-grammar key is worse because copying and archiving can perturb it; no global ordering machinery is added for this two-transition edge case.
+
 `seq` is **write-ahead durable**: the counter is committed *before* the message links, so a crash can only ever produce a GAP (an allocated seq whose message never landed), never a reuse for different content. Gaps are legal — `seq` is identity + sort key, not a no-gap contract.
 
 The canonical `from-<from>_seq-<020d>.md` is the only inbox filename format. A name that does not parse as a canonical seq filename is unrecognized: it is skipped by the lister and quarantined by `check` (§11.1).

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -309,6 +309,10 @@ func displayConsumed(cfg *loop.Config, agentID string, msg loop.Message, content
 			if err := loop.ClearOwed(cfg, agentID, key); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: failed to clear owed obligation %s: %v\n", ref, err)
 			}
+		} else if key, ok := loop.ParseTsRef(ref); ok && key.From == agentID && msg.Sender == key.To {
+			if err := loop.ClearOwed(cfg, agentID, key); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to clear owed obligation %s: %v\n", ref, err)
+			}
 		}
 	}
 
@@ -369,22 +373,22 @@ func sanitizeControlBytes(s string) string {
 }
 
 // printReplyRefIfRequired prints the copyable in_reply_to ref a reply to msg must
-// carry, when msg is reply_required. The ref is the ORIGINAL message's identity
-// MsgID{To: agentID (us, the recipient), From: msg.Sender, Seq}: the asker
-// recorded their `.owed` obligation under this exact tuple, so echoing it back as
-// the reply's in_reply_to is what lets the asker's `check` discharge it. A name
-// that does not parse as a canonical seq filename yields Seq=0 (a degenerate
-// ref); the listers surface only seq messages, so this does not occur on the
-// live path.
+// carry, when msg is reply_required. The emitted reference matches the message's
+// filename identity form so it clears the asker's matching obligation.
 func printReplyRefIfRequired(agentID string, msg loop.Message, fm map[string]string) {
 	if !isFrontmatterReplyRequired(fm) {
 		return
 	}
-	var seq uint64
-	if _, s, ok := loop.ParseSeqFilename(msg.Filename); ok {
-		seq = s
+
+	var ref string
+	if from, seq, ok := loop.ParseSeqFilename(msg.Filename); ok {
+		ref = (loop.MsgID{To: agentID, From: from, Seq: seq}).RefString()
+	} else if id, ok := loop.ParseTsFilename(msg.Filename); ok {
+		id.To = agentID
+		ref = id.RefString()
+	} else {
+		return
 	}
-	ref := loop.MsgID{To: agentID, From: msg.Sender, Seq: seq}.RefString()
 	fmt.Printf("reply-required: reply with `agentchute send --from %s --to %s --reply-to %s ...`\n\n", agentID, msg.Sender, ref)
 }
 

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -17,10 +17,9 @@ import (
 // surfaces age loudly, the reader judges relevance — no expiry, no auto-action.
 const oldMailBannerAfter = 24 * time.Hour
 
-// messageAge returns how long ago msg was sent, relative to now. Age source
-// today is always msg.Timestamp (file mtime) — the filename-timestamp
-// grammar doesn't exist yet (v2.5 plan B7). This is the one place plan slice
-// B6 edits to add the new-format filename-timestamp branch alongside mtime.
+// messageAge returns how long ago msg was sent, relative to now. The lister
+// populates msg.Timestamp from the embedded timestamp for new-format messages
+// and from file mtime for legacy seq messages.
 func messageAge(msg loop.Message, now time.Time) time.Duration {
 	return now.Sub(msg.Timestamp)
 }

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -144,13 +144,13 @@ func cmdCleanOwed(cfg *loop.Config, agentID string, apply, jsonOut bool, now tim
 			return fmt.Errorf("load owed ledger: %w", err)
 		}
 		expired := ledger.ExpiredOwed(now)
-		// Keyed by MsgID, not counted: RecordOwed's own API is idempotent per
-		// key and can never create two entries with the same (to,from,seq),
+		// Keyed by OwedKey, not counted: RecordOwed's own API is idempotent per
+		// key and can never create two entries with the same identity,
 		// so this can't observe a real duplicate through normal use. A
 		// hand-edited ledger with a duplicate key would have BOTH instances
 		// pruned together if either is expired — not reachable via the API,
 		// so left as a documented limitation rather than a count-based fix.
-		expiredKeys := make(map[loop.MsgID]bool, len(expired))
+		expiredKeys := make(map[loop.OwedKey]bool, len(expired))
 		for _, e := range expired {
 			result.Pruned = append(result.Pruned, e.Key().RefString())
 			expiredKeys[e.Key()] = true

--- a/internal/cli/consume_boundary_test.go
+++ b/internal/cli/consume_boundary_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -364,7 +365,7 @@ func TestOwedFlip_UsesFilenameSenderNotFrontmatter(t *testing.T) {
 	})
 
 	// alice asks bob; alice is owed a reply specifically by bob.
-	arm := func() loop.MsgID {
+	arm := func() loop.OwedKey {
 		withCwd(t, root, func() {
 			if err := cmdSend([]string{"--from", "alice", "--to", "bob",
 				"--ask", "--body", "please review"}); err != nil {
@@ -429,5 +430,184 @@ func TestOwedFlip_UsesFilenameSenderNotFrontmatter(t *testing.T) {
 	}
 	if got := out[0].Key(); !got.Equal(key2) {
 		t.Fatalf("remaining owed key after variant 2 = %+v; want %+v", got, key2)
+	}
+}
+
+func TestOwedFlip_ThirdPartyReplyDoesNotClear_Timestamp(t *testing.T) {
+	root, cfg := setupConsumeFixture(t)
+	withCwd(t, root, func() {
+		if err := cmdRegister([]string{"--as", "carol", "--vendor", "google", "--host", "third-host"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	key := loop.TsID{
+		To:     "bob",
+		From:   "alice",
+		Stamp:  "20260730T182415123456Z",
+		Suffix: "11111111111111111111111111111111",
+	}
+	now := time.Now().UTC()
+	if err := loop.RecordOwed(cfg, "alice", key, now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+
+	withCwd(t, root, func() {
+		spoof := loop.TsID{From: "carol", Stamp: "20260730T182416000000Z", Suffix: "22222222222222222222222222222222"}
+		body := "---\nfrom: carol\nin_reply_to: " + key.RefString() + "\n---\n\nspoofed\n"
+		mustWriteTsInbox(t, cfg.AgentInboxDir("alice"), spoof, []byte(body))
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := captureStdout(t, func() error { return cmdAck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+	})
+	owed, err := loop.LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owed.Owed) != 1 || !owed.Owed[0].MatchesRef(key) {
+		t.Fatalf("third-party timestamp reply cleared obligation: %+v", owed.Owed)
+	}
+
+	withCwd(t, root, func() {
+		reply := loop.TsID{From: "bob", Stamp: "20260730T182417000000Z", Suffix: "33333333333333333333333333333333"}
+		body := "---\nfrom: bob\nin_reply_to: " + key.RefString() + "\n---\n\ndone\n"
+		mustWriteTsInbox(t, cfg.AgentInboxDir("alice"), reply, []byte(body))
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+	})
+	owed, err = loop.LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owed.Owed) != 0 {
+		t.Fatalf("bob's timestamp reply did not clear obligation: %+v", owed.Owed)
+	}
+}
+
+func TestOwedFlip_UsesFilenameSenderNotFrontmatter_Timestamp(t *testing.T) {
+	root, cfg := setupConsumeFixture(t)
+	withCwd(t, root, func() {
+		if err := cmdRegister([]string{"--as", "carol", "--vendor", "google", "--host", "third-host"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	record := func(stamp, suffix string) loop.TsID {
+		t.Helper()
+		key := loop.TsID{To: "bob", From: "alice", Stamp: stamp, Suffix: suffix}
+		now := time.Now().UTC()
+		if err := loop.RecordOwed(cfg, "alice", key, now.Add(time.Hour), now); err != nil {
+			t.Fatal(err)
+		}
+		return key
+	}
+
+	key1 := record("20260730T182415123456Z", "44444444444444444444444444444444")
+	withCwd(t, root, func() {
+		reply := loop.TsID{From: "bob", Stamp: "20260730T182418000000Z", Suffix: "55555555555555555555555555555555"}
+		body := "---\nfrom: carol\nin_reply_to: " + key1.RefString() + "\n---\n\nfilename-bob\n"
+		mustWriteTsInbox(t, cfg.AgentInboxDir("alice"), reply, []byte(body))
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := captureStdout(t, func() error { return cmdAck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+	})
+	owed, err := loop.LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owed.Owed) != 0 {
+		t.Fatalf("filename bob did not clear timestamp obligation: %+v", owed.Owed)
+	}
+
+	key2 := record("20260730T182419000000Z", "66666666666666666666666666666666")
+	withCwd(t, root, func() {
+		spoof := loop.TsID{From: "carol", Stamp: "20260730T182420000000Z", Suffix: "77777777777777777777777777777777"}
+		body := "---\nfrom: bob\nin_reply_to: " + key2.RefString() + "\n---\n\nfilename-carol\n"
+		mustWriteTsInbox(t, cfg.AgentInboxDir("alice"), spoof, []byte(body))
+		if _, err := captureStdout(t, func() error { return cmdCheck([]string{"--as", "alice"}) }); err != nil {
+			t.Fatal(err)
+		}
+	})
+	owed, err = loop.LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owed.Owed) != 1 || !owed.Owed[0].MatchesRef(key2) {
+		t.Fatalf("filename carol incorrectly cleared timestamp obligation: %+v", owed.Owed)
+	}
+}
+
+func TestDualReadMixedInboxClaimsQuarantinesClearsAndMatchesRefs(t *testing.T) {
+	root, cfg := setupConsumeFixture(t)
+	now := time.Now().UTC()
+	oldOwed := loop.MsgID{To: "bob", From: "alice", Seq: 91}
+	newOwed := loop.TsID{
+		To:     "bob",
+		From:   "alice",
+		Stamp:  "20260730T182421000000Z",
+		Suffix: "88888888888888888888888888888888",
+	}
+	if err := loop.RecordOwed(cfg, "alice", oldOwed, now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+	if err := loop.RecordOwed(cfg, "alice", newOwed, now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+
+	oldMessage := loop.MsgID{To: "alice", From: "bob", Seq: 7}
+	newMessage := loop.TsID{
+		To:     "alice",
+		From:   "bob",
+		Stamp:  "20260730T182422000000Z",
+		Suffix: "99999999999999999999999999999999",
+	}
+	oldBody := "---\nfrom: bob\nreply_required: true\nin_reply_to: " + oldOwed.RefString() + "\n---\n\nold-format-body\n"
+	newBody := "---\nfrom: bob\nreply_required: true\nin_reply_to: " + newOwed.RefString() + "\n---\n\nnew-format-body\n"
+	mustWriteSeqInbox(t, cfg.AgentInboxDir("alice"), oldMessage.From, oldMessage.Seq, []byte(oldBody))
+	mustWriteTsInbox(t, cfg.AgentInboxDir("alice"), newMessage, []byte(newBody))
+	mustWrite(t, filepath.Join(cfg.AgentInboxDir("alice"), "garbage.md"), []byte("bad\n"))
+
+	var out string
+	withCwd(t, root, func() {
+		var err error
+		out, err = captureStdout(t, func() error { return cmdCheck([]string{"--as", "alice"}) })
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	for _, want := range []string{
+		"old-format-body",
+		"new-format-body",
+		oldMessage.RefString(),
+		newMessage.RefString(),
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("check output missing %q:\n%s", want, out)
+		}
+	}
+
+	claimed, err := loop.ListClaimedMessages(cfg.AgentClaimedDir("alice"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 2 {
+		t.Fatalf("claimed messages = %#v, want old and timestamp messages", claimed)
+	}
+	if countMessageFiles(t, cfg.MalformedDir()) != 1 {
+		t.Fatalf("malformed count = %d, want quarantined garbage", countMessageFiles(t, cfg.MalformedDir()))
+	}
+	owed, err := loop.LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(owed.Owed) != 0 {
+		t.Fatalf("old and timestamp obligations were not both discharged: %+v", owed.Owed)
 	}
 }

--- a/internal/cli/pending.go
+++ b/internal/cli/pending.go
@@ -175,10 +175,9 @@ func needsBootMessage(agentID string) string {
 	return fmt.Sprintf("agentchute: agent %q is not registered yet. Run agentchute boot --as %s --vendor <vendor> before processing mail (AGENTCHUTE.md §5.3).", agentID, agentID)
 }
 
-// pendingEntry is the structured record for a single unread message. The
-// canonical (to,from,seq) identity is surfaced via Filename (`from-<from>_seq-<seq>`)
-// plus From and the inbox owner (= the agent listing) — there is no sender-asserted
-// message_id (v0.9.0).
+// pendingEntry is the structured record for a single unread message. Its
+// canonical old or timestamp identity is surfaced via Filename plus From and
+// the inbox owner; there is no sender-asserted message_id.
 type pendingEntry struct {
 	From          string `json:"from"`
 	Filename      string `json:"filename"`

--- a/internal/cli/pending.go
+++ b/internal/cli/pending.go
@@ -232,7 +232,7 @@ func emitPendingText(entries []pendingEntry, owed []loop.OwedEntry, malformed in
 }
 
 // owedLine renders a single asker-owned obligation: the peer we are awaiting a
-// reply from and the canonical (to,from,seq) ref the reply must echo.
+// reply from and the canonical old or timestamp ref the reply must echo.
 func owedLine(o loop.OwedEntry) string {
 	return fmt.Sprintf("awaiting reply from %s — %s", o.To, o.Key().RefString())
 }

--- a/internal/cli/pending_test.go
+++ b/internal/cli/pending_test.go
@@ -72,6 +72,19 @@ func TestPendingJSONIncludesOwed(t *testing.T) {
 	})
 }
 
+func TestOwedLineRendersTimestampIdentity(t *testing.T) {
+	entry := loop.OwedEntry{
+		To:     "codex",
+		From:   "claude-code",
+		Stamp:  "20260730T182415123456Z",
+		Suffix: "9f2c04aa71de4b02b6d1c33f08e95a17",
+	}
+	wantRef := "to-codex_from-claude-code_20260730T182415123456Z_r9f2c04aa71de4b02b6d1c33f08e95a17"
+	if got := owedLine(entry); !strings.Contains(got, wantRef) {
+		t.Fatalf("owedLine = %q, want timestamp ref %q", got, wantRef)
+	}
+}
+
 // v0.9.0: --fail-if-any does NOT trigger on owed obligations. Owed is
 // asker-owned and NON-BLOCKING (mirrors gate not blocking + poller not waking on
 // owed), so an owed obligation with an empty inbox exits 0.

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -49,6 +49,11 @@ func mustWriteSeqInbox(t *testing.T, inboxDir, from string, seq uint64, content 
 	mustWrite(t, filepath.Join(inboxDir, name), content)
 }
 
+func mustWriteTsInbox(t *testing.T, inboxDir string, id loop.TsID, content []byte) {
+	t.Helper()
+	mustWrite(t, filepath.Join(inboxDir, id.Filename()), content)
+}
+
 // mustWriteAgedInbox is mustWriteSeqInbox plus a back-dated mtime, for tests
 // exercising the check age banner (v2.5 plan A3, C18): age is sourced from
 // file mtime today (Message.Timestamp), so back-dating mtime is how a test

--- a/internal/loop/inbox.go
+++ b/internal/loop/inbox.go
@@ -15,12 +15,12 @@ import (
 //
 // Timestamp is populated from the timestamp-format filename when present, or
 // from file mtime for legacy seq messages. It is advisory display/staleness
-// data only; ordering stays filename-lexicographic.
+// data only; ordering uses the parsed delivery identity.
 type Message struct {
 	Path      string    // absolute path to the file
 	Filename  string    // basename (just the file name, no directory)
 	Sender    string    // sender agent_id parsed from the filename
-	Timestamp time.Time // file mtime (advisory display/staleness only, never an ordering key)
+	Timestamp time.Time // embedded stamp or legacy mtime; advisory only
 }
 
 const (
@@ -98,11 +98,10 @@ func QuarantineInboxFile(srcPath, malformedDir, recipient string, now time.Time)
 	return destPath, nil
 }
 
-// ListInboxMessages returns inbox messages for a recipient, sorted oldest-first
-// by filename (canonical `from-<from>_seq-<020d>` — lexicographic = per-sender
-// seq FIFO). Skips temp files (.tmp_ prefix),
-// dotfiles (e.g., .DS_Store), and any file whose name does not parse per
-// §6.1. Returns an empty slice if the inbox dir is missing or empty.
+// ListInboxMessages returns inbox messages for a recipient, sorted by sender,
+// then legacy-before-timestamp grammar, then each grammar's own key. It skips
+// temp files (.tmp_ prefix), dotfiles (e.g., .DS_Store), and names that parse
+// as neither supported grammar. A missing or empty inbox returns an empty slice.
 //
 // Use ListInboxMessagesWithSkipped when callers need to surface filenames that
 // look like message attempts but failed parsing (e.g., to warn an operator
@@ -162,9 +161,9 @@ func ListInboxMessagesWithSkipped(inboxDir string) ([]Message, []string, error) 
 		if strings.HasPrefix(name, ".") {
 			continue
 		}
-		// A file whose name parses as the canonical seq format is a real message;
-		// only a genuinely-unrecognized name is `skipped` (and thus subject to the
-		// §11 quarantine + corrective).
+		// A file whose name parses as either canonical grammar is a real message;
+		// only a genuinely-unrecognized name is `skipped` (and thus subject to
+		// §11 quarantine).
 		msg, ok := parseAnyInboxName(name, modTime)
 		if !ok {
 			skipped = append(skipped, name)
@@ -179,12 +178,45 @@ func ListInboxMessagesWithSkipped(inboxDir string) ([]Message, []string, error) 
 		msgs = append(msgs, msg)
 	}
 
-	// Filename-lexicographic sort yields exact per-sender FIFO: within a sender
-	// the zero-padded %020d seq compares numerically. Cross-sender order is
-	// advisory (O1), satisfied by the sender-slug grouping the names impose.
-	sort.Slice(msgs, func(i, j int) bool { return msgs[i].Filename < msgs[j].Filename })
+	sortInboxMessages(msgs)
 	sort.Strings(skipped)
 	return msgs, skipped, nil
+}
+
+// sortInboxMessages preserves per-sender FIFO through the one-way migration:
+// all legacy messages from a sender precede timestamp-format messages, and each
+// grammar is ordered by its own monotonic key. Cross-sender order is advisory.
+func sortInboxMessages(msgs []Message) {
+	sort.Slice(msgs, func(i, j int) bool {
+		a, b := msgs[i], msgs[j]
+		if a.Sender != b.Sender {
+			return a.Sender < b.Sender
+		}
+
+		_, aSeq, aOld := ParseSeqFilename(a.Filename)
+		_, bSeq, bOld := ParseSeqFilename(b.Filename)
+		if aOld != bOld {
+			return aOld
+		}
+		if aOld {
+			if aSeq != bSeq {
+				return aSeq < bSeq
+			}
+			return a.Filename < b.Filename
+		}
+
+		aTs, aNew := ParseTsFilename(a.Filename)
+		bTs, bNew := ParseTsFilename(b.Filename)
+		if aNew && bNew {
+			if aTs.Stamp != bTs.Stamp {
+				return aTs.Stamp < bTs.Stamp
+			}
+			if aTs.Suffix != bTs.Suffix {
+				return aTs.Suffix < bTs.Suffix
+			}
+		}
+		return a.Filename < b.Filename
+	})
 }
 
 // isRegularDirEntry reports whether entry is a plain regular file (not a
@@ -303,13 +335,13 @@ func ArchiveMessage(msg Message, archiveDir, recipient string, consumedAt time.T
 // discipline. Returns the claimed-copy path.
 //
 // IDEMPOTENT / DEDUP (modeled on ArchiveMessage's EEXIST/SameFile path): the
-// canonical (to,from,seq) name encodes IDENTITY, so if it already sits in
-// claimedDir — whether the same inode (a re-claim) or a fresh inode (a resend
-// that re-landed the SAME identity in the inbox while the original was already
-// claimed) — the inbox source is the SAME protocol message. We DROP it (remove
-// the source) and return the already-claimed copy rather than erroring. (This is
-// the one divergence from ArchiveMessage, which errors on a different-inode
-// EEXIST; for a claim a same-identity resend is a benign duplicate to discard.)
+// canonical delivery name encodes IDENTITY, so if it already sits in claimedDir
+// — whether the same inode (a re-claim) or a fresh inode (a resend that re-landed
+// the SAME identity in the inbox while the original was already claimed) — the
+// inbox source is the SAME protocol message. We DROP it (remove the source) and
+// return the already-claimed copy rather than erroring. (This is the one
+// divergence from ArchiveMessage, which errors on a different-inode EEXIST; for
+// a claim a same-identity resend is a benign duplicate to discard.)
 func ClaimMessage(msg Message, claimedDir string) (string, error) {
 	if msg.Path == "" || msg.Filename == "" {
 		return "", fmt.Errorf("ClaimMessage: message Path and Filename required")
@@ -367,10 +399,9 @@ func ClaimMessage(msg Message, claimedDir string) (string, error) {
 
 // ListClaimedMessages returns the uncommitted residue in claimedDir — messages
 // CLAIMED by a prior `check` but not yet COMMITTED by `ack` (e.g. the agent
-// crashed, or hasn't run ack). It reuses parseAnyInboxName + the same
-// filename-lexicographic sort as the inbox lister. A missing claimedDir is not
-// an error (no residue → empty slice). Unrecognized residue is skipped silently
-// (it never came from a claim).
+// crashed, or hasn't run ack). It reuses parseAnyInboxName and the same
+// identity-aware sort as the inbox lister. A missing claimedDir is not an error
+// (no residue → empty slice). Unrecognized residue is skipped silently.
 func ListClaimedMessages(claimedDir string) ([]Message, error) {
 	entries, err := readInboxDir(claimedDir)
 	if err != nil {
@@ -407,7 +438,7 @@ func ListClaimedMessages(claimedDir string) ([]Message, error) {
 		msg.Filename = name
 		msgs = append(msgs, msg)
 	}
-	sort.Slice(msgs, func(i, j int) bool { return msgs[i].Filename < msgs[j].Filename })
+	sortInboxMessages(msgs)
 	return msgs, nil
 }
 

--- a/internal/loop/inbox.go
+++ b/internal/loop/inbox.go
@@ -13,10 +13,9 @@ import (
 
 // Message is a parsed inbox or archive message file.
 //
-// The filename is the canonical seq format `from-<from>_seq-<020d>.md` (§6.1).
-// There is NO timestamp embedded in the name, so Timestamp is populated from the
-// file mtime as an ADVISORY display/staleness value ONLY — it is NEVER an
-// ordering key (ordering stays filename-lexicographic; identity is (to,from,seq)).
+// Timestamp is populated from the timestamp-format filename when present, or
+// from file mtime for legacy seq messages. It is advisory display/staleness
+// data only; ordering stays filename-lexicographic.
 type Message struct {
 	Path      string    // absolute path to the file
 	Filename  string    // basename (just the file name, no directory)
@@ -40,16 +39,14 @@ var (
 // Mirrors AGENTCHUTE.md §5: "Lowercase, hyphen-separated, no spaces."
 var agentIDPattern = `[a-z0-9][a-z0-9-]*`
 
-// InferSenderFromFilename returns the sender slug captured from a canonical seq
-// filename (`from-<from>_seq-<020d>.md`). Retained caller-less for B6
-// dual-read (v2.5 plan A6): its production caller — the §11.1 corrective
-// notify path — was deleted along with the rest of that send, but B6 extends
-// this helper to recognize both the seq and timestamp filename grammars. A
-// name that is not a valid seq filename yields ok=false. The captured slug is
-// validated by ParseSeqFilename.
+// InferSenderFromFilename returns the sender slug captured from either canonical
+// inbox filename grammar.
 func InferSenderFromFilename(filename string) (string, bool) {
 	if from, _, ok := ParseSeqFilename(filename); ok {
 		return from, true
+	}
+	if id, ok := ParseTsFilename(filename); ok {
+		return id.From, true
 	}
 	return "", false
 }
@@ -207,16 +204,16 @@ func isRegularDirEntry(entry os.DirEntry) (bool, time.Time, error) {
 	return mode&os.ModeSymlink == 0 && mode.IsRegular(), info.ModTime(), nil
 }
 
-// parseAnyInboxName parses the canonical seq inbox filename and returns a partly
-// populated Message (Sender + advisory Timestamp; Path/Filename left for the
-// caller). A seq name has NO embedded timestamp, so modTime (the file mtime) is
-// used as the ADVISORY Timestamp — load-bearing for staleness (pending) and
-// display (boot); never an ordering key. A zero/forgotten Timestamp would render
-// every message ancient and print 0001-01-01. An unrecognized name returns
-// ok=false.
+// parseAnyInboxName is the shared dual-read gate for inbox and claimed listers.
+// Legacy seq names use mtime as the advisory timestamp; timestamp-format names
+// use their embedded timestamp.
 func parseAnyInboxName(name string, modTime time.Time) (Message, bool) {
 	if from, _, ok := ParseSeqFilename(name); ok {
 		return Message{Sender: from, Timestamp: modTime}, true
+	}
+	if id, ok := ParseTsFilename(name); ok {
+		stamp, _ := ParseStamp(id.Stamp)
+		return Message{Sender: id.From, Timestamp: stamp}, true
 	}
 	return Message{}, false
 }

--- a/internal/loop/inbox_test.go
+++ b/internal/loop/inbox_test.go
@@ -254,34 +254,66 @@ func TestListInboxMessagesWithSkippedReportsMalformedNames(t *testing.T) {
 
 func TestListInboxMessagesWithSkippedAcceptsOldAndTimestampFormats(t *testing.T) {
 	inbox := t.TempDir()
-	writeSeqInbox(t, inbox, "codex", 1, []byte("old\n"))
-	tsID := TsID{
-		From:   "gemini-cli",
-		Stamp:  "20260730T182415123456Z",
+	old1 := MsgID{From: "codex", Seq: 1}
+	old2 := MsgID{From: "codex", Seq: 2}
+	writeSeqInbox(t, inbox, old2.From, old2.Seq, []byte("old-2\n"))
+	writeSeqInbox(t, inbox, old1.From, old1.Seq, []byte("old-1\n"))
+	new1 := TsID{
+		From:   "codex",
+		Stamp:  "20260730T182415123455Z",
 		Suffix: testTsSuffix,
 	}
-	mustWrite(t, filepath.Join(inbox, tsID.Filename()), []byte("new\n"))
+	new2 := TsID{
+		From:   "codex",
+		Stamp:  "20260730T182415123456Z",
+		Suffix: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+	mustWrite(t, filepath.Join(inbox, new2.Filename()), []byte("new-2\n"))
+	mustWrite(t, filepath.Join(inbox, new1.Filename()), []byte("new-1\n"))
 	mustWrite(t, filepath.Join(inbox, "garbage.md"), []byte("bad\n"))
 
 	msgs, skipped, err := ListInboxMessagesWithSkipped(inbox)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(msgs) != 2 {
-		t.Fatalf("msgs = %#v, want old and timestamp messages", msgs)
+	if len(msgs) != 4 {
+		t.Fatalf("msgs = %#v, want two old and two timestamp messages", msgs)
 	}
-	got := map[string]string{}
-	for _, msg := range msgs {
-		got[msg.Filename] = msg.Sender
-	}
-	if got[(MsgID{From: "codex", Seq: 1}).Filename()] != "codex" {
-		t.Fatalf("old message missing or wrong sender: %#v", got)
-	}
-	if got[tsID.Filename()] != "gemini-cli" {
-		t.Fatalf("timestamp message missing or wrong sender: %#v", got)
+	wantOrder := []string{old1.Filename(), old2.Filename(), new1.Filename(), new2.Filename()}
+	for i, want := range wantOrder {
+		if msgs[i].Filename != want || msgs[i].Sender != "codex" {
+			t.Fatalf("msgs[%d] = %+v, want codex message %s; full order=%#v", i, msgs[i], want, msgs)
+		}
 	}
 	if len(skipped) != 1 || skipped[0] != "garbage.md" {
 		t.Fatalf("skipped = %v, want [garbage.md]", skipped)
+	}
+}
+
+func TestListClaimedMessagesUsesMixedFormatPerSenderOrder(t *testing.T) {
+	claimed := t.TempDir()
+	old1 := MsgID{From: "codex", Seq: 1}
+	old2 := MsgID{From: "codex", Seq: 2}
+	new1 := TsID{From: "codex", Stamp: "20260730T182415123455Z", Suffix: testTsSuffix}
+	new2 := TsID{From: "codex", Stamp: "20260730T182415123456Z", Suffix: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}
+
+	writeSeqInbox(t, claimed, old2.From, old2.Seq, []byte("old-2\n"))
+	writeSeqInbox(t, claimed, old1.From, old1.Seq, []byte("old-1\n"))
+	mustWrite(t, filepath.Join(claimed, new2.Filename()), []byte("new-2\n"))
+	mustWrite(t, filepath.Join(claimed, new1.Filename()), []byte("new-1\n"))
+
+	msgs, err := ListClaimedMessages(claimed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantOrder := []string{old1.Filename(), old2.Filename(), new1.Filename(), new2.Filename()}
+	if len(msgs) != len(wantOrder) {
+		t.Fatalf("msgs = %#v, want %d mixed-format messages", msgs, len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if msgs[i].Filename != want {
+			t.Fatalf("msgs[%d] = %s, want %s; full order=%#v", i, msgs[i].Filename, want, msgs)
+		}
 	}
 }
 

--- a/internal/loop/inbox_test.go
+++ b/internal/loop/inbox_test.go
@@ -252,6 +252,39 @@ func TestListInboxMessagesWithSkippedReportsMalformedNames(t *testing.T) {
 	}
 }
 
+func TestListInboxMessagesWithSkippedAcceptsOldAndTimestampFormats(t *testing.T) {
+	inbox := t.TempDir()
+	writeSeqInbox(t, inbox, "codex", 1, []byte("old\n"))
+	tsID := TsID{
+		From:   "gemini-cli",
+		Stamp:  "20260730T182415123456Z",
+		Suffix: testTsSuffix,
+	}
+	mustWrite(t, filepath.Join(inbox, tsID.Filename()), []byte("new\n"))
+	mustWrite(t, filepath.Join(inbox, "garbage.md"), []byte("bad\n"))
+
+	msgs, skipped, err := ListInboxMessagesWithSkipped(inbox)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("msgs = %#v, want old and timestamp messages", msgs)
+	}
+	got := map[string]string{}
+	for _, msg := range msgs {
+		got[msg.Filename] = msg.Sender
+	}
+	if got[(MsgID{From: "codex", Seq: 1}).Filename()] != "codex" {
+		t.Fatalf("old message missing or wrong sender: %#v", got)
+	}
+	if got[tsID.Filename()] != "gemini-cli" {
+		t.Fatalf("timestamp message missing or wrong sender: %#v", got)
+	}
+	if len(skipped) != 1 || skipped[0] != "garbage.md" {
+		t.Fatalf("skipped = %v, want [garbage.md]", skipped)
+	}
+}
+
 func TestListInboxMessagesWithSkippedIgnoresVanishedEntries(t *testing.T) {
 	oldReadInboxDir := readInboxDir
 	t.Cleanup(func() { readInboxDir = oldReadInboxDir })
@@ -322,7 +355,7 @@ func (i fakeFileInfo) ModTime() time.Time { return time.Time{} }
 func (i fakeFileInfo) IsDir() bool        { return i.mode.IsDir() }
 func (i fakeFileInfo) Sys() any           { return nil }
 
-// InferSenderFromFilename recovers the sender from a canonical seq filename.
+// InferSenderFromFilename recovers the sender from either canonical filename.
 // The legacy nonce-name inference path was removed in v0.9.0, so a legacy
 // `_msg-`-shaped name (tombstone case) is no longer attributed. Its sole
 // production caller (the §11.1 corrective-notify path) was deleted in v2.5
@@ -337,6 +370,7 @@ func TestInferSenderFromFilenameRecoversSeqSender(t *testing.T) {
 	}{
 		{"valid seq", MsgID{From: "codex", Seq: 7}.Filename(), "codex", true},
 		{"valid seq, hyphenated sender", MsgID{From: "gemini-cli", Seq: 1}.Filename(), "gemini-cli", true},
+		{"valid timestamp", (TsID{From: "sonnet", Stamp: "20260730T182415123456Z", Suffix: testTsSuffix}).Filename(), "sonnet", true},
 		// Tombstone: the removed legacy nonce format is no longer inferred.
 		{"legacy nonce name not inferred", "2026-05-09T16-32-00-123456Z_from-codex_msg-abcd.md", "", false},
 		{"seq not zero-padded to 20", "from-codex_seq-7.md", "", false},
@@ -441,5 +475,32 @@ func TestListInboxMessagesSeqTimestampFromMtime(t *testing.T) {
 	}
 	if !msgs[0].Timestamp.UTC().Truncate(time.Second).Equal(mtime.UTC().Truncate(time.Second)) {
 		t.Fatalf("seq Timestamp = %s, want ~mtime %s", msgs[0].Timestamp.UTC(), mtime.UTC())
+	}
+}
+
+func TestListInboxMessagesTimestampFromFilename(t *testing.T) {
+	inbox := t.TempDir()
+	id := TsID{
+		From:   "alice",
+		Stamp:  "20260730T182415123456Z",
+		Suffix: testTsSuffix,
+	}
+	path := filepath.Join(inbox, id.Filename())
+	mustWrite(t, path, []byte("timestamp"))
+	mtime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := ListInboxMessages(inbox)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("msgs = %d, want 1", len(msgs))
+	}
+	want, _ := ParseStamp(id.Stamp)
+	if !msgs[0].Timestamp.Equal(want) {
+		t.Fatalf("timestamp message Timestamp = %s, want filename stamp %s (mtime was %s)", msgs[0].Timestamp, want, mtime)
 	}
 }

--- a/internal/loop/owed.go
+++ b/internal/loop/owed.go
@@ -27,9 +27,9 @@ import (
 // (here) AND the recipient's stale `.live` (live.go) — so the asker never waits
 // on a corpse.
 //
-// KEY: the primary key is the trusted committed identity MsgID{To,From,Seq}.
-// From == the asker (== the ledger owner); To == the recipient the asker is owed
-// a reply by.
+// KEY: the primary key is the trusted committed old or new message identity.
+// From == the asker (== the ledger owner); To == the recipient the asker is
+// owed a reply by.
 
 // MaxOwedLedgerBytes caps the on-disk `.owed` file (refuses runaway/hand-corrupted state).
 const MaxOwedLedgerBytes = 4 << 20
@@ -42,18 +42,93 @@ const MaxOwedLedgerBytes = 4 << 20
 // by --reply-by.
 const ReplyOwedDeadline = 30 * time.Minute
 
+// OwedIdentity is either supported committed message identity.
+type OwedIdentity interface {
+	OwedKey() OwedKey
+}
+
+// OwedKey is the comparable dual-format obligation key.
+type OwedKey struct {
+	To     string
+	From   string
+	Seq    uint64
+	Stamp  string
+	Suffix string
+}
+
+// OwedKey converts a legacy message identity into an obligation key.
+func (m MsgID) OwedKey() OwedKey {
+	return OwedKey{To: m.To, From: m.From, Seq: m.Seq}
+}
+
+// OwedKey converts a timestamp message identity into an obligation key.
+func (t TsID) OwedKey() OwedKey {
+	return OwedKey{To: t.To, From: t.From, Stamp: t.Stamp, Suffix: t.Suffix}
+}
+
+// OwedKey satisfies OwedIdentity.
+func (k OwedKey) OwedKey() OwedKey { return k }
+
+// Equal reports whether two obligation identities have the same exact form and
+// components.
+func (k OwedKey) Equal(other OwedIdentity) bool {
+	return k == other.OwedKey()
+}
+
+// RefString renders the reference matching this key's identity form.
+func (k OwedKey) RefString() string {
+	if k.Seq > 0 {
+		return (MsgID{To: k.To, From: k.From, Seq: k.Seq}).RefString()
+	}
+	return (TsID{To: k.To, From: k.From, Stamp: k.Stamp, Suffix: k.Suffix}).RefString()
+}
+
+func validateOwedKey(key OwedKey) error {
+	if err := ValidateAgentID(key.To); err != nil {
+		return fmt.Errorf("to: %w", err)
+	}
+	if err := ValidateAgentID(key.From); err != nil {
+		return fmt.Errorf("from: %w", err)
+	}
+
+	hasSeq := key.Seq > 0
+	hasTsFields := key.Stamp != "" || key.Suffix != ""
+	if hasSeq && hasTsFields {
+		return fmt.Errorf("both seq and timestamp identities are set")
+	}
+	if hasSeq {
+		return nil
+	}
+	if !hasTsFields {
+		return fmt.Errorf("neither seq nor timestamp identity is set")
+	}
+	if _, ok := ParseStamp(key.Stamp); !ok || !tsSuffixRE.MatchString(key.Suffix) {
+		return fmt.Errorf("invalid timestamp identity")
+	}
+	return nil
+}
+
 // OwedEntry is one outstanding obligation. From=asker (ledger owner),
-// To=recipient owing the reply; key = MsgID{To,From,Seq}.
+// To=recipient owing the reply; exactly one identity form must be present.
 type OwedEntry struct {
 	To         string    `json:"to"`
 	From       string    `json:"from"`
-	Seq        uint64    `json:"seq"`
+	Seq        uint64    `json:"seq,omitempty"`
+	Stamp      string    `json:"stamp,omitempty"`
+	Suffix     string    `json:"suffix,omitempty"`
 	By         time.Time `json:"by"` // deadline; By < now => expired (dead-recipient signal).
 	RecordedAt time.Time `json:"recorded_at"`
 }
 
 // Key returns the committed delivery identity this obligation is keyed on.
-func (e OwedEntry) Key() MsgID { return MsgID{To: e.To, From: e.From, Seq: e.Seq} }
+func (e OwedEntry) Key() OwedKey {
+	return OwedKey{To: e.To, From: e.From, Seq: e.Seq, Stamp: e.Stamp, Suffix: e.Suffix}
+}
+
+// MatchesRef reports whether this entry is keyed by the supplied identity.
+func (e OwedEntry) MatchesRef(key OwedIdentity) bool {
+	return e.Key().Equal(key)
+}
 
 // OwedLedger is the JSON shape of <loop>/state/<asker>/owed.json.
 type OwedLedger struct {
@@ -68,9 +143,8 @@ func owedPath(cfg *Config, asker string) string {
 
 // LoadOwedLedger reads the asker's ledger. A missing file is not an error
 // (returns an empty ledger). Parse errors, oversized files, and NON-CANONICAL
-// entries (invalid agent_ids, seq==0) are surfaced — defense-in-depth so a
-// hand-edited/peer-corrupted state file can't reach the gate with a
-// path-escaping value.
+// entries are surfaced — defense-in-depth so a hand-edited/peer-corrupted state
+// file cannot reach the gate with a path-escaping or unclearable value.
 func LoadOwedLedger(cfg *Config, asker string) (*OwedLedger, error) {
 	if err := ValidateAgentID(asker); err != nil {
 		return nil, err
@@ -94,14 +168,8 @@ func LoadOwedLedger(cfg *Config, asker string) (*OwedLedger, error) {
 		ledger.Owed = []OwedEntry{}
 	}
 	for i, e := range ledger.Owed {
-		if err := ValidateAgentID(e.To); err != nil {
-			return nil, fmt.Errorf("parse owed ledger %s: entry %d has invalid to: %w", path, i, err)
-		}
-		if err := ValidateAgentID(e.From); err != nil {
-			return nil, fmt.Errorf("parse owed ledger %s: entry %d has invalid from: %w", path, i, err)
-		}
-		if e.Seq == 0 {
-			return nil, fmt.Errorf("parse owed ledger %s: entry %d has zero seq", path, i)
+		if err := validateOwedKey(e.Key()); err != nil {
+			return nil, fmt.Errorf("parse owed ledger %s: entry %d: %w", path, i, err)
 		}
 	}
 	return &ledger, nil
@@ -127,24 +195,22 @@ func SaveOwedLedger(cfg *Config, asker string, ledger *OwedLedger) error {
 }
 
 // RecordOwed records an obligation when asker sends a reply_required message
-// keyed (To=recipient, From=asker, Seq). Idempotent on the MsgID key (re-record
-// is a no-op). Runs under withAgentLock(asker). `now` is injectable for
-// deterministic recorded_at.
-func RecordOwed(cfg *Config, asker string, key MsgID, by, now time.Time) error {
+// keyed by either committed identity form. Re-recording the same key is a no-op.
+// Runs under withAgentLock(asker). `now` is injectable for deterministic
+// recorded_at.
+func RecordOwed(cfg *Config, asker string, identity OwedIdentity, by, now time.Time) error {
 	if err := ValidateAgentID(asker); err != nil {
 		return err
 	}
-	if err := ValidateAgentID(key.From); err != nil {
-		return fmt.Errorf("RecordOwed: from: %w", err)
+	if identity == nil {
+		return fmt.Errorf("RecordOwed: identity is nil")
 	}
-	if err := ValidateAgentID(key.To); err != nil {
-		return fmt.Errorf("RecordOwed: to: %w", err)
+	key := identity.OwedKey()
+	if err := validateOwedKey(key); err != nil {
+		return fmt.Errorf("RecordOwed: %w", err)
 	}
 	if key.From != asker {
 		return fmt.Errorf("RecordOwed: key.From %q must equal asker %q (the ledger owner)", key.From, asker)
-	}
-	if key.Seq == 0 {
-		return fmt.Errorf("RecordOwed: seq must be >= 1")
 	}
 	return withAgentLock(cfg, asker, func() error {
 		ledger, err := LoadOwedLedger(cfg, asker)
@@ -152,7 +218,7 @@ func RecordOwed(cfg *Config, asker string, key MsgID, by, now time.Time) error {
 			return err
 		}
 		for _, e := range ledger.Owed {
-			if e.Key().Equal(key) {
+			if e.MatchesRef(key) {
 				return nil // idempotent: obligation already recorded.
 			}
 		}
@@ -160,6 +226,8 @@ func RecordOwed(cfg *Config, asker string, key MsgID, by, now time.Time) error {
 			To:         key.To,
 			From:       key.From,
 			Seq:        key.Seq,
+			Stamp:      key.Stamp,
+			Suffix:     key.Suffix,
 			By:         by.UTC(),
 			RecordedAt: now.UTC(),
 		})
@@ -167,13 +235,18 @@ func RecordOwed(cfg *Config, asker string, key MsgID, by, now time.Time) error {
 	})
 }
 
-// ClearOwed discharges the obligation keyed by `key` — called when asker
-// consumes a reply whose in_reply_to references (key.To, key.From, key.Seq). A
-// non-matching key removes nothing (the obligation stays). Idempotent: clearing
-// an absent key is a no-op success. Runs under withAgentLock(asker).
-func ClearOwed(cfg *Config, asker string, key MsgID) error {
+// ClearOwed discharges the obligation keyed by either supported identity form.
+// A non-matching key removes nothing. Clearing an absent key is idempotent.
+func ClearOwed(cfg *Config, asker string, identity OwedIdentity) error {
 	if err := ValidateAgentID(asker); err != nil {
 		return err
+	}
+	if identity == nil {
+		return fmt.Errorf("ClearOwed: identity is nil")
+	}
+	key := identity.OwedKey()
+	if err := validateOwedKey(key); err != nil {
+		return fmt.Errorf("ClearOwed: %w", err)
 	}
 	return withAgentLock(cfg, asker, func() error {
 		ledger, err := LoadOwedLedger(cfg, asker)
@@ -183,7 +256,7 @@ func ClearOwed(cfg *Config, asker string, key MsgID) error {
 		kept := make([]OwedEntry, 0, len(ledger.Owed))
 		removed := false
 		for _, e := range ledger.Owed {
-			if e.Key().Equal(key) {
+			if e.MatchesRef(key) {
 				removed = true
 				continue
 			}

--- a/internal/loop/owed.go
+++ b/internal/loop/owed.go
@@ -12,8 +12,8 @@ import (
 // owed.go — the ASKER-OWNED obligation ledger, the SOLE reply-obligation
 // mechanism (v0.9.0 `.owed` redesign; protocol-v2 TEAM-DECISION §3).
 //
-// The reply obligation is asker-owned only: "I am owed a reply to (to,from,seq)
-// from <recipient> by <T>." Held as an asker-LOCAL `.owed` ledger
+// The reply obligation is asker-owned only: "I am owed a reply to this committed
+// delivery identity from <recipient> by <T>." Held as an asker-LOCAL `.owed` ledger
 // (single-writer, atomic rename). The gate reads ONLY its own `.owed`; it never
 // scans peers. It is NON-BLOCKING: an outstanding/expired obligation surfaces as
 // a gate WARNING, never a finish blocker.
@@ -245,9 +245,6 @@ func ClearOwed(cfg *Config, asker string, identity OwedIdentity) error {
 		return fmt.Errorf("ClearOwed: identity is nil")
 	}
 	key := identity.OwedKey()
-	if err := validateOwedKey(key); err != nil {
-		return fmt.Errorf("ClearOwed: %w", err)
-	}
 	return withAgentLock(cfg, asker, func() error {
 		ledger, err := LoadOwedLedger(cfg, asker)
 		if err != nil {

--- a/internal/loop/owed_test.go
+++ b/internal/loop/owed_test.go
@@ -86,6 +86,26 @@ func TestRecordThenClearTimestampIdentity(t *testing.T) {
 	}
 }
 
+func TestRecordOwedRejectsFilenameTsIDUntilRecipientIsSet(t *testing.T) {
+	cfg := newOwedTestConfig(t)
+	now := time.Now()
+	id, ok := ParseTsFilename("20260730T182415123456Z_from-alice_r" + testTsSuffix + ".md")
+	if !ok {
+		t.Fatal("ParseTsFilename failed")
+	}
+	if id.To != "" {
+		t.Fatalf("filename-derived TsID.To = %q, want empty", id.To)
+	}
+	if err := RecordOwed(cfg, "alice", id, now.Add(time.Hour), now); err == nil {
+		t.Fatal("RecordOwed accepted filename-derived TsID without setting To")
+	}
+
+	id.To = "bob"
+	if err := RecordOwed(cfg, "alice", id, now.Add(time.Hour), now); err != nil {
+		t.Fatalf("RecordOwed rejected TsID after setting To: %v", err)
+	}
+}
+
 func TestClearOwedMatchesOnlySameIdentityForm(t *testing.T) {
 	cfg := newOwedTestConfig(t)
 	now := time.Now()

--- a/internal/loop/owed_test.go
+++ b/internal/loop/owed_test.go
@@ -50,6 +50,66 @@ func TestRecordThenClearOnMatchingReply(t *testing.T) {
 	}
 }
 
+func TestRecordThenClearTimestampIdentity(t *testing.T) {
+	cfg := newOwedTestConfig(t)
+	now := time.Date(2026, 7, 30, 18, 24, 15, 0, time.UTC)
+	key := TsID{
+		To:     "bob",
+		From:   "alice",
+		Stamp:  "20260730T182415123456Z",
+		Suffix: testTsSuffix,
+	}
+
+	if err := RecordOwed(cfg, "alice", key, now.Add(time.Hour), now); err != nil {
+		t.Fatalf("RecordOwed: %v", err)
+	}
+	ledger, err := LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ledger.Owed) != 1 || !ledger.Owed[0].MatchesRef(key) {
+		t.Fatalf("timestamp obligation = %+v, want key %+v", ledger.Owed, key)
+	}
+	if got := ledger.Owed[0].Key().RefString(); got != key.RefString() {
+		t.Fatalf("rendered timestamp ref = %q, want %q", got, key.RefString())
+	}
+
+	if err := ClearOwed(cfg, "alice", key); err != nil {
+		t.Fatalf("ClearOwed: %v", err)
+	}
+	ledger, err = LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ledger.Owed) != 0 {
+		t.Fatalf("timestamp obligation remained after clear: %+v", ledger.Owed)
+	}
+}
+
+func TestClearOwedMatchesOnlySameIdentityForm(t *testing.T) {
+	cfg := newOwedTestConfig(t)
+	now := time.Now()
+	tsKey := TsID{
+		To:     "bob",
+		From:   "alice",
+		Stamp:  "20260730T182415123456Z",
+		Suffix: testTsSuffix,
+	}
+	if err := RecordOwed(cfg, "alice", tsKey, now.Add(time.Hour), now); err != nil {
+		t.Fatal(err)
+	}
+	if err := ClearOwed(cfg, "alice", MsgID{To: "bob", From: "alice", Seq: 1}); err != nil {
+		t.Fatal(err)
+	}
+	ledger, err := LoadOwedLedger(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ledger.Owed) != 1 || !ledger.Owed[0].MatchesRef(tsKey) {
+		t.Fatalf("legacy key cleared timestamp obligation: %+v", ledger.Owed)
+	}
+}
+
 func TestClearNonMatchingLeavesObligation(t *testing.T) {
 	cfg := newOwedTestConfig(t)
 	now := time.Now()
@@ -119,7 +179,7 @@ func TestSaveOwedLedgerRoundTrips(t *testing.T) {
 	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC).UTC()
 	in := &OwedLedger{Owed: []OwedEntry{
 		{To: "bob", From: "alice", Seq: 1, By: now.Add(time.Hour), RecordedAt: now},
-		{To: "carol", From: "alice", Seq: 5, By: now.Add(2 * time.Hour), RecordedAt: now},
+		{To: "carol", From: "alice", Stamp: "20260730T182415123456Z", Suffix: testTsSuffix, By: now.Add(2 * time.Hour), RecordedAt: now},
 	}}
 	if err := SaveOwedLedger(cfg, "alice", in); err != nil {
 		t.Fatalf("SaveOwedLedger: %v", err)
@@ -134,7 +194,7 @@ func TestSaveOwedLedgerRoundTrips(t *testing.T) {
 	if out.Owed[0].To != "bob" || out.Owed[0].Seq != 1 || !out.Owed[0].By.Equal(now.Add(time.Hour)) {
 		t.Fatalf("entry 0 mismatch: %+v", out.Owed[0])
 	}
-	if out.Owed[1].To != "carol" || out.Owed[1].Seq != 5 {
+	if out.Owed[1].To != "carol" || out.Owed[1].Stamp != "20260730T182415123456Z" || out.Owed[1].Suffix != testTsSuffix {
 		t.Fatalf("entry 1 mismatch: %+v", out.Owed[1])
 	}
 }
@@ -161,13 +221,31 @@ func TestLoadOwedLedgerRejectsNonCanonical(t *testing.T) {
 		t.Fatal("non-canonical to must be rejected on load")
 	}
 
-	// Zero seq is also non-canonical.
+	// Neither identity form is non-canonical.
 	badSeq := []byte(`{"owed":[{"to":"bob","from":"alice","seq":0,"by":"2026-06-30T13:00:00Z","recorded_at":"2026-06-30T12:00:00Z"}]}`)
 	if err := atomicWriteFile(owedPath(cfg, "alice"), badSeq); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := LoadOwedLedger(cfg, "alice"); err == nil {
-		t.Fatal("zero seq must be rejected on load")
+		t.Fatal("entry with neither identity form must be rejected on load")
+	}
+
+	// Both identity forms are non-canonical.
+	both := []byte(`{"owed":[{"to":"bob","from":"alice","seq":1,"stamp":"20260730T182415123456Z","suffix":"9f2c04aa71de4b02b6d1c33f08e95a17","by":"2026-06-30T13:00:00Z","recorded_at":"2026-06-30T12:00:00Z"}]}`)
+	if err := atomicWriteFile(owedPath(cfg, "alice"), both); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadOwedLedger(cfg, "alice"); err == nil {
+		t.Fatal("entry with both identity forms must be rejected on load")
+	}
+
+	// A partial timestamp identity is non-canonical.
+	partialTs := []byte(`{"owed":[{"to":"bob","from":"alice","stamp":"20260730T182415123456Z","by":"2026-06-30T13:00:00Z","recorded_at":"2026-06-30T12:00:00Z"}]}`)
+	if err := atomicWriteFile(owedPath(cfg, "alice"), partialTs); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadOwedLedger(cfg, "alice"); err == nil {
+		t.Fatal("partial timestamp identity must be rejected on load")
 	}
 }
 

--- a/internal/loop/tsid.go
+++ b/internal/loop/tsid.go
@@ -1,0 +1,105 @@
+package loop
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// TsID is the timestamp-based message identity introduced for the v2.5
+// migration. The timestamp and suffix together replace the legacy per-pair
+// sequence counter.
+type TsID struct {
+	To     string
+	From   string
+	Stamp  string
+	Suffix string
+}
+
+const tsStampLayout = "20060102T150405"
+
+var (
+	tsStampRE    = regexp.MustCompile(`^\d{8}T\d{12}Z$`)
+	tsSuffixRE   = regexp.MustCompile(`^[0-9a-f]{32}$`)
+	tsFilenameRE = regexp.MustCompile(
+		`^(\d{8}T\d{12}Z)_from-(` + agentIDPattern + `)_r([0-9a-f]{32})\.md$`,
+	)
+	tsRefRE = regexp.MustCompile(
+		`^to-(` + agentIDPattern + `)_from-(` + agentIDPattern + `)_(\d{8}T\d{12}Z)_r([0-9a-f]{32})$`,
+	)
+)
+
+// FormatStamp returns the fixed-width, microsecond-precision UTC wire form.
+func FormatStamp(t time.Time) string {
+	t = t.UTC()
+	return t.Format(tsStampLayout) + fmt.Sprintf("%06dZ", t.Nanosecond()/1000)
+}
+
+// ParseStamp parses the exact fixed-width timestamp wire form.
+func ParseStamp(stamp string) (time.Time, bool) {
+	if !tsStampRE.MatchString(stamp) {
+		return time.Time{}, false
+	}
+	base, err := time.Parse(tsStampLayout, stamp[:15])
+	if err != nil {
+		return time.Time{}, false
+	}
+	micros, err := strconv.ParseInt(stamp[15:21], 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return base.Add(time.Duration(micros) * time.Microsecond), true
+}
+
+// Filename returns the timestamp-format inbox filename.
+func (t TsID) Filename() string {
+	return fmt.Sprintf("%s_from-%s_r%s%s", t.Stamp, t.From, t.Suffix, inboxFilenameSuffix)
+}
+
+// RefString returns the canonical timestamp-format in_reply_to reference.
+func (t TsID) RefString() string {
+	return fmt.Sprintf("to-%s_from-%s_%s_r%s", t.To, t.From, t.Stamp, t.Suffix)
+}
+
+// Equal reports whether two timestamp identities denote the same delivery key.
+func (t TsID) Equal(other TsID) bool {
+	return t.To == other.To &&
+		t.From == other.From &&
+		t.Stamp == other.Stamp &&
+		t.Suffix == other.Suffix
+}
+
+// ParseTsFilename parses a timestamp-format inbox filename. To is not encoded
+// in the filename and is therefore left empty in the returned identity.
+func ParseTsFilename(name string) (TsID, bool) {
+	m := tsFilenameRE.FindStringSubmatch(name)
+	if m == nil {
+		return TsID{}, false
+	}
+	if _, ok := ParseStamp(m[1]); !ok {
+		return TsID{}, false
+	}
+	if err := ValidateAgentID(m[2]); err != nil {
+		return TsID{}, false
+	}
+	return TsID{From: m[2], Stamp: m[1], Suffix: m[3]}, true
+}
+
+// ParseTsRef parses a timestamp-format in_reply_to reference.
+func ParseTsRef(ref string) (TsID, bool) {
+	m := tsRefRE.FindStringSubmatch(ref)
+	if m == nil {
+		return TsID{}, false
+	}
+	if err := ValidateAgentID(m[1]); err != nil {
+		return TsID{}, false
+	}
+	if err := ValidateAgentID(m[2]); err != nil {
+		return TsID{}, false
+	}
+	if _, ok := ParseStamp(m[3]); !ok {
+		return TsID{}, false
+	}
+	return TsID{To: m[1], From: m[2], Stamp: m[3], Suffix: m[4]}, true
+}

--- a/internal/loop/tsid_test.go
+++ b/internal/loop/tsid_test.go
@@ -1,0 +1,134 @@
+package loop
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+	"time"
+)
+
+const testTsSuffix = "9f2c04aa71de4b02b6d1c33f08e95a17"
+
+func TestTsIDWorkedExampleRoundTrips(t *testing.T) {
+	id := TsID{
+		To:     "claude-code",
+		From:   "codex-agentchute",
+		Stamp:  "20260730T182415123456Z",
+		Suffix: testTsSuffix,
+	}
+	filename := "20260730T182415123456Z_from-codex-agentchute_r" + testTsSuffix + ".md"
+	ref := "to-claude-code_from-codex-agentchute_20260730T182415123456Z_r" + testTsSuffix
+
+	if got := id.Filename(); got != filename {
+		t.Fatalf("Filename() = %q, want %q", got, filename)
+	}
+	parsedFilename, ok := ParseTsFilename(filename)
+	if !ok {
+		t.Fatal("worked filename did not parse")
+	}
+	if parsedFilename.From != id.From || parsedFilename.Stamp != id.Stamp || parsedFilename.Suffix != id.Suffix {
+		t.Fatalf("ParseTsFilename = %+v, want filename fields from %+v", parsedFilename, id)
+	}
+
+	if got := id.RefString(); got != ref {
+		t.Fatalf("RefString() = %q, want %q", got, ref)
+	}
+	parsedRef, ok := ParseTsRef(ref)
+	if !ok || !parsedRef.Equal(id) {
+		t.Fatalf("ParseTsRef = (%+v, %v), want (%+v, true)", parsedRef, ok, id)
+	}
+}
+
+func TestFormatParseStampRoundTrip(t *testing.T) {
+	cases := []time.Time{
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 7, 30, 18, 24, 15, 123456789, time.FixedZone("offset", -5*60*60)),
+		time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC),
+	}
+	for _, input := range cases {
+		stamp := FormatStamp(input)
+		if len(stamp) != 22 {
+			t.Fatalf("FormatStamp(%s) length = %d, want 22: %q", input, len(stamp), stamp)
+		}
+		got, ok := ParseStamp(stamp)
+		if !ok {
+			t.Fatalf("ParseStamp(%q) failed", stamp)
+		}
+		want := input.UTC().Truncate(time.Microsecond)
+		if !got.Equal(want) {
+			t.Fatalf("ParseStamp(FormatStamp(%s)) = %s, want %s", input, got, want)
+		}
+	}
+}
+
+func TestFormatStampLexicographicSortIsChronological(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	base := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	times := make([]time.Time, 500)
+	for i := range times {
+		times[i] = base.Add(time.Duration(rng.Int63n(int64(20 * 365 * 24 * time.Hour)))).Truncate(time.Microsecond)
+	}
+	chronological := append([]time.Time(nil), times...)
+	sort.Slice(chronological, func(i, j int) bool { return chronological[i].Before(chronological[j]) })
+	stamps := make([]string, len(times))
+	for i, value := range times {
+		stamps[i] = FormatStamp(value)
+	}
+	sort.Strings(stamps)
+	for i, stamp := range stamps {
+		if want := FormatStamp(chronological[i]); stamp != want {
+			t.Fatalf("sorted stamp[%d] = %q, want chronological %q", i, stamp, want)
+		}
+	}
+}
+
+func TestTsIDParsersRejectNonCanonicalForms(t *testing.T) {
+	validStamp := "20260730T182415123456Z"
+	validFilename := validStamp + "_from-codex_r" + testTsSuffix + ".md"
+	validRef := "to-claude-code_from-codex_" + validStamp + "_r" + testTsSuffix
+
+	filenameCases := []string{
+		"",
+		"2026-07-30T18:24:15.123456Z_from-codex_r" + testTsSuffix + ".md",
+		"20260730T18241512345Z_from-codex_r" + testTsSuffix + ".md",
+		validStamp + "_from-codex_r9F2c04aa71de4b02b6d1c33f08e95a17.md",
+		validStamp + "_from-codex_r9f2c.md",
+		validStamp + "_from-CODEX_r" + testTsSuffix + ".md",
+		"20260230T182415123456Z_from-codex_r" + testTsSuffix + ".md",
+		validFilename + ".md",
+	}
+	for _, value := range filenameCases {
+		if _, ok := ParseTsFilename(value); ok {
+			t.Errorf("ParseTsFilename(%q) accepted non-canonical value", value)
+		}
+	}
+
+	refCases := []string{
+		"",
+		"to-claude-code_from-codex_2026-07-30T18:24:15.123456Z_r" + testTsSuffix,
+		"to-claude-code_from-codex_" + validStamp + "_r9F2c04aa71de4b02b6d1c33f08e95a17",
+		"to-claude-code_from-codex_" + validStamp + "_r9f2c",
+		"to-Claude_from-codex_" + validStamp + "_r" + testTsSuffix,
+		validRef + "_extra",
+	}
+	for _, value := range refCases {
+		if _, ok := ParseTsRef(value); ok {
+			t.Errorf("ParseTsRef(%q) accepted non-canonical value", value)
+		}
+	}
+}
+
+func TestParseStampRejectsNonCanonicalForms(t *testing.T) {
+	for _, stamp := range []string{
+		"",
+		"20260730T18241512345Z",
+		"20260730T1824151234567Z",
+		"2026-07-30T18:24:15.123456Z",
+		"20260230T182415123456Z",
+		"20260730t182415123456Z",
+	} {
+		if _, ok := ParseStamp(stamp); ok {
+			t.Errorf("ParseStamp(%q) accepted non-canonical value", stamp)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add strict timestamp identity filename, reference, and stamp parsers
- dual-read old and timestamp formats in inbox, claimed residue, reply refs, and owed obligations
- preserve the legacy seq writer; no B7 writer or allocator changes

## Verification
- gofmt -w .
- go vet ./...
- go test ./...
- go build ./...
- go test -race ./...
- cd conformance && go test ./...
- sh tests/install_test.sh

## Deviations
- None.