### PR TITLE
feat(registration): soft-state registration + lazy sweep (v2.5 plan B1)

### DIFF
--- a/internal/cli/b1_convergence_test.go
+++ b/internal/cli/b1_convergence_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// TestB1ConvergencePoolWithDeadRowsAndLiveServe is B1's own Done-when
+// acceptance (v2.5 plan B1), proven in a test rather than by hand: a pool
+// with one live serve and two dead rows converges — dead rows are gone
+// after boot or a serve poll tick; the live row survives indefinitely;
+// killing the serve lets its own row age out and be swept by a peer's boot;
+// restarting recreates it.
+//
+// A very short --stale-after ("50ms") lets the test control staleness by
+// backdating registration timestamps rather than sleeping in real time; a
+// poll tick's lazy sweep is due immediately on its first call regardless
+// (lastSweep's zero value), so no sweepInterval shrinking is needed either.
+func TestB1ConvergencePoolWithDeadRowsAndLiveServe(t *testing.T) {
+	root := setupShortRunFixture(t)
+	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPoolState(cfg, "runner", nil, "50ms"); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	writeConvergenceRegistration(t, cfg, "dead-one", now.Add(-time.Hour))
+	writeConvergenceRegistration(t, cfg, "dead-two", now.Add(-time.Hour))
+
+	// The live serve: a real runnerRuntime (real lease, real registration).
+	rt := newPollTestRuntime(t, cfg, "live-agent")
+
+	// dead-one/dead-two gone after ONE poll tick (the "≤10min of serve" path;
+	// lastSweep's zero value makes the very first tick due immediately).
+	rt.pollOnce()
+	for _, id := range []string{"dead-one", "dead-two"} {
+		if _, err := os.Stat(cfg.AgentRegistrationPath(id)); !os.IsNotExist(err) {
+			t.Fatalf("%s should be swept by serve's poll tick: stat err = %v", id, err)
+		}
+	}
+	live, err := loop.ReadRegistration(cfg.AgentRegistrationPath("live-agent"))
+	if err != nil {
+		t.Fatalf("live-agent row missing after its own poll tick: %v", err)
+	}
+	// Registration timestamps round-trip at whole-second precision
+	// (formatTimestamp uses time.RFC3339), so compare against `now` truncated
+	// the same way rather than a spurious same-second sub-second mismatch.
+	if live.LastSeen.Before(now.Truncate(time.Second)) {
+		t.Fatalf("live-agent row was not heartbeated: LastSeen = %s", live.LastSeen)
+	}
+
+	// The live row survives across further ticks.
+	rt.pollOnce()
+	if _, err := os.Stat(cfg.AgentRegistrationPath("live-agent")); err != nil {
+		t.Fatalf("live-agent row should survive while heartbeating: %v", err)
+	}
+
+	// Kill the serve: release its lease (no more heartbeats), then let its
+	// own row age out past stale_after. A DIFFERENT agent's boot sweeps it —
+	// live-agent is not that peer's self, so it is not exempt.
+	if err := loop.ReleaseLease(rt.lease); err != nil {
+		t.Fatal(err)
+	}
+	writeConvergenceRegistration(t, cfg, "live-agent", time.Now().UTC().Add(-time.Hour))
+
+	withCwd(t, root, func() {
+		if _, err := captureStdout(t, func() error {
+			return cmdBoot([]string{"--as", "peer-agent", "--vendor", "anthropic", "--json"})
+		}); err != nil {
+			t.Fatalf("peer boot: %v", err)
+		}
+	})
+	if _, err := os.Stat(cfg.AgentRegistrationPath("live-agent")); !os.IsNotExist(err) {
+		t.Fatalf("dead live-agent row should be swept by the peer's boot: stat err = %v", err)
+	}
+
+	// Restart recreates it.
+	withCwd(t, root, func() {
+		if _, err := captureStdout(t, func() error {
+			return cmdBoot([]string{"--as", "live-agent", "--vendor", "test", "--json"})
+		}); err != nil {
+			t.Fatalf("restart boot: %v", err)
+		}
+	})
+	if _, err := loop.ReadRegistration(cfg.AgentRegistrationPath("live-agent")); err != nil {
+		t.Fatalf("live-agent row should be recreated on restart: %v", err)
+	}
+}
+
+func writeConvergenceRegistration(t *testing.T, cfg *loop.Config, agentID string, lastSeen time.Time) {
+	t.Helper()
+	reg := &loop.Registration{
+		AgentID:     agentID,
+		Vendor:      "test",
+		ControlRepo: cfg.ControlRepo,
+		LastSeen:    lastSeen,
+		Status:      loop.StatusActive,
+	}
+	if err := loop.WriteRegistration(cfg.AgentRegistrationPath(agentID), reg); err != nil {
+		t.Fatalf("seed registration %s: %v", agentID, err)
+	}
+}

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -104,6 +104,15 @@ func cmdBoot(args []string) error {
 		return fmt.Errorf("write active session heartbeat: %w", err)
 	}
 
+	// C11: boot is one of the two sweep triggers (the other is serve's slow
+	// poll tick) — register-self-first, THEN sweep peers, so a pool whose only
+	// runner is offline still gets bounded hygiene from whoever boots into it.
+	// A sweep failure is a warning, never a boot failure: hygiene is best-effort
+	// and must not block session start.
+	if _, serr := loop.SweepStaleRegistrations(cfg, agentID, now); serr != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("sweep stale registrations: %v", serr))
+	}
+
 	// Inbox peek — strictly side-effect free, same path `pending` uses.
 	msgs, skipped, err := loop.ListInboxMessagesWithSkipped(result.InboxDir)
 	if err != nil {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -113,6 +113,58 @@ func TestBootRefreshExistingRegistrationExitsZero(t *testing.T) {
 	})
 }
 
+// C11/B1: boot is one of the two sweep triggers. This confirms the actual
+// wiring order in cmdBoot — register self FIRST, sweep peers SECOND — by
+// seeding a stale row for BOTH self and a peer: the peer's stale, claim-dead
+// row must be swept, while self's own (also stale-looking, pre-boot) row
+// must survive and come out refreshed rather than removed.
+func TestBootRegistersSelfFirstThenSweepsStalePeers(t *testing.T) {
+	root := setupBootFixture(t)
+	withCwd(t, root, func() {
+		t.Setenv("TMUX_PANE", "%1")
+		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		old := time.Now().UTC().Add(-2 * time.Hour) // past the 1h default StaleAfter.
+		selfReg := &loop.Registration{
+			AgentID:     "claude-code",
+			Vendor:      "anthropic",
+			ControlRepo: cfg.ControlRepo,
+			LastSeen:    old,
+			Status:      loop.StatusActive,
+		}
+		if err := loop.WriteRegistration(cfg.AgentRegistrationPath("claude-code"), selfReg); err != nil {
+			t.Fatal(err)
+		}
+		peerReg := &loop.Registration{
+			AgentID:     "stale-peer",
+			Vendor:      "openai",
+			ControlRepo: cfg.ControlRepo,
+			LastSeen:    old,
+			Status:      loop.StatusActive,
+		}
+		if err := loop.WriteRegistration(cfg.AgentRegistrationPath("stale-peer"), peerReg); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := captureStdout(t, func() error { return cmdBoot(bootArgs("--json")) }); err != nil {
+			t.Fatalf("cmdBoot: %v", err)
+		}
+
+		if _, err := os.Stat(cfg.AgentRegistrationPath("stale-peer")); !os.IsNotExist(err) {
+			t.Fatalf("stale peer row survived boot's sweep: stat err = %v", err)
+		}
+		self, err := loop.ReadRegistration(cfg.AgentRegistrationPath("claude-code"))
+		if err != nil {
+			t.Fatalf("self row missing after boot: %v", err)
+		}
+		if !self.LastSeen.After(old) {
+			t.Fatalf("self row was not refreshed by boot's own registration step: LastSeen = %s", self.LastSeen)
+		}
+	})
+}
+
 // Test 8 line 3: registration with 1 unread direct mail → boot exits 2.
 func TestBootWithUnreadMailReturnsBlocked(t *testing.T) {
 	root := setupBootFixture(t)

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -87,13 +87,13 @@ func cmdCheck(args []string) error {
 	// for an unregistered agent. check is an active agent command — it
 	// archives, quarantines, and sends corrective notify; all of those
 	// imply the agent IS enrolled in the pool.
+	// B1: CLI touches no longer refresh liveness — only serve's lease-gated
+	// heartbeat does (HeartbeatRegistration). This preflight only confirms
+	// the agent is enrolled at all.
 	selfPath := cfg.AgentRegistrationPath(agentID)
 	selfExists := false
 	if _, err := os.Stat(selfPath); err == nil {
 		selfExists = true
-		if err := loop.UpdateLastSeen(cfg, agentID, now); err != nil {
-			return fmt.Errorf("update last_seen for %s: %w", agentID, err)
-		}
 	} else if os.IsNotExist(err) {
 		return fmt.Errorf("agent %q is not registered. Run `agentchute boot --as %s --vendor <vendor>` first (AGENTCHUTE.md §5.3)", agentID, agentID)
 	} else {

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -227,12 +227,12 @@ func publishRegistrationOnce(cfg *loop.Config, opts registerOpts, host string, n
 	// is first established. Every enrollment path (boot, register) funnels
 	// through here, so this is the single place a freshly registered agent gets
 	// its first `.live` — letting it read LIVE immediately, before its first
-	// UpdateLastSeen heartbeat tick (runner tick / check / send / status).
-	// busy=false: busy is advisory and is set only by serve. WriteLive is a
-	// separate atomic file write and takes no agent lock, so emitting it here
-	// (after WithAgentLock has returned) is safe. Treated as fatal: with `.live`
-	// the source of liveness, a registered agent with no initial `.live` would
-	// read stale at gate/doctor until its first tick.
+	// HeartbeatRegistration tick (serve's poll loop; B1 — CLI touches no longer
+	// refresh liveness). busy=false: busy is advisory and is set only by serve.
+	// WriteLive is a separate atomic file write and takes no agent lock, so
+	// emitting it here (after WithAgentLock has returned) is safe. Treated as
+	// fatal: with `.live` the source of liveness, a registered agent with no
+	// initial `.live` would read stale at gate/doctor until its first tick.
 	if err := loop.WriteLive(cfg, opts.AgentID, false); err != nil {
 		return nil, fmt.Errorf("write initial .live presence: %w", err)
 	}

--- a/internal/cli/register_test.go
+++ b/internal/cli/register_test.go
@@ -35,6 +35,19 @@ func TestRegister_RMWUnderAgentLock(t *testing.T) {
 		if _, err := performRegister(cfg, seed, now); err != nil {
 			t.Fatal(err)
 		}
+		// B1: the heartbeat is lease-gated, so racing it here needs a real
+		// serve lease token, not merely a timestamp.
+		lease, err := loop.AcquireServeLease(cfg, agentID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		template := loop.Registration{
+			AgentID:      agentID,
+			Vendor:       "anthropic",
+			ControlRepo:  cfg.ControlRepo,
+			WorkingRepos: []string{cfg.ControlRepo},
+			Status:       loop.StatusActive,
+		}
 
 		var wg sync.WaitGroup
 		errs := make(chan error, 128)
@@ -49,12 +62,12 @@ func TestRegister_RMWUnderAgentLock(t *testing.T) {
 				}
 			}(i)
 		}
-		// ...racing UpdateLastSeen on the same registration.
+		// ...racing HeartbeatRegistration on the same registration.
 		for i := 0; i < 30; i++ {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				if err := loop.UpdateLastSeen(cfg, agentID, now.Add(time.Duration(i)*time.Minute)); err != nil {
+				if err := loop.HeartbeatRegistration(cfg, template, lease.Token); err != nil {
 					errs <- err
 				}
 			}(i)
@@ -62,7 +75,7 @@ func TestRegister_RMWUnderAgentLock(t *testing.T) {
 		wg.Wait()
 		close(errs)
 		for err := range errs {
-			t.Fatalf("concurrent register/update: %v", err)
+			t.Fatalf("concurrent register/heartbeat: %v", err)
 		}
 
 		// The file must always be readable (never half-written / torn).

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -183,11 +183,10 @@ func TestRunnerPollShutsDownWhenFenced(t *testing.T) {
 		t.Fatal(err)
 	}
 	rt := newPollTestRuntime(t, cfg, "runner-test")
-	lease, err := loop.AcquireServeLease(cfg, "runner-test")
-	if err != nil {
-		t.Fatalf("acquire lease: %v", err)
-	}
-	rt.lease = lease
+	// newPollTestRuntime already acquires a real lease for "runner-test"
+	// (B1: HeartbeatRegistration needs a genuine token); reuse it rather than
+	// acquiring a second one, which would fail closed (ErrLeaseHeld) against
+	// the fixture's still-fresh claim.
 
 	// Simulate a reclaim: overwrite the live claim with a different serve_token.
 	reclaimed := loop.ServeClaim{
@@ -223,11 +222,10 @@ func TestRunnerFencedShutdownLogsAndBuffersFatal(t *testing.T) {
 	rt := newPollTestRuntime(t, cfg, "runner-test")
 	rt.diag = newRunnerDiagnostics(cfg, "runner-test")
 	defer rt.diag.close()
-	lease, err := loop.AcquireServeLease(cfg, "runner-test")
-	if err != nil {
-		t.Fatalf("acquire lease: %v", err)
-	}
-	rt.lease = lease
+	// newPollTestRuntime already acquires a real lease for "runner-test"
+	// (B1: HeartbeatRegistration needs a genuine token); reuse it rather than
+	// acquiring a second one, which would fail closed (ErrLeaseHeld) against
+	// the fixture's still-fresh claim.
 
 	reclaimed := loop.ServeClaim{
 		ID:         "runner-test",
@@ -392,43 +390,12 @@ func TestRunExportsRunnerPIDToWrapper(t *testing.T) {
 	}
 }
 
-// Pull-only (Gate 6c): markRunnerOffline sets Status=offline. The reachability
-// cache it used to clear no longer exists (registrations carry no wake state).
-func TestMarkRunnerOfflineSetsOfflineStatus(t *testing.T) {
-	root := setupShortRunFixture(t)
-	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
-	if err != nil {
-		t.Fatal(err)
-	}
-	agentID := "runner-test"
-	reg := &loop.Registration{
-		AgentID:     agentID,
-		Vendor:      "test",
-		ControlRepo: cfg.ControlRepo,
-		Host:        localHostname(),
-		LastSeen:    time.Now().UTC().Add(-time.Minute),
-		Status:      loop.StatusActive,
-	}
-	if err := loop.WriteRegistration(cfg.AgentRegistrationPath(agentID), reg); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := markRunnerOffline(cfg, agentID); err != nil {
-		t.Fatal(err)
-	}
-	got, err := loop.ReadRegistration(cfg.AgentRegistrationPath(agentID))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Status != loop.StatusOffline {
-		t.Fatalf("status = %s, want offline", got.Status)
-	}
-}
-
 // newPollTestRuntime builds a minimal runnerRuntime sufficient to exercise
-// pollOnce in isolation (no PTY, no socket). It registers the agent so the
-// pollOnce UpdateLastSeen call has a registration to read, and seeds the
-// runner state dir so saveState can write.
+// pollOnce in isolation (no PTY, no socket). It registers the agent and
+// acquires a real serve lease so pollOnce's HeartbeatRegistration call
+// (B1: lease-gated, requires a genuine token) has both a registration to
+// read and a claim to verify against, and seeds the runner state dir so
+// saveState can write.
 func newPollTestRuntime(t *testing.T, cfg *loop.Config, agentID string) *runnerRuntime {
 	t.Helper()
 	if err := loop.EnsurePrivateDir(cfg.AgentInboxDir(agentID)); err != nil {
@@ -444,12 +411,19 @@ func newPollTestRuntime(t *testing.T, cfg *loop.Config, agentID string) *runnerR
 	if err := loop.WriteRegistration(cfg.AgentRegistrationPath(agentID), reg); err != nil {
 		t.Fatal(err)
 	}
+	opts := runnerOptions{AgentID: agentID, Vendor: "test", IntervalSeconds: 5}
+	lease, err := loop.AcquireServeLease(cfg, agentID)
+	if err != nil {
+		t.Fatal(err)
+	}
 	rt := &runnerRuntime{
-		cfg:     cfg,
-		opts:    runnerOptions{AgentID: agentID, Vendor: "test", IntervalSeconds: 5},
-		started: time.Now().UTC(),
-		wakeCh:  make(chan bool, 1),
-		stopCh:  make(chan struct{}),
+		cfg:         cfg,
+		opts:        opts,
+		started:     time.Now().UTC(),
+		lease:       lease,
+		regTemplate: heartbeatTemplate(cfg, opts),
+		wakeCh:      make(chan bool, 1),
+		stopCh:      make(chan struct{}),
 	}
 	return rt
 }

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -109,11 +109,12 @@ func cmdSend(args []string) error {
 	// v0.2.1 "Enforced Enrollment" (AGENTCHUTE.md §5.3): refuse invalid
 	// sender or recipient state before reading stdin, so a piped body remains
 	// untouched on every preflight failure.
+	// B1: CLI touches no longer refresh liveness — only serve's lease-gated
+	// heartbeat does (HeartbeatRegistration). This preflight only confirms
+	// the sender is enrolled at all.
 	selfPath := cfg.AgentRegistrationPath(fromID)
 	if _, err := os.Stat(selfPath); err == nil {
-		if err := loop.UpdateLastSeen(cfg, fromID, time.Now().UTC()); err != nil {
-			return fmt.Errorf("update last_seen for %s: %w", fromID, err)
-		}
+		// registered; proceed.
 	} else if os.IsNotExist(err) {
 		return fmt.Errorf("sender %q is not registered. Run `agentchute boot --as %s --vendor <vendor>` first (AGENTCHUTE.md §5.3)", fromID, fromID)
 	} else {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -38,6 +38,13 @@ const (
 // re-cues never chase their own echo.
 var recueInterval = 60 * time.Second
 
+// sweepInterval bounds how often the runner's poll tick runs
+// SweepStaleRegistrations (v2.5 plan B1, C11). Package var (same pattern as
+// recueInterval/leaseTimeout) so tests can shrink it; production keeps 10m —
+// hygiene stays lazy but bounded, and boot already covers a pool whose only
+// runner is offline.
+var sweepInterval = 10 * time.Minute
+
 type interruptPolicy string
 
 const (
@@ -221,6 +228,17 @@ type runnerRuntime struct {
 	done     <-chan error
 	diag     *runnerDiagnostics
 
+	// regTemplate is the no-wake registration template HeartbeatRegistration
+	// refreshes every tick (v2.5 plan B1, C13). Built once from the same
+	// fields registerRunner used for the initial write, so every heartbeat
+	// re-asserts the same AgentID/Vendor/ControlRepo/Host/provenance.
+	regTemplate loop.Registration
+	// lastSweep is the last time this runner ran SweepStaleRegistrations
+	// (v2.5 plan B1, C11). Zero value means "never yet" — pollOnce treats
+	// that as due immediately, matching boot's "sweep once, early" behavior
+	// for a pool whose only hygiene path is this runner.
+	lastSweep time.Time
+
 	mu                 sync.Mutex
 	ptmxMu             sync.Mutex
 	stopOnce           sync.Once
@@ -385,7 +403,6 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 		_ = cmd.Process.Kill()
 		<-done
 		_ = saveRunnerOfflineState(cfg, opts.AgentID, cmd.Process.Pid, time.Now().UTC())
-		_ = markRunnerOffline(cfg, opts.AgentID)
 		_ = loop.ReleaseLease(lease)
 		return fmt.Errorf("set stdin raw mode: %w", err)
 	}
@@ -398,18 +415,19 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 	}
 
 	rt := &runnerRuntime{
-		cfg:      cfg,
-		opts:     opts,
-		cwd:      cwd,
-		started:  time.Now().UTC(),
-		childPID: cmd.Process.Pid,
-		cmd:      cmd,
-		ptmx:     ptmx,
-		lease:    lease,
-		done:     done,
-		diag:     diag,
-		wakeCh:   make(chan bool, 1),
-		stopCh:   make(chan struct{}),
+		cfg:         cfg,
+		opts:        opts,
+		cwd:         cwd,
+		started:     time.Now().UTC(),
+		childPID:    cmd.Process.Pid,
+		cmd:         cmd,
+		ptmx:        ptmx,
+		lease:       lease,
+		done:        done,
+		diag:        diag,
+		regTemplate: heartbeatTemplate(cfg, opts),
+		wakeCh:      make(chan bool, 1),
+		stopCh:      make(chan struct{}),
 	}
 	nowUnix := time.Now().UnixNano()
 	rt.lastOutputUnixNano.Store(nowUnix)
@@ -420,13 +438,16 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 
 	defer func() {
 		rt.stopLoops()
-		// Wait for the poll loop to fully exit BEFORE marking offline. stopLoops
-		// only closes stopCh; a pollOnce already in flight would otherwise run
-		// its UpdateLastSeen after markRunnerOffline and resurrect Status=active.
+		// B1: a quitting agent does nothing to its registration row — no more
+		// Status=offline write here. The row simply stops heartbeating and
+		// either ages past StaleAfter (swept by boot/serve elsewhere) or gets
+		// refreshed again if this same process relaunches. Still wait for the
+		// poll loop to fully exit before proceeding: rt.pollWG.Wait() below
+		// keeps saveStateWithStatus("offline") (runner.json, not the
+		// registration) from racing a pollOnce still in flight.
 		rt.pollWG.Wait()
 		rt.closePTY()
 		_ = rt.saveStateWithStatus("offline")
-		_ = markRunnerOffline(cfg, opts.AgentID)
 		// Release the serve lease last. ErrFenced => we were already reclaimed
 		// (another serve owns the id); releasing would be a no-op and must not
 		// delete the new owner's claim, so it is not an error to report.
@@ -501,22 +522,25 @@ func registerRunner(cfg *loop.Config, opts runnerOptions, now time.Time) error {
 	return err
 }
 
-func markRunnerOffline(cfg *loop.Config, agentID string) error {
-	// Serialize against a concurrent pollOnce -> UpdateLastSeen so the offline
-	// status write is not clobbered by a stale-read last_seen refresh that would
-	// resurrect Status=active after shutdown. (The caller also joins the poll
-	// loop before invoking this, so by here no poller should still be running;
-	// the lock is belt-and-suspenders against any other writer.)
-	return loop.WithAgentLock(cfg, agentID, func() error {
-		regPath := cfg.AgentRegistrationPath(agentID)
-		reg, err := loop.ReadRegistration(regPath)
-		if err != nil {
-			return err
-		}
-		reg.Status = loop.StatusOffline
-		reg.LastSeen = time.Now().UTC()
-		return loop.WriteRegistration(regPath, reg)
-	})
+// heartbeatTemplate builds the no-wake registration template HeartbeatRegistration
+// refreshes every poll tick (v2.5 plan B1, C13), from the same fields
+// registerRunner passes to performRegister for the runner's initial write.
+// Built once in runWrapper and reused for the lifetime of the process: it is
+// what a swept-then-recreated row comes back as, and what every tick
+// re-asserts for AgentID/Vendor/ControlRepo/Host/provenance (Body and
+// WorkingRepos come from the on-disk row instead — see HeartbeatRegistration).
+func heartbeatTemplate(cfg *loop.Config, opts runnerOptions) loop.Registration {
+	return loop.Registration{
+		AgentID:         opts.AgentID,
+		ProtocolVersion: loop.CurrentProtocolVersion,
+		Vendor:          opts.Vendor,
+		ControlRepo:     cfg.ControlRepo,
+		WorkingRepos:    []string{cfg.ControlRepo},
+		Host:            localHostname(),
+		Status:          loop.StatusActive,
+		LaunchedBy:      loop.LaunchedByRunner,
+		ShimName:        opts.ShimName,
+	}
 }
 
 // refuseLiveRunnerCollision enforces id-uniqueness via the serve lease
@@ -579,8 +603,25 @@ func (r *runnerRuntime) pollOnce() {
 			r.logf("agentchute serve: renew serve lease: %v\n", err)
 		}
 	}
-	if err := loop.UpdateLastSeen(r.cfg, r.opts.AgentID, now); err != nil {
-		r.logf("agentchute serve: update last_seen: %v\n", err)
+	// Lease-gated heartbeat (v2.5 plan B1, C13): unconditional refresh of the
+	// registration row, self-healing if a sweep (ours or a peer's) removed it
+	// since the last tick. nil lease in the poll-only unit-test runtime: skip
+	// rather than pass an empty token, which HeartbeatRegistration rejects.
+	if r.lease != nil {
+		if err := loop.HeartbeatRegistration(r.cfg, r.regTemplate, r.lease.Token); err != nil {
+			r.logf("agentchute serve: heartbeat registration: %v\n", err)
+		}
+	}
+
+	// Lazy sweep (C11): bounded, 10-minute cadence. lastSweep's zero value
+	// makes the very first tick due immediately — harmless even right after
+	// boot's own sweep (nothing is stale seconds later) and useful for a pool
+	// whose runner is its only hygiene path.
+	if now.Sub(r.lastSweep) >= sweepInterval {
+		if _, err := loop.SweepStaleRegistrations(r.cfg, r.opts.AgentID, now); err != nil {
+			r.logf("agentchute serve: sweep stale registrations: %v\n", err)
+		}
+		r.lastSweep = now
 	}
 
 	// Re-cue predicate (v2.5 plan A2, C16/C17): cue whenever mail is pending —

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -39,6 +39,7 @@ type setupOptions struct {
 	ControlRepo string
 	ShimDir     string
 	Profile     string
+	StaleAfter  string
 	Yes         bool
 	DryRun      bool
 	NoProfile   bool
@@ -69,7 +70,12 @@ type setupPoolState struct {
 	Wrappers    []string `json:"wrappers"`
 	ControlRepo string   `json:"control_repo"`
 	LoopDir     string   `json:"loop_dir"`
-	UpdatedAt   string   `json:"updated_at"`
+	// StaleAfter is the C9 registration-staleness threshold (Go duration
+	// string, e.g. "1h"), read by loop.StaleAfter for the sweep/heartbeat
+	// freshness rule. Empty on state written by a pre-v2.5 binary; readers
+	// treat empty as the 1h default rather than treating it as unset config.
+	StaleAfter string `json:"stale_after,omitempty"`
+	UpdatedAt  string `json:"updated_at"`
 }
 
 func cmdSetup(args []string) error {
@@ -88,11 +94,17 @@ func cmdSetup(args []string) error {
 	fs.BoolVar(&opts.InitNew, "init", false, "allow setup to initialize a non-project directory")
 	fs.BoolVar(&opts.Reset, "reset", false, "explicitly run the runtime reset (always performed); required alongside --wipe-state")
 	fs.BoolVar(&opts.WipeState, "wipe-state", false, "DESTRUCTIVE: after reset, wipe loop runtime state (inbox/archive/malformed/live/scratch/state); requires --reset")
+	fs.StringVar(&opts.StaleAfter, "stale-after", "", "registration staleness threshold, e.g. 1h (default: prior value, or 1h on first setup)")
 	if err := fs.Parse(args); err != nil {
 		return setupUsage(err)
 	}
 	if fs.NArg() != 0 {
 		return setupUsage(fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")))
+	}
+	if strings.TrimSpace(opts.StaleAfter) != "" {
+		if _, err := time.ParseDuration(strings.TrimSpace(opts.StaleAfter)); err != nil {
+			return fmt.Errorf("--stale-after %q: %w", opts.StaleAfter, err)
+		}
 	}
 	// --wipe-state is destructive; require the explicit --reset affirmation
 	// alongside it. Reject --wipe-state alone with a clear (non-help) error.
@@ -218,6 +230,8 @@ Flags:
                          a live bus. Use --dry-run to preview, --yes to skip the
                          destructive confirm. Intended for the v0.7.0 -> v2
                          transition.
+  --stale-after <dur>    registration staleness threshold (Go duration, e.g. 1h;
+                         default: prior value, or 1h on first setup)
   --dry-run              print plan without writing files
   --yes                  skip confirmation prompts
 `) + "\n"
@@ -463,6 +477,9 @@ func printSetupPlan(w io.Writer, root string, opts setupOptions, wrappers []stri
 		fmt.Fprintf(w, "  wrappers:     %s\n", strings.Join(wrappers, ", "))
 	}
 	fmt.Fprintf(w, "  init:         %s\n", filepath.Join(root, "AGENTCHUTE.md"))
+	if sa := strings.TrimSpace(opts.StaleAfter); sa != "" {
+		fmt.Fprintf(w, "  stale-after:  %s\n", sa)
+	}
 	if opts.WipeState {
 		fmt.Fprintln(w, "  reset:        DESTRUCTIVE wipe-state — stop local pollers/runners, then WIPE loop runtime")
 		fmt.Fprintln(w, "                state (inbox/archive/malformed/live/scratch/state) + live registrations;")
@@ -690,7 +707,19 @@ func applySetup(root string, opts setupOptions, wrappers []string) error {
 			}
 		}
 
-		if err := writeSetupPoolState(cfg, opts.Wake, wrappers); err != nil {
+		// C9: an explicit --stale-after wins; otherwise a resync (setup re-run,
+		// update's replay) preserves the prior pool value; a genuinely first-ever
+		// setup falls back to the 1h default. This is the "normalize-on-read"
+		// guard — the new field must never be silently dropped by a resync that
+		// only intended to touch wake/wrappers.
+		staleAfter := strings.TrimSpace(opts.StaleAfter)
+		if staleAfter == "" {
+			staleAfter = strings.TrimSpace(poolState.StaleAfter)
+		}
+		if staleAfter == "" {
+			staleAfter = loop.DefaultStaleAfter.String()
+		}
+		if err := writeSetupPoolState(cfg, opts.Wake, wrappers, staleAfter); err != nil {
 			return err
 		}
 		profiles := setupPlausibleProfiles(opts.Profile)
@@ -1240,13 +1269,13 @@ func writeSetupGlobalState(state setupGlobalState) error {
 		return err
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	if err := atomicWriteSetupState(path, data); err != nil {
 		return fmt.Errorf("write setup state: %w", err)
 	}
 	return nil
 }
 
-func writeSetupPoolState(cfg *loop.Config, wake string, wrappers []string) error {
+func writeSetupPoolState(cfg *loop.Config, wake string, wrappers []string, staleAfter string) error {
 	stateDir := filepath.Join(cfg.LoopDir, "state")
 	if err := loop.EnsurePrivateDir(stateDir); err != nil {
 		return err
@@ -1257,6 +1286,7 @@ func writeSetupPoolState(cfg *loop.Config, wake string, wrappers []string) error
 		Wrappers:    wrappers,
 		ControlRepo: cfg.ControlRepo,
 		LoopDir:     cfg.LoopDir,
+		StaleAfter:  staleAfter,
 		UpdatedAt:   time.Now().UTC().Format(time.RFC3339),
 	}
 	data, err := json.MarshalIndent(state, "", "  ")
@@ -1264,8 +1294,52 @@ func writeSetupPoolState(cfg *loop.Config, wake string, wrappers []string) error
 		return err
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(filepath.Join(stateDir, "setup.json"), data, 0o600); err != nil {
+	if err := atomicWriteSetupState(filepath.Join(stateDir, "setup.json"), data); err != nil {
 		return fmt.Errorf("write pool setup state: %w", err)
 	}
+	return nil
+}
+
+// atomicWriteSetupState writes data to path via temp-file-then-rename so a
+// concurrent reader (send/check/status preflights, the sweep, `doctor`) never
+// observes a torn write — C9: these now read state/setup.json on every
+// operation instead of only at setup time, so a plain os.WriteFile's
+// non-atomic write window becomes a real (if narrow) race.
+func atomicWriteSetupState(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".tmp_"+filepath.Base(path)+"_")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	cleanup = false
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	syncDir(dir)
 	return nil
 }

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentchute/agentchute/internal/loop"
 )
@@ -337,6 +338,74 @@ func TestSetupClearsExistingLiveRegistrations(t *testing.T) {
 			t.Fatalf("%s should be preserved: %v", keep, err)
 		}
 	}
+}
+
+// C9: --stale-after round-trips through the pool's state/setup.json, and a
+// resync (no --stale-after passed) preserves the prior value rather than
+// silently reverting it to the 1h default.
+func TestSetupStaleAfterRoundTripsThroughPoolState(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, ".git"))
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("AGENTCHUTE_CONTROL_REPO", "")
+	t.Setenv("AGENTCHUTE_LOOP_DIR", "")
+
+	withCwd(t, root, func() {
+		if err := cmdSetup([]string{"--wake", "runner", "--wrappers", "none", "--stale-after", "45m", "--yes"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool, err := readSetupPoolState(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pool.StaleAfter != "45m" {
+		t.Fatalf("StaleAfter = %q, want 45m", pool.StaleAfter)
+	}
+	if got := loop.StaleAfter(cfg); got != 45*time.Minute {
+		t.Fatalf("loop.StaleAfter(cfg) = %v, want 45m", got)
+	}
+
+	// Resync without --stale-after: the prior value must survive, not revert
+	// to the 1h default.
+	withCwd(t, root, func() {
+		if err := cmdSetup([]string{"--wake", "runner", "--wrappers", "none", "--yes"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	pool, err = readSetupPoolState(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pool.StaleAfter != "45m" {
+		t.Fatalf("resync StaleAfter = %q, want 45m preserved", pool.StaleAfter)
+	}
+}
+
+// C9: an invalid --stale-after value is rejected before any write.
+func TestSetupRejectsInvalidStaleAfter(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, ".git"))
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AGENTCHUTE_CONTROL_REPO", "")
+	t.Setenv("AGENTCHUTE_LOOP_DIR", "")
+
+	withCwd(t, root, func() {
+		err := cmdSetup([]string{"--wake", "runner", "--wrappers", "none", "--stale-after", "not-a-duration", "--yes"})
+		if err == nil {
+			t.Fatal("expected an error for an invalid --stale-after value")
+		}
+	})
 }
 
 func TestSetupResetsRuntimeStateButPreservesPendingReplies(t *testing.T) {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -65,11 +65,12 @@ func cmdStatus(args []string) error {
 		// acts AS the agent (refreshes its last_seen). Refuse for an
 		// unregistered id. Pool-overview status (no --as) stays
 		// unaffected and remains a side-effect-free read.
+		// B1: CLI touches no longer refresh liveness — only serve's
+		// lease-gated heartbeat does (HeartbeatRegistration). This preflight
+		// only confirms the agent is enrolled at all.
 		selfPath := cfg.AgentRegistrationPath(agentID)
 		if _, err := os.Stat(selfPath); err == nil {
-			if err := loop.UpdateLastSeen(cfg, agentID, now); err != nil {
-				return fmt.Errorf("update last_seen for %s: %w", agentID, err)
-			}
+			// registered; proceed.
 		} else if os.IsNotExist(err) {
 			return fmt.Errorf("agent %q is not registered. Run `agentchute boot --as %s --vendor <vendor>` first, or omit --as to view the pool overview (AGENTCHUTE.md §5.3)", agentID, agentID)
 		} else {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -302,7 +302,11 @@ func TestCmdStatusWithoutAgentIDPrintsPoolWithoutSideEffects(t *testing.T) {
 
 // With --as set, status still ticks the caller's last_seen (preserves the
 // historical acting-agent mode).
-func TestCmdStatusWithAgentIDRefreshesLastSeen(t *testing.T) {
+// B1: CLI touches no longer refresh liveness — only serve's lease-gated
+// HeartbeatRegistration does. `status --as` still requires the agent to be
+// enrolled (the registration-exists preflight stays), but no longer bumps
+// last_seen as a side effect of that preflight.
+func TestCmdStatusWithAgentIDDoesNotRefreshLastSeen(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
 	mustMkdir(t, filepath.Join(root, ".agentchute", "loop"))
@@ -347,7 +351,7 @@ func TestCmdStatusWithAgentIDRefreshesLastSeen(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !after.LastSeen.After(before.LastSeen) {
-		t.Errorf("status with --as did NOT refresh last_seen: %v → %v", before.LastSeen, after.LastSeen)
+	if !after.LastSeen.Equal(before.LastSeen) {
+		t.Errorf("status with --as refreshed last_seen (B1: CLI touches must not): %v → %v", before.LastSeen, after.LastSeen)
 	}
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -129,6 +129,11 @@ func cmdUpdate(args []string) error {
 
 		// The exact setup re-sync, replaying the saved install config.
 		setupArgs = []string{"setup", "--control-repo", cfg.ControlRepo, "--wake", storedWake, "--wrappers", wrappersArg, "--yes"}
+		if sa := strings.TrimSpace(pool.StaleAfter); sa != "" {
+			// C9: replay the pool's configured staleness threshold so a resync
+			// never silently reverts it to the 1h default.
+			setupArgs = append(setupArgs, "--stale-after", sa)
+		}
 		if sd := strings.TrimSpace(global.ShimDir); sd != "" {
 			setupArgs = append(setupArgs, "--shim-dir", sd)
 		}
@@ -472,13 +477,23 @@ func syncDir(dir string) {
 
 // activeAgentIDs returns the agent ids of live registrations on this host in
 // this pool, for the restart warning and dry-run plan.
+//
+// C9/B1 interim: soft-state registration has no reliable Status=offline
+// signal anymore (a quitting serve does nothing to its row — B1's Behavior
+// spec), so "active" is now computed the same way the sweep judges liveness:
+// row age <= the pool's configured StaleAfter threshold. This is interim
+// because it doesn't yet check the serve lease (that refinement is B2/B5's
+// concern, once lease invalidation is the forcing function); a fresh-enough
+// row is treated as active even if its owning process already exited.
 func activeAgentIDs(cfg *loop.Config) []string {
 	regs, _ := loop.ReadRegistrationsLenient(cfg.AgentsDir())
 	localHost, _ := os.Hostname()
 	localHost = strings.TrimSpace(localHost)
+	threshold := loop.StaleAfter(cfg)
+	now := time.Now().UTC()
 	var ids []string
 	for _, reg := range regs {
-		if reg.Status == loop.StatusOffline {
+		if now.Sub(reg.LastSeen) > threshold {
 			continue
 		}
 		if localHost != "" && strings.TrimSpace(reg.Host) != "" && reg.Host != localHost {

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -382,7 +382,7 @@ func TestCmdUpdateWrappersNoneReplays(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := writeSetupPoolState(cfg, "tmux", nil); err != nil {
+		if err := writeSetupPoolState(cfg, "tmux", nil, "1h"); err != nil {
 			t.Fatal(err)
 		}
 		out, err := captureStdout(t, func() error {
@@ -393,6 +393,31 @@ func TestCmdUpdateWrappersNoneReplays(t *testing.T) {
 		}
 		if !strings.Contains(out, "--wrappers none") {
 			t.Fatalf("re-sync plan should replay `--wrappers none`; got:\n%s", out)
+		}
+	})
+}
+
+// C9 regression: update's setup re-sync replays the pool's configured
+// --stale-after rather than silently reverting it to the 1h default.
+func TestCmdUpdateReplaysStaleAfter(t *testing.T) {
+	root := t.TempDir()
+	withCwd(t, root, func() {
+		mustExampleRepo(t, root)
+		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writeSetupPoolState(cfg, "runner", nil, "45m"); err != nil {
+			t.Fatal(err)
+		}
+		out, err := captureStdout(t, func() error {
+			return cmdUpdate([]string{"--version", "v0.5.0", "--dry-run"})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(out, "--stale-after 45m") {
+			t.Fatalf("re-sync plan should replay `--stale-after 45m`; got:\n%s", out)
 		}
 	})
 }

--- a/internal/loop/config.go
+++ b/internal/loop/config.go
@@ -3,11 +3,13 @@ package loop
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const (
@@ -396,7 +398,7 @@ func EnsurePrivateDir(path string) error {
 // WithAgentLock runs fn while holding the exclusive per-agent file lock at
 // <loop>/state/<agent>/.lock. Exported for package-main callers (the runner)
 // that read-modify-write an agent's registration outside this package and must
-// serialize against UpdateLastSeen / ledger writes. See the build-tagged
+// serialize against HeartbeatRegistration / ledger writes. See the build-tagged
 // withAgentLock for the no-nested-lock contract: a single call stack must never
 // acquire this lock twice for the same agentID.
 func WithAgentLock(cfg *Config, agentID string, fn func() error) error {
@@ -418,6 +420,42 @@ func ensurePrivateDir(path string) error {
 		return fmt.Errorf("%s: not a directory", path)
 	}
 	return os.Chmod(path, 0o700)
+}
+
+// DefaultStaleAfter is the registration-staleness threshold (C9) applied when
+// state/setup.json is absent, unreadable, or carries no parseable
+// "stale_after" value — including every pre-v2.5 pool that has never run the
+// new `setup --stale-after` flag.
+const DefaultStaleAfter = time.Hour
+
+// staleAfterState mirrors only the one field of internal/cli's setupPoolState
+// this package needs; loop cannot import internal/cli (it would invert the
+// dependency direction), so it reads state/setup.json's JSON directly rather
+// than sharing that type.
+type staleAfterState struct {
+	StaleAfter string `json:"stale_after"`
+}
+
+// StaleAfter returns the pool's configured registration-staleness threshold
+// (C9), read directly from <loop>/state/setup.json. Tolerant by design: an
+// absent file, an unreadable/corrupt file, or an unparsable/non-positive
+// duration all fall back to DefaultStaleAfter rather than erroring — every
+// caller (the sweep, the heartbeat-driven "active" computation) needs a
+// threshold even when setup has never run or wrote an old-format file.
+func StaleAfter(cfg *Config) time.Duration {
+	data, err := os.ReadFile(filepath.Join(cfg.LoopDir, "state", "setup.json"))
+	if err != nil {
+		return DefaultStaleAfter
+	}
+	var state staleAfterState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return DefaultStaleAfter
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(state.StaleAfter))
+	if err != nil || d <= 0 {
+		return DefaultStaleAfter
+	}
+	return d
 }
 
 func fileExists(path string) bool {

--- a/internal/loop/filelock_test.go
+++ b/internal/loop/filelock_test.go
@@ -192,13 +192,25 @@ func TestWithAgentLock_BoundedWaitDoesNotDeadlock(t *testing.T) {
 	}
 }
 
-// TestUpdateLastSeen_NoLostUpdateUnderConcurrency runs concurrent UpdateLastSeen
-// calls alongside a status mutation and asserts the registration is never torn
-// (always parses) and the status mutation survives.
-func TestUpdateLastSeen_NoLostUpdateUnderConcurrency(t *testing.T) {
+// TestHeartbeatRegistration_NoLostUpdateUnderConcurrency runs concurrent
+// HeartbeatRegistration calls alongside a status mutation and asserts the
+// registration is never torn (always parses) and the status mutation
+// survives. B1: replaces the retired UpdateLastSeen version of this test —
+// the heartbeat is now lease-gated, so it needs a real serve lease token.
+func TestHeartbeatRegistration_NoLostUpdateUnderConcurrency(t *testing.T) {
 	cfg := newLockTestConfig(t)
 	const agentID = "claude-code"
 	writeTestRegistration(t, cfg, agentID, StatusActive)
+	lease, err := AcquireServeLease(cfg, agentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := Registration{
+		AgentID:     agentID,
+		Vendor:      "agentchute",
+		ControlRepo: cfg.ControlRepo,
+		Status:      StatusActive,
+	}
 
 	var wg sync.WaitGroup
 	errs := make(chan error, 64)
@@ -206,8 +218,7 @@ func TestUpdateLastSeen_NoLostUpdateUnderConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			ts := time.Date(2026, 5, 10, 0, 0, i%60, 0, time.UTC)
-			if err := UpdateLastSeen(cfg, agentID, ts); err != nil {
+			if err := HeartbeatRegistration(cfg, template, lease.Token); err != nil {
 				errs <- err
 			}
 		}(i)
@@ -239,49 +250,6 @@ func TestUpdateLastSeen_NoLostUpdateUnderConcurrency(t *testing.T) {
 	}
 	if reg.AgentID != agentID {
 		t.Fatalf("agent_id = %q, want %q", reg.AgentID, agentID)
-	}
-}
-
-// TestRunnerOfflineNotResurrectedByConcurrentLastSeen models the serve.go shutdown
-// race: a registration marked offline must not be flipped back to active by a
-// concurrent last_seen refresh. With both writers serialized through
-// withAgentLock and the offline write applied last, the terminal state is
-// offline.
-func TestRunnerOfflineNotResurrectedByConcurrentLastSeen(t *testing.T) {
-	cfg := newLockTestConfig(t)
-	const agentID = "claude-code"
-	writeTestRegistration(t, cfg, agentID, StatusActive)
-
-	var wg sync.WaitGroup
-	// Pollers refreshing last_seen (they read whatever status is on disk).
-	for i := 0; i < 20; i++ {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
-			_ = UpdateLastSeen(cfg, agentID, time.Date(2026, 5, 10, 0, 0, i%60, 0, time.UTC))
-		}(i)
-	}
-	wg.Wait()
-
-	// Shutdown: mark offline under the lock, AFTER pollers have joined.
-	if err := withAgentLock(cfg, agentID, func() error {
-		reg, err := ReadRegistration(cfg.AgentRegistrationPath(agentID))
-		if err != nil {
-			return err
-		}
-		reg.Status = StatusOffline
-		reg.LastSeen = time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC)
-		return WriteRegistration(cfg.AgentRegistrationPath(agentID), reg)
-	}); err != nil {
-		t.Fatalf("mark offline: %v", err)
-	}
-
-	reg, err := ReadRegistration(cfg.AgentRegistrationPath(agentID))
-	if err != nil {
-		t.Fatalf("read after offline: %v", err)
-	}
-	if reg.Status != StatusOffline {
-		t.Fatalf("status = %q, want offline (resurrected by concurrent last_seen)", reg.Status)
 	}
 }
 

--- a/internal/loop/registration.go
+++ b/internal/loop/registration.go
@@ -229,11 +229,20 @@ func WriteRegistrationExclusive(path string, r *Registration) error {
 // a paused-then-resumed laptop) writes NOTHING on ErrFenced — it cannot
 // resurrect a row another serve now owns.
 //
-// Merge: template wins for every field EXCEPT Body and WorkingRepos, which
-// the on-disk row wins for when one exists — those two are user-editable
-// (`register`/`boot --working-repo`, a hand-edited bio) and must survive
-// ticks the runner's own template has no opinion on. When no row exists yet,
-// template is written as-is (Body/WorkingRepos included).
+// Merge: template wins for every field EXCEPT Body, WorkingRepos, and
+// LastActive, which the on-disk row wins for when one exists — those are
+// user/other-command-owned (`register`/`boot --working-repo`, a hand-edited
+// bio, `check`'s UpdateLastActive) and must survive ticks the runner's own
+// template has no opinion on. Launch provenance (LaunchedBy/ShimName/
+// HookEvent) follows publishRegistrationOnce's own established rule: a
+// non-empty template value wins (the runner's template DOES know its own
+// LaunchedBy/ShimName), empty falls back to the existing row — so a tick
+// never silently wipes provenance the template simply didn't set (e.g.
+// HookEvent, which heartbeatTemplate never populates) (codex/claude-code
+// review, PR #91 round 2, SHOULD-FIX 4: a per-5s-tick blind template-wins
+// merge was erasing both within one tick — a real regression against the
+// invariant performRegister's own regression test already protects). When no
+// row exists yet, template is written as-is.
 func HeartbeatRegistration(cfg *Config, template Registration, leaseToken string) error {
 	if leaseToken == "" {
 		return fmt.Errorf("HeartbeatRegistration: empty lease token (heartbeat is serve-only)")
@@ -250,6 +259,16 @@ func HeartbeatRegistration(cfg *Config, template Registration, leaseToken string
 		if existing, err := ReadRegistration(path); err == nil {
 			reg.Body = existing.Body
 			reg.WorkingRepos = existing.WorkingRepos
+			reg.LastActive = existing.LastActive
+			if strings.TrimSpace(template.LaunchedBy) == "" {
+				reg.LaunchedBy = existing.LaunchedBy
+			}
+			if strings.TrimSpace(template.ShimName) == "" {
+				reg.ShimName = existing.ShimName
+			}
+			if strings.TrimSpace(template.HookEvent) == "" {
+				reg.HookEvent = existing.HookEvent
+			}
 		} else if !os.IsNotExist(err) {
 			return err
 		}
@@ -269,8 +288,9 @@ func HeartbeatRegistration(cfg *Config, template Registration, leaseToken string
 }
 
 // UpdateLastActive updates last_active via the same structured path as other
-// registration writes. Runs under the per-agent lock for the same lost-update
-// reasons as UpdateLastSeen.
+// registration writes. Runs under the per-agent lock so a concurrent
+// HeartbeatRegistration tick cannot lose this update (the tick's own merge
+// preserves LastActive precisely so it survives a concurrent write here).
 func UpdateLastActive(cfg *Config, agentID string, t time.Time) error {
 	return withAgentLock(cfg, agentID, func() error {
 		path := cfg.AgentRegistrationPath(agentID)

--- a/internal/loop/registration.go
+++ b/internal/loop/registration.go
@@ -213,31 +213,58 @@ func WriteRegistrationExclusive(path string, r *Registration) error {
 	return nil
 }
 
-// UpdateLastSeen updates last_seen via the same structured path as other
-// registration writes. The read-modify-write runs under the per-agent lock so
-// a concurrent status mutation (e.g. the runner marking itself offline) is not
-// clobbered by a stale-read overwrite, and two concurrent updaters cannot tear
-// the registration file.
-func UpdateLastSeen(cfg *Config, agentID string, t time.Time) error {
-	return withAgentLock(cfg, agentID, func() error {
-		path := cfg.AgentRegistrationPath(agentID)
-		reg, err := ReadRegistration(path)
-		if err != nil {
+// HeartbeatRegistration is the lease-gated, unconditional per-tick refresh of
+// a registration row (v2.5 plan B1, C13). It replaces UpdateLastSeen: instead
+// of a CLI touch refreshing an existing row (and erroring if the row is
+// gone), only a live `serve` process advances LastSeen, and it self-heals — a
+// row that SweepStaleRegistrations removed, or one that never existed, is
+// recreated fresh from template rather than erroring.
+//
+// SERVE-ONLY: an empty leaseToken is a caller bug (unit tests constructing one
+// directly aside), not a legitimate "no lease" case — only a process holding
+// a live serve lease should ever be advancing a row's LastSeen.
+//
+// Fencing: VerifyFence runs FIRST, inside the SAME WithAgentLock(id) critical
+// section as the read-merge-write, so a holder reclaimed between ticks (e.g.
+// a paused-then-resumed laptop) writes NOTHING on ErrFenced — it cannot
+// resurrect a row another serve now owns.
+//
+// Merge: template wins for every field EXCEPT Body and WorkingRepos, which
+// the on-disk row wins for when one exists — those two are user-editable
+// (`register`/`boot --working-repo`, a hand-edited bio) and must survive
+// ticks the runner's own template has no opinion on. When no row exists yet,
+// template is written as-is (Body/WorkingRepos included).
+func HeartbeatRegistration(cfg *Config, template Registration, leaseToken string) error {
+	if leaseToken == "" {
+		return fmt.Errorf("HeartbeatRegistration: empty lease token (heartbeat is serve-only)")
+	}
+	if err := ValidateAgentID(template.AgentID); err != nil {
+		return err
+	}
+	return withAgentLock(cfg, template.AgentID, func() error {
+		if err := VerifyFence(cfg, template.AgentID, leaseToken); err != nil {
 			return err
 		}
-		reg.LastSeen = t.UTC()
-		if err := WriteRegistration(path, reg); err != nil {
+		path := cfg.AgentRegistrationPath(template.AgentID)
+		reg := template
+		if existing, err := ReadRegistration(path); err == nil {
+			reg.Body = existing.Body
+			reg.WorkingRepos = existing.WorkingRepos
+		} else if !os.IsNotExist(err) {
 			return err
 		}
-		// GATE 3: `.live` is the SOURCE of presence/liveness. Every heartbeat
-		// site that refreshes registration last_seen (the runner tick,
-		// check.go, send.go, status.go) calls UpdateLastSeen, so republishing
-		// `.live` here gives all of them fresh presence with no per-call-site
-		// edits. busy=false: busy is advisory and is set only by serve (Gate 6).
-		// WriteLive writes a separate file atomically and does NOT take
-		// withAgentLock, so this nested call is safe (withAgentLock is
+		reg.LastSeen = time.Now().UTC()
+		if err := WriteRegistration(path, &reg); err != nil {
+			return err
+		}
+		// B1 note (plan §4 risk list — the B5 dependency): keep the WriteLive
+		// call here so the tree keeps compiling and `.live`-driven presence
+		// readers stay accurate until B5 deletes live.go and this call along
+		// with it. busy=false: busy is advisory and set only by serve
+		// elsewhere (Gate 6). WriteLive is a separate atomic file write and
+		// takes no agent lock, so this nested call is safe (withAgentLock is
 		// non-reentrant).
-		return WriteLive(cfg, agentID, false)
+		return WriteLive(cfg, template.AgentID, false)
 	})
 }
 

--- a/internal/loop/registration_test.go
+++ b/internal/loop/registration_test.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -140,7 +141,30 @@ func TestReadFileLimit_RejectsSymlink(t *testing.T) {
 // shape-validates a wake target (ValidateWakeTarget is gone with the wake
 // adapters).
 
-func TestUpdateLastSeenPreservesBody(t *testing.T) {
+// heartbeatTestTemplate builds a minimal template for HeartbeatRegistration
+// tests: agent_id/vendor/control_repo/status only, mirroring the fields
+// serve's real template carries (WorkingRepos/Host/provenance vary by test).
+func heartbeatTestTemplate(agentID string) Registration {
+	return Registration{
+		AgentID:     agentID,
+		Vendor:      "openai",
+		ControlRepo: "/tmp/repo",
+		Status:      StatusActive,
+	}
+}
+
+// mustAcquireTestLease acquires a real serve lease for agentID so
+// HeartbeatRegistration's VerifyFence has a genuine claim to check against.
+func mustAcquireTestLease(t *testing.T, cfg *Config, agentID string) *ServeLease {
+	t.Helper()
+	lease, err := AcquireServeLease(cfg, agentID)
+	if err != nil {
+		t.Fatalf("AcquireServeLease(%s): %v", agentID, err)
+	}
+	return lease
+}
+
+func TestHeartbeatRegistrationPreservesBody(t *testing.T) {
 	cfg := newLockTestConfig(t)
 	path := cfg.AgentRegistrationPath("codex")
 	mustWrite(t, path, []byte(`---
@@ -153,20 +177,133 @@ status: active
 
 # Keep this body
 `))
+	lease := mustAcquireTestLease(t, cfg, "codex")
 
-	next := time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC)
-	if err := UpdateLastSeen(cfg, "codex", next); err != nil {
+	if err := HeartbeatRegistration(cfg, heartbeatTestTemplate("codex"), lease.Token); err != nil {
 		t.Fatal(err)
 	}
 	reg, err := ReadRegistration(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if reg.LastSeen.UTC().Format(time.RFC3339) != "2026-05-10T00:00:00Z" {
-		t.Fatalf("LastSeen = %s", reg.LastSeen.Format(time.RFC3339))
+	if reg.LastSeen.Before(time.Now().Add(-time.Minute)) {
+		t.Fatalf("LastSeen = %s, want ~now", reg.LastSeen.Format(time.RFC3339))
 	}
 	if reg.Body != "# Keep this body\n" {
 		t.Fatalf("Body = %q", reg.Body)
+	}
+}
+
+// TestHeartbeatRegistrationPreservesWorkingRepos: the on-disk row's
+// WorkingRepos wins over the template's, since only register/boot's explicit
+// --working-repo flag should change it — a heartbeat tick must not silently
+// drop repos the template doesn't know about (C13).
+func TestHeartbeatRegistrationPreservesWorkingRepos(t *testing.T) {
+	cfg := newLockTestConfig(t)
+	agentID := "codex"
+	existing := &Registration{
+		AgentID:      agentID,
+		Vendor:       "openai",
+		ControlRepo:  "/tmp/repo",
+		WorkingRepos: []string{"/tmp/repo", "/tmp/other-repo"},
+		LastSeen:     time.Now().UTC().Add(-time.Hour),
+		Status:       StatusActive,
+	}
+	if err := WriteRegistration(cfg.AgentRegistrationPath(agentID), existing); err != nil {
+		t.Fatal(err)
+	}
+	lease := mustAcquireTestLease(t, cfg, agentID)
+
+	template := heartbeatTestTemplate(agentID)
+	template.WorkingRepos = []string{"/tmp/repo"} // narrower than the on-disk row
+	if err := HeartbeatRegistration(cfg, template, lease.Token); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := ReadRegistration(cfg.AgentRegistrationPath(agentID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reg.WorkingRepos) != 2 || reg.WorkingRepos[0] != "/tmp/repo" || reg.WorkingRepos[1] != "/tmp/other-repo" {
+		t.Fatalf("WorkingRepos = %v, want the on-disk row preserved", reg.WorkingRepos)
+	}
+}
+
+// TestHeartbeatRegistrationCreatesWhenMissing: a swept-away (or never-yet-
+// written) row is recreated from template rather than erroring (C13,
+// "create-from-template if missing").
+func TestHeartbeatRegistrationCreatesWhenMissing(t *testing.T) {
+	cfg := newLockTestConfig(t)
+	agentID := "codex"
+	lease := mustAcquireTestLease(t, cfg, agentID)
+
+	path := cfg.AgentRegistrationPath(agentID)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("precondition: registration should not exist yet, stat err = %v", err)
+	}
+
+	if err := HeartbeatRegistration(cfg, heartbeatTestTemplate(agentID), lease.Token); err != nil {
+		t.Fatalf("HeartbeatRegistration on a missing row must create it, not error: %v", err)
+	}
+	reg, err := ReadRegistration(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reg.AgentID != agentID || reg.Vendor != "openai" || reg.ControlRepo != "/tmp/repo" {
+		t.Fatalf("recreated registration = %+v, want the template's fields", reg)
+	}
+}
+
+// TestHeartbeatRegistrationRefusesWithoutLease: no serve claim exists at all
+// for this id, so VerifyFence fails closed with ErrFenced and the call must
+// write NOTHING — a caller passing a token with no backing claim (e.g. a
+// stale/forged token) must never resurrect or create a row.
+func TestHeartbeatRegistrationRefusesWithoutLease(t *testing.T) {
+	cfg := newLockTestConfig(t)
+	agentID := "codex"
+	path := cfg.AgentRegistrationPath(agentID)
+
+	err := HeartbeatRegistration(cfg, heartbeatTestTemplate(agentID), "not-a-real-token")
+	if !errors.Is(err, ErrFenced) {
+		t.Fatalf("err = %v, want ErrFenced", err)
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Fatalf("HeartbeatRegistration wrote a registration despite ErrFenced: stat err = %v", statErr)
+	}
+}
+
+// TestHeartbeatRegistrationRefusesReclaimedLease: a token that DID once own
+// the lease, but was reclaimed by a fresh AcquireServeLease in the meantime
+// (the paused-laptop-resume scenario), must also fail closed — the stale
+// token no longer equals the live claim's token. Mirrors lease_test.go's own
+// stale-reclaim pattern: pidAlive is forced false so a same-host stale claim
+// is reclaimable (pid-proof failure), not protected as "frozen but alive".
+func TestHeartbeatRegistrationRefusesReclaimedLease(t *testing.T) {
+	cfg := newLockTestConfig(t)
+	agentID := "codex"
+	host, _ := os.Hostname()
+	writeClaim(t, cfg, &ServeClaim{
+		ID:         agentID,
+		Host:       host,
+		PID:        4242,
+		ServeToken: "stale-token",
+		StartedAt:  time.Now().Add(-time.Hour).UTC(),
+		LastSeen:   time.Now().Add(-time.Hour).UTC(),
+	})
+	withPidAlive(t, func(int) bool { return false })
+	if _, err := AcquireServeLease(cfg, agentID); err != nil {
+		t.Fatalf("reclaim: %v", err)
+	}
+
+	err := HeartbeatRegistration(cfg, heartbeatTestTemplate(agentID), "stale-token")
+	if !errors.Is(err, ErrFenced) {
+		t.Fatalf("err = %v, want ErrFenced for a reclaimed (stale) token", err)
+	}
+}
+
+func TestHeartbeatRegistrationEmptyTokenErrors(t *testing.T) {
+	cfg := newLockTestConfig(t)
+	if err := HeartbeatRegistration(cfg, heartbeatTestTemplate("codex"), ""); err == nil {
+		t.Fatal("expected an error for an empty lease token (heartbeat is serve-only)")
 	}
 }
 
@@ -200,7 +337,7 @@ status: active
 	}
 }
 
-func TestUpdateLastSeenUsesStructuredRegistrationWrite(t *testing.T) {
+func TestHeartbeatRegistrationUsesStructuredRegistrationWrite(t *testing.T) {
 	cfg := newLockTestConfig(t)
 	path := cfg.AgentRegistrationPath("codex")
 	mustWrite(t, path, []byte(`---
@@ -212,9 +349,9 @@ last_seen: 2026-05-09T16:08:36Z
 status: active
 ---
 `))
+	lease := mustAcquireTestLease(t, cfg, "codex")
 
-	next := time.Date(2026, 5, 10, 0, 0, 0, 0, time.UTC)
-	if err := UpdateLastSeen(cfg, "codex", next); err != nil {
+	if err := HeartbeatRegistration(cfg, heartbeatTestTemplate("codex"), lease.Token); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(path)
@@ -222,15 +359,17 @@ status: active
 		t.Fatal(err)
 	}
 	if strings.Contains(string(data), "custom_field:") {
-		t.Fatalf("UpdateLastSeen preserved unknown frontmatter field:\n%s", string(data))
+		t.Fatalf("HeartbeatRegistration preserved unknown frontmatter field:\n%s", string(data))
 	}
 }
 
-// GATE 3: UpdateLastSeen is the shared heartbeat path (runner tick, check, send,
-// status). Besides refreshing registration last_seen it must publish a fresh
-// `.live` presence fact (busy=false; busy is advisory, set only by serve) so all
-// heartbeat sites yield fresh presence with no per-call-site edits.
-func TestUpdateLastSeenWritesLive(t *testing.T) {
+// GATE 3 / B1: HeartbeatRegistration is now the shared heartbeat path (only
+// serve's poll tick calls it — CLI touches no longer refresh liveness).
+// Besides refreshing registration last_seen it must publish a fresh `.live`
+// presence fact (busy=false; busy is advisory, set only by serve) — B1 keeps
+// this write for now (B5 removes it with live.go, per the plan's B5
+// dependency note).
+func TestHeartbeatRegistrationWritesLive(t *testing.T) {
 	cfg := newLockTestConfig(t)
 	path := cfg.AgentRegistrationPath("codex")
 	mustWrite(t, path, []byte(`---
@@ -241,25 +380,26 @@ last_seen: 2026-05-09T16:08:36Z
 status: active
 ---
 `))
+	lease := mustAcquireTestLease(t, cfg, "codex")
 
 	// No `.live` exists before the heartbeat.
 	if _, err := ReadLive(cfg, "codex"); err == nil {
-		t.Fatal("expected no .live before UpdateLastSeen")
+		t.Fatal("expected no .live before the heartbeat")
 	}
 
-	if err := UpdateLastSeen(cfg, "codex", time.Now().UTC()); err != nil {
+	if err := HeartbeatRegistration(cfg, heartbeatTestTemplate("codex"), lease.Token); err != nil {
 		t.Fatal(err)
 	}
 
 	if !IsLive(cfg, "codex", liveWindow, time.Now()) {
-		t.Fatal("UpdateLastSeen did not publish a fresh .live")
+		t.Fatal("HeartbeatRegistration did not publish a fresh .live")
 	}
 	live, err := ReadLive(cfg, "codex")
 	if err != nil {
 		t.Fatalf("ReadLive: %v", err)
 	}
 	if live.Busy {
-		t.Error("UpdateLastSeen wrote busy=true; busy is advisory and must be false here")
+		t.Error("HeartbeatRegistration wrote busy=true; busy is advisory and must be false here")
 	}
 }
 

--- a/internal/loop/registration_test.go
+++ b/internal/loop/registration_test.go
@@ -228,6 +228,79 @@ func TestHeartbeatRegistrationPreservesWorkingRepos(t *testing.T) {
 	}
 }
 
+// TestHeartbeatRegistrationPreservesLastActive: check's UpdateLastActive
+// records activity between heartbeat ticks; a tick must not wipe it, since
+// heartbeatTemplate never carries a LastActive of its own (PR #91 round 2,
+// SHOULD-FIX 4 — a per-5s-tick merge that blindly took the template's zero
+// value here would erase check-recorded activity within one tick).
+func TestHeartbeatRegistrationPreservesLastActive(t *testing.T) {
+	cfg := newLockTestConfig(t)
+	agentID := "codex"
+	lastActive := time.Now().UTC().Add(-time.Minute).Truncate(time.Second)
+	existing := &Registration{
+		AgentID:     agentID,
+		Vendor:      "openai",
+		ControlRepo: "/tmp/repo",
+		LastSeen:    time.Now().UTC().Add(-time.Hour),
+		LastActive:  &lastActive,
+		Status:      StatusActive,
+	}
+	if err := WriteRegistration(cfg.AgentRegistrationPath(agentID), existing); err != nil {
+		t.Fatal(err)
+	}
+	lease := mustAcquireTestLease(t, cfg, agentID)
+
+	if err := HeartbeatRegistration(cfg, heartbeatTestTemplate(agentID), lease.Token); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := ReadRegistration(cfg.AgentRegistrationPath(agentID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reg.LastActive == nil || !reg.LastActive.Equal(lastActive) {
+		t.Fatalf("LastActive = %v, want preserved %v", reg.LastActive, lastActive)
+	}
+}
+
+// TestHeartbeatRegistrationPreservesLaunchProvenanceTemplateDoesNotSet: the
+// template only carries LaunchedBy/ShimName, never HookEvent — a tick must
+// not wipe HookEvent recorded at initial enrollment (PR #91 round 2,
+// SHOULD-FIX 4).
+func TestHeartbeatRegistrationPreservesLaunchProvenanceTemplateDoesNotSet(t *testing.T) {
+	cfg := newLockTestConfig(t)
+	agentID := "codex"
+	existing := &Registration{
+		AgentID:     agentID,
+		Vendor:      "openai",
+		ControlRepo: "/tmp/repo",
+		LastSeen:    time.Now().UTC().Add(-time.Hour),
+		Status:      StatusActive,
+		LaunchedBy:  LaunchedByHook,
+		HookEvent:   "boot",
+	}
+	if err := WriteRegistration(cfg.AgentRegistrationPath(agentID), existing); err != nil {
+		t.Fatal(err)
+	}
+	lease := mustAcquireTestLease(t, cfg, agentID)
+
+	template := heartbeatTestTemplate(agentID)
+	template.LaunchedBy = LaunchedByRunner // the template DOES have an opinion on LaunchedBy...
+	// ...but not on HookEvent (heartbeatTemplate never sets it in production).
+	if err := HeartbeatRegistration(cfg, template, lease.Token); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := ReadRegistration(cfg.AgentRegistrationPath(agentID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reg.LaunchedBy != LaunchedByRunner {
+		t.Fatalf("LaunchedBy = %q, want the template's non-empty value %q to win", reg.LaunchedBy, LaunchedByRunner)
+	}
+	if reg.HookEvent != "boot" {
+		t.Fatalf("HookEvent = %q, want the existing row's value preserved (template never sets it)", reg.HookEvent)
+	}
+}
+
 // TestHeartbeatRegistrationCreatesWhenMissing: a swept-away (or never-yet-
 // written) row is recreated from template rather than erroring (C13,
 // "create-from-template if missing").

--- a/internal/loop/sweep.go
+++ b/internal/loop/sweep.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -71,6 +72,23 @@ func SweepStaleRegistrations(cfg *Config, selfID string, now time.Time) ([]strin
 			continue
 		}
 		id := strings.TrimSuffix(name, ".md")
+		if ValidateAgentID(id) != nil {
+			// A stray non-agent-id .md file (a hand-dropped note, a typo) is
+			// not a registration candidate at all — never a sweep failure.
+			// Every other directory enumerator in this codebase already
+			// guards this (presence_scan.go, setup_wipe.go); an unguarded
+			// candidate here would reach sweepOneCandidate's withAgentLock,
+			// which hard-errors on an invalid id and would abort the WHOLE
+			// pass before any later (sorted) candidate is even considered
+			// (codex/claude-code review, PR #91 round 2, BLOCKER 1). Belt
+			// and suspenders alongside claimProvablyDead's fail-closed
+			// handling below (BLOCKER 2's fix already independently
+			// immunizes an invalid id too, since ReadServeClaim validates
+			// it and a validation error is not os.ErrNotExist) — this guard
+			// is the cheaper, more direct fix and matches the established
+			// precedent, so it is not left to that side effect alone.
+			continue
+		}
 		if id == selfID {
 			continue
 		}
@@ -82,8 +100,8 @@ func SweepStaleRegistrations(cfg *Config, selfID string, now time.Time) ([]strin
 		if age <= threshold {
 			continue
 		}
-		if claim, cerr := ReadServeClaim(cfg, id); cerr == nil && !ClaimIsStale(claim, now) {
-			continue // a fresh lease owns this id; the row is not dead.
+		if !claimProvablyDead(cfg, id, now) {
+			continue // a fresh lease owns this id, OR we can't prove otherwise.
 		}
 		candidates = append(candidates, candidate{id: id, path: path})
 	}
@@ -121,6 +139,19 @@ func SweepStaleRegistrations(cfg *Config, selfID string, now time.Time) ([]strin
 // sweepOneCandidate re-checks id's staleness (age AND lease) under
 // WithAgentLock(id) and removes its registration row iff both still hold —
 // closing the TOCTOU window between the outer scan and the delete.
+//
+// Side effect, noted per review (PR #91 round 2, SHOULD-FIX 3): like every
+// WithAgentLock(id) caller, this creates state/<id>/ + its .lock file as a
+// side effect of taking the lock — even for a candidate that turns out to
+// still be fresh (survives the re-check) and even for the id it just
+// deleted. This is the same accepted tradeoff clean.go's mailbox/owed clean
+// already documents (clean.go: cmdCleanOwed's doc comment, and the
+// WithAgentLock(target) comment in the --mailbox apply path): the lock is
+// load-bearing for correctness (it is what closes the TOCTOU window against
+// a concurrent heartbeat or serve launch), and cleaning up the directory
+// afterward would race that same concurrent activity for no correctness
+// benefit — only cosmetic state-dir accumulation for ids that no longer have
+// a live registration, which doctor/gate/status never read.
 func sweepOneCandidate(cfg *Config, id, path string, threshold time.Duration, now time.Time) (bool, error) {
 	var swept bool
 	err := withAgentLock(cfg, id, func() error {
@@ -131,8 +162,8 @@ func sweepOneCandidate(cfg *Config, id, path string, threshold time.Duration, no
 		if age <= threshold {
 			return nil // refreshed since the outer scan; not stale anymore.
 		}
-		if claim, cerr := ReadServeClaim(cfg, id); cerr == nil && !ClaimIsStale(claim, now) {
-			return nil // a fresh lease appeared since the outer scan.
+		if !claimProvablyDead(cfg, id, now) {
+			return nil // a fresh lease appeared, or its claim is no longer provably dead.
 		}
 		if err := os.Remove(path); err != nil {
 			if os.IsNotExist(err) {
@@ -149,18 +180,58 @@ func sweepOneCandidate(cfg *Config, id, path string, threshold time.Duration, no
 	return swept, nil
 }
 
+// claimProvablyDead reports whether id's serve claim can be PROVEN dead: it
+// must be genuinely absent (os.ErrNotExist) and stale-or-nonexistent is not
+// enough on its own — ClaimIsStale(nil, now) already reports true for a nil
+// claim, so the absent case is folded into the same ClaimIsStale check. Any
+// OTHER read error (corrupt JSON, an invalid id, a symlink rejected by
+// openRegularNoFollow, an oversize file, a permission error) means the claim
+// cannot be read at all — and "cannot prove ownership" must fail CLOSED here,
+// the same direction VerifyFence/AcquireServeLease already fail in for this
+// exact ambiguity (codex/claude-code review, PR #91 round 2, BLOCKER 2: the
+// prior `cerr == nil && !stale` shape failed OPEN on any non-absent error,
+// so a single corrupt claim file could delete a live lane's registration —
+// and worse, that lane could then neither self-heal via HeartbeatRegistration
+// (VerifyFence also fails closed on a parse error) nor restart serve
+// (AcquireServeLease fails closed on an unreadable claim too), silently
+// vanishing it from the pool with no recovery path).
+func claimProvablyDead(cfg *Config, id string, now time.Time) bool {
+	claim, err := ReadServeClaim(cfg, id)
+	if err == nil {
+		return ClaimIsStale(claim, now)
+	}
+	return os.IsNotExist(err)
+}
+
 // registrationAge returns path's staleness age: the parsed last_seen when the
 // file parses as a registration, or the file's mtime (C12) when it doesn't —
 // so a hand-corrupted or otherwise unparseable row is not immortal just
 // because ReadRegistration can't recover a last_seen from it. ok is false
 // only when the file itself is gone or unstatable.
+//
+// A negative age (a future-dated last_seen — clock skew or a hand edit) is
+// clamped to an arbitrarily-large positive value rather than left negative
+// (grok review residual, PR #91 round 2, item 6): unlike a serve claim's
+// staleness check, where failing a future timestamp closed as "still fresh"
+// protects a live lane from being stolen, a registration row is discoverable
+// display state, not a lock — a bogus future timestamp granting it permanent
+// sweep-immunity is the wrong failure direction here. Erring toward eventual
+// cleanup, not toward permanence, is what keeps a corrupted timestamp from
+// producing an unkillable ghost row.
 func registrationAge(path string, now time.Time) (age time.Duration, ok bool) {
 	if reg, err := ReadRegistration(path); err == nil {
-		return now.Sub(reg.LastSeen), true
+		return clampNonNegativeAge(now.Sub(reg.LastSeen)), true
 	}
 	info, err := os.Stat(path)
 	if err != nil {
 		return 0, false
 	}
-	return now.Sub(info.ModTime()), true
+	return clampNonNegativeAge(now.Sub(info.ModTime())), true
+}
+
+func clampNonNegativeAge(age time.Duration) time.Duration {
+	if age < 0 {
+		return math.MaxInt64
+	}
+	return age
 }

--- a/internal/loop/sweep.go
+++ b/internal/loop/sweep.go
@@ -1,0 +1,166 @@
+package loop
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// sweep.go — the lazy stale-registration sweep (v2.5 plan B1, C11/C12). A
+// registration row with no fresh serve lease and an age past the pool's
+// configured StaleAfter threshold is deleted so the pool's live view stays
+// honest without any agent having to explicitly deregister. Triggered from
+// two places only (C11): `boot`, once, immediately after the caller
+// registers itself and before it peeks its own inbox; and `serve`'s poll
+// tick, at most once per sweepInterval. Never send/status/doctor/gate —
+// those commands only report.
+
+// MaxSweepPerPass caps how many stale rows a single SweepStaleRegistrations
+// call removes (C12). A hard bound keeps one sweep call cheap and bounded
+// even if a pool has accumulated many dead rows (e.g. after a long serve
+// outage); the remainder is swept on the next trigger.
+const MaxSweepPerPass = 5
+
+// afterSweepScanHook is a test-only seam; see its call site below. nil in
+// production.
+var afterSweepScanHook func()
+
+// SweepStaleRegistrations removes stale, lease-dead registration rows under
+// cfg's agents directory, skipping selfID. A row is a sweep candidate when
+// its age exceeds StaleAfter(cfg) AND its serve claim is absent or stale
+// (ClaimIsStale) — a fresh lease immunizes an old-looking row (C12: never
+// steal a live lane just because its last registration write happens to
+// predate the threshold). A row that fails to parse (corrupt frontmatter)
+// uses the file's mtime as its age proxy (C12) so a corrupt row is not
+// immortal merely because ReadRegistration can't recover its last_seen.
+//
+// Candidates are re-checked (age AND lease, freshly re-read) under
+// WithAgentLock(id) immediately before os.Remove — a concurrent heartbeat
+// that revives the row between the initial scan and the delete wins; the
+// sweep backs off rather than deleting a row that just got fresh again.
+//
+// Sweeping never touches inboxes, mail, or any other agent state — only the
+// agents/*.md registration file itself.
+func SweepStaleRegistrations(cfg *Config, selfID string, now time.Time) ([]string, error) {
+	dir := cfg.AgentsDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	threshold := StaleAfter(cfg)
+
+	type candidate struct {
+		id   string
+		path string
+	}
+	var candidates []candidate
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() ||
+			strings.HasPrefix(name, ".") ||
+			!strings.HasSuffix(name, ".md") ||
+			strings.HasSuffix(name, ".example.md") ||
+			name == "README.md" {
+			continue
+		}
+		id := strings.TrimSuffix(name, ".md")
+		if id == selfID {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		age, ok := registrationAge(path, now)
+		if !ok {
+			continue // vanished between ReadDir and stat; nothing to sweep.
+		}
+		if age <= threshold {
+			continue
+		}
+		if claim, cerr := ReadServeClaim(cfg, id); cerr == nil && !ClaimIsStale(claim, now) {
+			continue // a fresh lease owns this id; the row is not dead.
+		}
+		candidates = append(candidates, candidate{id: id, path: path})
+	}
+
+	// Deterministic order (not filesystem order) so a capped pass behaves the
+	// same across repeated test runs and log reads.
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].id < candidates[j].id })
+
+	// afterSweepScanHook, when non-nil, runs once here — after the outer scan
+	// has fixed the candidate list but before any per-candidate lock is taken.
+	// Test-only (nil in production): lets a test deterministically simulate a
+	// revival racing the sweep (e.g. call HeartbeatRegistration for one
+	// candidate) and confirm sweepOneCandidate's under-lock re-check backs off
+	// for that id instead of deleting a row that got fresh again in between.
+	if afterSweepScanHook != nil {
+		afterSweepScanHook()
+	}
+
+	var removed []string
+	for _, c := range candidates {
+		if len(removed) >= MaxSweepPerPass {
+			break
+		}
+		swept, err := sweepOneCandidate(cfg, c.id, c.path, threshold, now)
+		if err != nil {
+			return removed, err
+		}
+		if swept {
+			removed = append(removed, c.id)
+		}
+	}
+	return removed, nil
+}
+
+// sweepOneCandidate re-checks id's staleness (age AND lease) under
+// WithAgentLock(id) and removes its registration row iff both still hold —
+// closing the TOCTOU window between the outer scan and the delete.
+func sweepOneCandidate(cfg *Config, id, path string, threshold time.Duration, now time.Time) (bool, error) {
+	var swept bool
+	err := withAgentLock(cfg, id, func() error {
+		age, ok := registrationAge(path, now)
+		if !ok {
+			return nil // already gone (raced with a concurrent sweep/removal).
+		}
+		if age <= threshold {
+			return nil // refreshed since the outer scan; not stale anymore.
+		}
+		if claim, cerr := ReadServeClaim(cfg, id); cerr == nil && !ClaimIsStale(claim, now) {
+			return nil // a fresh lease appeared since the outer scan.
+		}
+		if err := os.Remove(path); err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		swept = true
+		return syncDir(filepath.Dir(path))
+	})
+	if err != nil {
+		return false, err
+	}
+	return swept, nil
+}
+
+// registrationAge returns path's staleness age: the parsed last_seen when the
+// file parses as a registration, or the file's mtime (C12) when it doesn't —
+// so a hand-corrupted or otherwise unparseable row is not immortal just
+// because ReadRegistration can't recover a last_seen from it. ok is false
+// only when the file itself is gone or unstatable.
+func registrationAge(path string, now time.Time) (age time.Duration, ok bool) {
+	if reg, err := ReadRegistration(path); err == nil {
+		return now.Sub(reg.LastSeen), true
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, false
+	}
+	return now.Sub(info.ModTime()), true
+}

--- a/internal/loop/sweep.go
+++ b/internal/loop/sweep.go
@@ -1,6 +1,8 @@
 package loop
 
 import (
+	"errors"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -41,6 +43,17 @@ var afterSweepScanHook func()
 // WithAgentLock(id) immediately before os.Remove — a concurrent heartbeat
 // that revives the row between the initial scan and the delete wins; the
 // sweep backs off rather than deleting a row that just got fresh again.
+//
+// A per-candidate failure (e.g. a poisoned state/<id>/.lock that is itself a
+// directory, so withAgentLock cannot even open it) NEVER aborts the pass:
+// the failure is accumulated and the loop continues to the next candidate,
+// so one wedged id can never permanently block every other row from being
+// swept (claude-code/codex review, PR #91 round 3 — the same shape codex
+// independently fixed the same day in InvalidateAllServeLeases, PR #92: a
+// fleet-wide maintenance operation must never be disableable by the contents
+// of the pool it maintains). The returned error, when non-nil, is an
+// errors.Join of every per-candidate failure; removed still reports every id
+// that WAS successfully swept even when other candidates failed.
 //
 // Sweeping never touches inboxes, mail, or any other agent state — only the
 // agents/*.md registration file itself.
@@ -120,20 +133,24 @@ func SweepStaleRegistrations(cfg *Config, selfID string, now time.Time) ([]strin
 		afterSweepScanHook()
 	}
 
-	var removed []string
+	var (
+		removed  []string
+		failures []error
+	)
 	for _, c := range candidates {
 		if len(removed) >= MaxSweepPerPass {
 			break
 		}
 		swept, err := sweepOneCandidate(cfg, c.id, c.path, threshold, now)
 		if err != nil {
-			return removed, err
+			failures = append(failures, fmt.Errorf("%s: %w", c.id, err))
+			continue
 		}
 		if swept {
 			removed = append(removed, c.id)
 		}
 	}
-	return removed, nil
+	return removed, errors.Join(failures...)
 }
 
 // sweepOneCandidate re-checks id's staleness (age AND lease) under

--- a/internal/loop/sweep_test.go
+++ b/internal/loop/sweep_test.go
@@ -1,0 +1,245 @@
+package loop
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// seedSweepRegistration writes a minimal registration for agentID with the
+// given LastSeen, for sweep staleness-threshold tests.
+func seedSweepRegistration(t *testing.T, cfg *Config, agentID string, lastSeen time.Time) {
+	t.Helper()
+	reg := &Registration{
+		AgentID:     agentID,
+		Vendor:      "agentchute",
+		ControlRepo: cfg.ControlRepo,
+		LastSeen:    lastSeen,
+		Status:      StatusActive,
+	}
+	if err := WriteRegistration(cfg.AgentRegistrationPath(agentID), reg); err != nil {
+		t.Fatalf("seed registration %s: %v", agentID, err)
+	}
+}
+
+// seedFreshClaim writes a fresh (non-stale) serve claim for agentID directly,
+// bypassing AcquireServeLease — a fixture for "a live lease immunizes an
+// old-looking row" tests.
+func seedFreshClaim(t *testing.T, cfg *Config, agentID string, now time.Time) {
+	t.Helper()
+	writeClaim(t, cfg, &ServeClaim{
+		ID:         agentID,
+		Host:       "some-host",
+		PID:        99999,
+		ServeToken: "fresh-token-" + agentID,
+		StartedAt:  now,
+		LastSeen:   now,
+	})
+}
+
+func TestSweepStaleRegistrationsRemovesStaleDeadRow(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	seedSweepRegistration(t, cfg, "dead", now.Add(-2*time.Hour)) // stale, no claim.
+	seedSweepRegistration(t, cfg, "fresh", now.Add(-time.Minute))
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "dead" {
+		t.Fatalf("removed = %v, want [dead]", removed)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("dead")); !os.IsNotExist(err) {
+		t.Fatalf("dead row survived: stat err = %v", err)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("fresh")); err != nil {
+		t.Fatalf("fresh row was removed: %v", err)
+	}
+}
+
+// TestSweepStaleRegistrationsFreshLeaseImmunizesStaleRow: an old-looking row
+// (last_seen past StaleAfter) with a FRESH serve claim must survive — a fresh
+// lease proves the lane is alive even if its last registration write happens
+// to predate the threshold (C12).
+func TestSweepStaleRegistrationsFreshLeaseImmunizesStaleRow(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	seedSweepRegistration(t, cfg, "alive", now.Add(-2*time.Hour))
+	seedFreshClaim(t, cfg, "alive", now)
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v, want none (fresh lease must immunize)", removed)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("alive")); err != nil {
+		t.Fatalf("row with a fresh lease was removed: %v", err)
+	}
+}
+
+func TestSweepStaleRegistrationsNeverSelf(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	seedSweepRegistration(t, cfg, "self", now.Add(-2*time.Hour))
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v, want none (never sweep self)", removed)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("self")); err != nil {
+		t.Fatalf("self row was removed: %v", err)
+	}
+}
+
+// TestSweepStaleRegistrationsCapHonored: 7 stale dead rows seeded, one pass
+// removes exactly MaxSweepPerPass (5) — deterministically the first 5 in
+// sorted-id order, per SweepStaleRegistrations' documented ordering.
+func TestSweepStaleRegistrationsCapHonored(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	ids := []string{"a", "b", "c", "d", "e", "f", "g"}
+	for _, id := range ids {
+		seedSweepRegistration(t, cfg, id, now.Add(-2*time.Hour))
+	}
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != MaxSweepPerPass {
+		t.Fatalf("removed %d rows, want %d (cap)", len(removed), MaxSweepPerPass)
+	}
+	want := []string{"a", "b", "c", "d", "e"}
+	for i, id := range want {
+		if removed[i] != id {
+			t.Fatalf("removed = %v, want %v (sorted, capped)", removed, want)
+		}
+	}
+	for _, id := range []string{"f", "g"} {
+		if _, err := os.Stat(cfg.AgentRegistrationPath(id)); err != nil {
+			t.Fatalf("row %s beyond the cap was removed: %v", id, err)
+		}
+	}
+}
+
+// TestSweepStaleRegistrationsUnderLockRecheckBacksOffOnRevival: a candidate
+// that gets HEARTBEATED (revived) between the outer scan and its
+// per-candidate lock acquisition must survive — the re-check under
+// WithAgentLock is what closes this TOCTOU window. afterSweepScanHook fires
+// after the candidate list is fixed but before any lock is taken, letting
+// this test deterministically simulate the race in a single goroutine.
+func TestSweepStaleRegistrationsUnderLockRecheckBacksOffOnRevival(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	// Neither row has a claim yet at scan time, so both are candidates —
+	// the divergence must come entirely from the hook firing in the gap
+	// between the outer scan and the per-candidate lock.
+	seedSweepRegistration(t, cfg, "revived", now.Add(-2*time.Hour))
+	seedSweepRegistration(t, cfg, "still-dead", now.Add(-2*time.Hour))
+
+	t.Cleanup(func() { afterSweepScanHook = nil })
+	afterSweepScanHook = func() {
+		// Mirrors a real revival: a fresh serve process starts between the
+		// scan and the sweep's per-candidate lock, acquires the lease
+		// (succeeds — no claim existed yet), and heartbeats.
+		lease, err := AcquireServeLease(cfg, "revived")
+		if err != nil {
+			t.Fatalf("revival acquire: %v", err)
+		}
+		template := Registration{AgentID: "revived", Vendor: "agentchute", ControlRepo: cfg.ControlRepo, Status: StatusActive}
+		if err := HeartbeatRegistration(cfg, template, lease.Token); err != nil {
+			t.Fatalf("revival heartbeat: %v", err)
+		}
+	}
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "still-dead" {
+		t.Fatalf("removed = %v, want [still-dead] (revived row must survive)", removed)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("revived")); err != nil {
+		t.Fatalf("revived row was removed despite the race-closing re-check: %v", err)
+	}
+}
+
+// TestSweepStaleRegistrationsCorruptRowSweptByMtime: a hand-corrupted
+// registration file (fails ReadRegistration) is not immortal — its file
+// mtime stands in for last_seen (C12).
+func TestSweepStaleRegistrationsCorruptRowSweptByMtime(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	path := cfg.AgentRegistrationPath("corrupt")
+	if err := ensurePrivateDir(filepath.Dir(path)); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWriteFile(path, []byte("{not a valid registration")); err != nil {
+		t.Fatal(err)
+	}
+	old := now.Add(-2 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "corrupt" {
+		t.Fatalf("removed = %v, want [corrupt] (mtime-aged corrupt row)", removed)
+	}
+}
+
+// TestSweepStaleRegistrationsNeverSweepsReadmeOrExample: the allowlist skip
+// (README.md, *.example.md) applies even when those files look arbitrarily
+// stale by mtime.
+func TestSweepStaleRegistrationsNeverSweepsReadmeOrExample(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	dir := cfg.AgentsDir()
+	if err := ensurePrivateDir(dir); err != nil {
+		t.Fatal(err)
+	}
+	old := now.Add(-24 * time.Hour)
+	for _, name := range []string{"README.md", "codex.example.md"} {
+		p := filepath.Join(dir, name)
+		if err := atomicWriteFile(p, []byte("not a registration")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(p, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v, want none (README/example must never sweep)", removed)
+	}
+	for _, name := range []string{"README.md", "codex.example.md"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("%s was removed: %v", name, err)
+		}
+	}
+}
+
+func TestSweepStaleRegistrationsMissingAgentsDirIsCleanEmpty(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	removed, err := SweepStaleRegistrations(cfg, "self", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("missing agents dir should be a clean empty result, got err: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v, want none", removed)
+	}
+}

--- a/internal/loop/sweep_test.go
+++ b/internal/loop/sweep_test.go
@@ -233,6 +233,154 @@ func TestSweepStaleRegistrationsNeverSweepsReadmeOrExample(t *testing.T) {
 	}
 }
 
+// TestSweepStaleRegistrationsSkipsNonAgentIDFilenames: a stray .md file whose
+// basename is not a valid agent id (a hand-dropped note, a typo — anything
+// other than README.md/*.example.md, which are already allowlisted) must
+// never abort the pass. Reproduces the exact probe from PR #91 round 2,
+// BLOCKER 1: 3 stale valid rows + one uppercase NOTES.md, all aged past
+// threshold — before the fix this returned removed=[] and an error, leaving
+// every legitimately-stale row permanently un-swept on every future pass
+// (uppercase sorts before lowercase, so the poison candidate is always
+// first).
+func TestSweepStaleRegistrationsSkipsNonAgentIDFilenames(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	old := now.Add(-2 * time.Hour)
+	for _, id := range []string{"aaa", "bbb", "ccc"} {
+		seedSweepRegistration(t, cfg, id, old)
+	}
+	if err := ensurePrivateDir(cfg.AgentsDir()); err != nil {
+		t.Fatal(err)
+	}
+	poison := filepath.Join(cfg.AgentsDir(), "NOTES.md")
+	if err := atomicWriteFile(poison, []byte("not a registration")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(poison, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatalf("a stray non-agent-id filename must not abort the sweep: %v", err)
+	}
+	if len(removed) != 3 {
+		t.Fatalf("removed = %v, want all 3 valid stale rows", removed)
+	}
+	for _, id := range []string{"aaa", "bbb", "ccc"} {
+		if _, err := os.Stat(cfg.AgentRegistrationPath(id)); !os.IsNotExist(err) {
+			t.Fatalf("%s survived: stat err = %v", id, err)
+		}
+	}
+	if _, err := os.Stat(poison); err != nil {
+		t.Fatalf("NOTES.md itself should be left alone (not a registration): %v", err)
+	}
+}
+
+// TestSweepStaleRegistrationsFailsClosedOnCorruptClaim: a corrupt (unparseable)
+// serve claim must NOT be treated as "no lease, safe to delete" — that read
+// error means "cannot prove dead", so the candidate is skipped, not removed
+// (PR #91 round 2, BLOCKER 2). Before the fix this deleted the row outright.
+func TestSweepStaleRegistrationsFailsClosedOnCorruptClaim(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	seedSweepRegistration(t, cfg, "live", now.Add(-2*time.Hour))
+	if err := ensurePrivateDir(cfg.AgentStateDir("live")); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWriteFile(claimPath(cfg, "live"), []byte("{not json")); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("removed = %v, want none — a corrupt claim must fail closed, not delete", removed)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("live")); err != nil {
+		t.Fatalf("row with a corrupt (unprovable) claim was removed: %v", err)
+	}
+}
+
+// TestSweepStaleRegistrationsUnderLockRecheckSurvivesLeaseOnlyRevival isolates
+// the LEASE half of the under-lock re-check: the candidate's registration row
+// stays stale (no heartbeat), but a FRESH lease is acquired for it in the gap
+// between the outer scan and the per-candidate lock — mirroring a real serve
+// process starting on a stale lane before its first heartbeat tick. The
+// combined test (...BacksOffOnRevival, above) exercises age-revival and
+// lease-revival together, which cannot tell which clause is load-bearing;
+// this isolates the lease clause alone (PR #91 round 2, SHOULD-FIX 5).
+func TestSweepStaleRegistrationsUnderLockRecheckSurvivesLeaseOnlyRevival(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	seedSweepRegistration(t, cfg, "lease-only", now.Add(-2*time.Hour))
+	seedSweepRegistration(t, cfg, "still-dead", now.Add(-2*time.Hour))
+
+	t.Cleanup(func() { afterSweepScanHook = nil })
+	afterSweepScanHook = func() {
+		if _, err := AcquireServeLease(cfg, "lease-only"); err != nil {
+			t.Fatalf("lease-only revival acquire: %v", err)
+		}
+	}
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "still-dead" {
+		t.Fatalf("removed = %v, want [still-dead] (a fresh lease alone must save the row)", removed)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("lease-only")); err != nil {
+		t.Fatalf("lease-only-revived row was removed: %v", err)
+	}
+}
+
+// TestSweepStaleRegistrationsUnderLockRecheckSurvivesHeartbeatOnlyRevival
+// isolates the AGE half: the row's last_seen is refreshed directly (no claim
+// ever exists for it) in the gap between the outer scan and the per-candidate
+// lock. Age alone must save it (PR #91 round 2, SHOULD-FIX 5).
+func TestSweepStaleRegistrationsUnderLockRecheckSurvivesHeartbeatOnlyRevival(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	seedSweepRegistration(t, cfg, "heartbeat-only", now.Add(-2*time.Hour))
+	seedSweepRegistration(t, cfg, "still-dead", now.Add(-2*time.Hour))
+
+	t.Cleanup(func() { afterSweepScanHook = nil })
+	afterSweepScanHook = func() {
+		seedSweepRegistration(t, cfg, "heartbeat-only", time.Now().UTC())
+	}
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "still-dead" {
+		t.Fatalf("removed = %v, want [still-dead] (a fresh last_seen alone must save the row)", removed)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("heartbeat-only")); err != nil {
+		t.Fatalf("heartbeat-only-revived row was removed: %v", err)
+	}
+}
+
+// TestSweepStaleRegistrationsFutureLastSeenIsNotImmortal: a future-dated
+// last_seen (clock skew or a hand edit) must not grant permanent
+// sweep-immunity — grok review residual, PR #91 round 2, item 6.
+func TestSweepStaleRegistrationsFutureLastSeenIsNotImmortal(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	seedSweepRegistration(t, cfg, "future", now.Add(2*time.Hour))
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "future" {
+		t.Fatalf("removed = %v, want [future] (a future last_seen must not grant immortality)", removed)
+	}
+}
+
 func TestSweepStaleRegistrationsMissingAgentsDirIsCleanEmpty(t *testing.T) {
 	cfg := newLeaseTestConfig(t)
 	removed, err := SweepStaleRegistrations(cfg, "self", time.Now().UTC())

--- a/internal/loop/sweep_test.go
+++ b/internal/loop/sweep_test.go
@@ -3,6 +3,7 @@ package loop
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -378,6 +379,42 @@ func TestSweepStaleRegistrationsFutureLastSeenIsNotImmortal(t *testing.T) {
 	}
 	if len(removed) != 1 || removed[0] != "future" {
 		t.Fatalf("removed = %v, want [future] (a future last_seen must not grant immortality)", removed)
+	}
+}
+
+// TestSweepStaleRegistrationsPoisonedLockDoesNotAbortPass: a candidate whose
+// state/<id>/.lock path is itself a DIRECTORY (withAgentLock's OpenFile fails
+// with EISDIR, before the closure ever runs) must not abort the whole pass —
+// codex found the identical shape in InvalidateAllServeLeases the same day
+// (PR #92) and it is now the house pattern for fleet-wide maintenance: never
+// disableable by the contents of the pool it maintains (PR #91 round 3,
+// BLOCKER). "locked" sorts before "still-dead", so before the fix the pass
+// aborted at "locked" and "still-dead" was never reached.
+func TestSweepStaleRegistrationsPoisonedLockDoesNotAbortPass(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	old := now.Add(-2 * time.Hour)
+	seedSweepRegistration(t, cfg, "locked", old)
+	seedSweepRegistration(t, cfg, "still-dead", old)
+	if err := os.MkdirAll(filepath.Join(cfg.AgentStateDir("locked"), ".lock"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err == nil {
+		t.Fatal("want a non-nil aggregate error naming the poisoned candidate")
+	}
+	if !strings.Contains(err.Error(), "locked") {
+		t.Fatalf("aggregate error = %v, want it to name %q", err, "locked")
+	}
+	if len(removed) != 1 || removed[0] != "still-dead" {
+		t.Fatalf("removed = %v, want [still-dead] (poisoned candidate must not block later ones)", removed)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("locked")); err != nil {
+		t.Fatalf("locked row should survive (its lock could never be taken): %v", err)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("still-dead")); !os.IsNotExist(err) {
+		t.Fatalf("still-dead should have been swept: stat err = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements v2.5 plan slice B1 (`docs/decisions/agentchute-v2.5-implementation-plan.md`, §2 B1 + constants C9–C13): registration becomes "reachable now-ish" instead of relying on `.live`/explicit deregistration.

- **C9** — `--stale-after` pool config flag (`setup.go`), `loop.StaleAfter(cfg)` reader (default 1h, tolerant of absent/corrupt state), `setup.json` writes converted to atomic temp+rename, `update` replays the flag on resync.
- **C13** — `loop.HeartbeatRegistration(cfg, template, leaseToken)` replaces `UpdateLastSeen`: lease-gated (empty token errors; `ErrFenced` on a reclaimed/absent claim, writing nothing), self-healing (recreates a swept/missing row from `template`), merges with existing on-disk `Body`/`WorkingRepos`/`LastActive`/launch provenance (template wins for everything else, empty-falls-back-to-existing for provenance — see round 2 item 4). Sole caller is `serve`'s poll tick. `check`/`send`/`status` no longer refresh liveness — their registration-exists preflights stay, with the existing "run `agentchute boot --as <id>`" hint.
- **C11/C12** — `loop.SweepStaleRegistrations(cfg, selfID, now)`: candidates are rows past `StaleAfter` with an absent/stale serve claim (never self); capped at 5/pass; corrupt rows use file mtime as an age proxy; README/`*.example.md` are never touched; each candidate is re-checked (age + lease) under `WithAgentLock` immediately before delete, closing the scan→delete TOCTOU window. Triggered from `boot` (after self-register, before the inbox peek) and `serve`'s poll tick (10-minute cadence, immediate on the very first tick).
- **Quitting agent does nothing** — `markRunnerOffline` and its shutdown-defer call are deleted; a dead lane just stops heartbeating and ages out. `update.go`'s `activeAgentIDs` is now interim age-based (row age ≤ `StaleAfter`) instead of `Status != offline`.

**Done-when** (proven in `internal/cli/b1_convergence_test.go`, `TestB1ConvergencePoolWithDeadRowsAndLiveServe`): one live serve + two dead rows — dead rows gone after a single poll tick; the live row survives across ticks; killing the serve (release lease + backdate its row) and running a *peer's* boot sweeps it; restarting (booting again) recreates it.

## Deviations from plan text (disclosed per team convention)

1. `filelock_test.go`'s `TestRunnerOfflineNotResurrectedByConcurrentLastSeen` was **deleted** rather than rewritten to a `HeartbeatRegistration` equivalent — it modeled a race against `markRunnerOffline`, which B1 removes entirely, so the scenario no longer exists in production. Replaced the adjacent `TestUpdateLastSeen_NoLostUpdateUnderConcurrency` with a `HeartbeatRegistration`-based twin (same torn-write/lost-update coverage, now lease-gated).
2. `HeartbeatRegistration`'s signature omits `now time.Time` (uses `time.Now().UTC()` internally) — the plan's literal C13 signature doesn't list it, though sibling functions (`UpdateLastActive`) do take it. Kept literal since no test needed injectable time at this call (age-threshold math lives entirely in `SweepStaleRegistrations`, which *does* take `now` per plan).
3. `setup.go`'s default `--stale-after` fallback serializes as `loop.DefaultStaleAfter.String()` = `"1h0m0s"` rather than the literal `"1h"` — functionally identical (`time.ParseDuration` round-trips either), tied to the single source of truth instead of a duplicated literal.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` and `go test -race ./...` green (env stripped of `AGENTCHUTE_*`)
- [x] Mutation-verified: sweep's never-self guard, sweep's under-lock re-check, boot's sweep call (twice — unit + convergence integration), setup's stale-after preservation-on-resync — each reverted, confirmed the targeted test fails, restored, confirmed it passes again
- [x] Convergence Done-when test passing

Reviewers: claude-code, codex. Do not merge — merges on the gate per program convention.

## Review round 2 (claude-code panel + grok residuals) — head `bef9e53`

All items independently probe-reproduced against pre-fix code before touching anything, then revert-verified after (revert → confirm targeted test fails → restore → confirm it passes).

1. **BLOCKER, fixed** — stray non-agent-id `.md` in `agents/` (e.g. `NOTES.md`) no longer hard-errors the whole sweep pass. `SweepStaleRegistrations`'s scan loop now skips any basename failing `ValidateAgentID` before it ever reaches `sweepOneCandidate`'s `withAgentLock`. Test: `TestSweepStaleRegistrationsSkipsNonAgentIDFilenames`.
2. **BLOCKER, fixed** — the lease cross-check (`claimProvablyDead`) now fails CLOSED: only `os.ErrNotExist` counts as "no lease, safe to delete"; any other read error (corrupt claim, EACCES, symlink rejection, oversize) means "cannot prove dead" and the candidate is skipped, consistent with `VerifyFence`/`AcquireServeLease`'s existing fail-closed direction. Test: `TestSweepStaleRegistrationsFailsClosedOnCorruptClaim`.
3. **SHOULD-FIX, recorded not re-engineered** — `sweepOneCandidate`'s `withAgentLock` still creates `state/<id>/` + `.lock` as a side effect, for every candidate evaluated and for the id it deletes. Documented in `sweep.go`'s doc comment as the same accepted tradeoff `clean.go` (`cmdCleanOwed`, `--mailbox` apply path) already lives with: the lock is load-bearing for correctness (closes the TOCTOU window), cleanup would race concurrent activity for cosmetic benefit only, and doctor/gate/status never read these dirs.
4. **SHOULD-FIX, fixed** — `HeartbeatRegistration`'s merge now also preserves `LastActive` and launch provenance (`LaunchedBy`/`ShimName`/`HookEvent`, empty-template-value-falls-back-to-existing, matching `performRegister`'s own merge rule) instead of only `Body`/`WorkingRepos`. Tests: `TestHeartbeatRegistrationPreservesLastActive`, `TestHeartbeatRegistrationPreservesLaunchProvenanceTemplateDoesNotSet`.
5. **SHOULD-FIX, fixed** — added two tests decomposing the composite revival-hook coverage: `TestSweepStaleRegistrationsUnderLockRecheckSurvivesLeaseOnlyRevival` and `...SurvivesHeartbeatOnlyRevival`, each isolating one re-check clause (age vs. lease) as independently load-bearing, closing the "mutation-verified" gap the composite-only hook left.
6. **grok residual, fixed** — a future-dated `last_seen` (clock skew/hand edit) no longer grants permanent sweep immunity. `registrationAge` clamps any negative age to `math.MaxInt64` via `clampNonNegativeAge`, erring toward eventual cleanup rather than toward immortality (a registration row is discoverable display state, not a lock). Test: `TestSweepStaleRegistrationsFutureLastSeenIsNotImmortal`.
7. **grok residual, recorded not implemented** (cross-slice, correctly out of scope for B1) — `boot`/`register` advance `last_seen` without a lease, so a `boot --as ghost` loop with no runner behind it keeps a roster entry looking fresh indefinitely. Harmless under B1 (registration freshness gates nothing yet); flagged here for **B3 and B9**: once send-reachability or any other decision keys off registration age, a lease-less boot loop becomes a black-hole attractor that reads as reachable while nothing is actually polling the inbox. No code change in this PR.

CI green on `bef9e53` (build/vet/gofmt/test/test-race, `AGENTCHUTE_*` stripped).
