### PR TITLE
feat(update): lease invalidation forces restart at the wire break (v2.5 plan B2)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches: [main, release/v2.5]
   pull_request:
 
 jobs:
@@ -50,5 +50,22 @@ jobs:
         run: shellcheck -s sh install.sh
       - name: shellcheck tests/install_test.sh
         run: shellcheck -s sh tests/install_test.sh
+      - name: shellcheck tests/upgrade_smoke.sh
+        run: shellcheck -s sh tests/upgrade_smoke.sh
       - name: run install_test.sh
         run: sh tests/install_test.sh
+
+  upgrade-smoke:
+    name: old-to-v2.5 upgrade rehearsal
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release/v2.5'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          check-latest: true
+      - name: run upgrade smoke
+        run: sh tests/upgrade_smoke.sh

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -214,7 +214,7 @@ func TestRunnerPollShutsDownWhenFenced(t *testing.T) {
 	}
 }
 
-func TestRunnerFencedShutdownLogsAndBuffersFatal(t *testing.T) {
+func TestRunnerInvalidatedLeaseLogsC15NoticeAndBuffersFatal(t *testing.T) {
 	root := setupShortRunFixture(t)
 	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
 	if err != nil {
@@ -229,19 +229,13 @@ func TestRunnerFencedShutdownLogsAndBuffersFatal(t *testing.T) {
 	}
 	rt.lease = lease
 
-	reclaimed := loop.ServeClaim{
-		ID:         "runner-test",
-		Host:       "other-host",
-		PID:        os.Getpid(),
-		ServeToken: "ffffffffffffffffffffffffffffffff",
-		StartedAt:  time.Now().UTC(),
-		LastSeen:   time.Now().UTC(),
-	}
-	data, err := json.Marshal(reclaimed)
+	invalidated, err := loop.InvalidateAllServeLeases(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustWrite(t, filepath.Join(cfg.AgentStateDir("runner-test"), "serve.claim"), data)
+	if invalidated != 1 {
+		t.Fatalf("invalidated = %d, want 1", invalidated)
+	}
 
 	stderr := captureStderr(t, func() {
 		rt.pollOnce()
@@ -253,7 +247,7 @@ func TestRunnerFencedShutdownLogsAndBuffersFatal(t *testing.T) {
 		t.Fatal("fenced runner did not request shutdown")
 	}
 	log := readRunnerLog(t, cfg, "runner-test")
-	want := "agentchute serve: serve lease reclaimed (fenced); shutting down"
+	want := "serve: this agentchute binary was fenced out (update or identity reclaim). Restart this lane: ac serve <wrapper>"
 	if !strings.Contains(log, want) {
 		t.Fatalf("runner.log missing fenced fatal:\n%s", log)
 	}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -572,7 +572,7 @@ func (r *runnerRuntime) pollOnce() {
 	if r.lease != nil {
 		if err := loop.RenewLease(r.lease); err != nil {
 			if errors.Is(err, loop.ErrFenced) {
-				r.bufferFatalf("agentchute serve: serve lease reclaimed (fenced); shutting down\n")
+				r.bufferFatalf("serve: this agentchute binary was fenced out (update or identity reclaim). Restart this lane: ac serve <wrapper>\n")
 				r.requestShutdown(syscall.SIGTERM)
 				return
 			}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -191,8 +191,8 @@ Usage:
   agentchute setup [--wake runner] [--wrappers all|none|<list>] [--yes] [--dry-run]
 
 Scaffolds the control repo with agentchute init, stops local agentchute
-pollers/runners, clears stale live registrations so agents re-enroll, installs
-lifecycle hooks for the selected wrappers, and installs the
+pollers/runners, invalidates serve leases while preserving registration rows,
+installs lifecycle hooks for the selected wrappers, and installs the
 single ac dispatcher (launch a wrapper with: ac serve <wrapper>).
 
 runner is the only supported wake path: the tmux/herdr wake adapters were
@@ -468,7 +468,7 @@ func printSetupPlan(w io.Writer, root string, opts setupOptions, wrappers []stri
 		fmt.Fprintln(w, "                state (inbox/archive/malformed/live/scratch/state) + live registrations;")
 		fmt.Fprintln(w, "                preserves scaffold + state/setup.json; refuses a live bus (prompts before deleting)")
 	} else {
-		fmt.Fprintln(w, "  reset:        stop local agentchute pollers/runners and clear live agents/*.md")
+		fmt.Fprintln(w, "  reset:        stop local agentchute pollers/runners, invalidate serve leases, preserve agents/*.md")
 	}
 	if len(hookWrappers) > 0 {
 		fmt.Fprintln(w, "  hooks:        repo scope, force/idempotent")
@@ -551,12 +551,13 @@ func previousSetupShimWrappers(state setupGlobalState) []string {
 }
 
 // setupRunRuntimeReset is the DESTRUCTIVE phase of setup: it stops local
-// pollers/runners, clears runtime state files, then deletes live registrations
-// so agents re-enroll. It is a package var so tests can inject a failure to
+// pollers/runners, clears runtime state files, then invalidates every serve
+// lease so surviving supervisors fence out. Registration rows are preserved.
+// It is a package var so tests can inject a failure to
 // prove the ordering invariant below. It is invoked LAST in
 // applySetup — after every idempotent, recoverable write (init/enrollment, hooks,
 // shims, PATH block, saved setup state) has landed — so a mid-setup failure can
-// never leave the bus with cleared registrations AND no wake infrastructure.
+// never leave the bus fenced AND without wake infrastructure.
 var setupRunRuntimeReset = func(root string, cfg *loop.Config, wrappers []string) error {
 	reset := resetSetupRuntimeState(root, cfg, wrappers)
 	if len(reset.Pollers) > 0 {
@@ -571,12 +572,12 @@ var setupRunRuntimeReset = func(root string, cfg *loop.Config, wrappers []string
 	for _, warning := range reset.Warnings {
 		fmt.Printf("warning: setup reset: %s\n", warning)
 	}
-	cleared, err := clearSetupLiveRegistrations(cfg)
+	invalidated, err := loop.InvalidateAllServeLeases(cfg)
 	if err != nil {
 		return err
 	}
-	if len(cleared) > 0 {
-		fmt.Printf("cleared %d stale live registration(s): %s\n", len(cleared), strings.Join(cleared, ", "))
+	if invalidated > 0 {
+		fmt.Printf("invalidated %d serve lease(s); supervisors will exit on their next tick\n", invalidated)
 	}
 	return nil
 }
@@ -745,41 +746,6 @@ func applySetup(root string, opts setupOptions, wrappers []string) error {
 		printSetupCompletionGuidance(os.Stdout, opts.Wake)
 		return nil
 	})
-}
-
-func clearSetupLiveRegistrations(cfg *loop.Config) ([]string, error) {
-	entries, err := os.ReadDir(cfg.AgentsDir())
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read live registrations: %w", err)
-	}
-
-	var cleared []string
-	for _, entry := range entries {
-		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".md") || strings.HasSuffix(name, ".example.md") || name == "README.md" {
-			continue
-		}
-		path := filepath.Join(cfg.AgentsDir(), name)
-		info, err := os.Lstat(path)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-			return nil, fmt.Errorf("inspect live registration %s: %w", name, err)
-		}
-		if !info.Mode().IsRegular() && info.Mode()&os.ModeSymlink == 0 {
-			continue
-		}
-		if err := os.Remove(path); err != nil {
-			return nil, fmt.Errorf("remove live registration %s: %w", name, err)
-		}
-		cleared = append(cleared, name)
-	}
-	sort.Strings(cleared)
-	return cleared, nil
 }
 
 func hookWrapperByName(name string) (hookWrapper, bool) {

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -306,7 +306,7 @@ func TestSetupHelpAndInvalidWakeRunnerOnly(t *testing.T) {
 	})
 }
 
-func TestSetupClearsExistingLiveRegistrations(t *testing.T) {
+func TestSetupInvalidatesServeLeasesAndPreservesRegistrations(t *testing.T) {
 	root := t.TempDir()
 	mustMkdir(t, filepath.Join(root, ".git"))
 	home := t.TempDir()
@@ -319,9 +319,16 @@ func TestSetupClearsExistingLiveRegistrations(t *testing.T) {
 
 	agentsDir := filepath.Join(root, ".agentchute", "loop", "agents")
 	mustMkdir(t, agentsDir)
-	mustWrite(t, filepath.Join(agentsDir, "codex-agentchute.md"), []byte("---\nagent_id: codex-agentchute\nvendor: openai\ncontrol_repo: "+root+"\nhost: test\nlast_seen: 2026-01-01T00:00:00Z\nstatus: active\n---\n"))
+	registrationPath := filepath.Join(agentsDir, "codex-agentchute.md")
+	registration := []byte("---\nagent_id: codex-agentchute\nvendor: openai\ncontrol_repo: " + root + "\nhost: test\nlast_seen: 2026-01-01T00:00:00Z\nstatus: active\n---\n")
+	mustWrite(t, registrationPath, registration)
 	mustWrite(t, filepath.Join(agentsDir, "codex.example.md"), []byte("tracked example\n"))
 	mustWrite(t, filepath.Join(agentsDir, "README.md"), []byte("format reference\n"))
+	cfg := &loop.Config{ControlRepo: root, LoopDir: filepath.Join(root, ".agentchute", "loop")}
+	lease, err := loop.AcquireServeLease(cfg, "codex-agentchute")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	withCwd(t, root, func() {
 		if err := cmdSetup([]string{"--wake", "runner", "--wrappers", "none", "--yes"}); err != nil {
@@ -329,8 +336,15 @@ func TestSetupClearsExistingLiveRegistrations(t *testing.T) {
 		}
 	})
 
-	if _, err := os.Stat(filepath.Join(agentsDir, "codex-agentchute.md")); !os.IsNotExist(err) {
-		t.Fatalf("live registration should be cleared by setup: %v", err)
+	gotRegistration, err := os.ReadFile(registrationPath)
+	if err != nil {
+		t.Fatalf("registration should be preserved by setup: %v", err)
+	}
+	if string(gotRegistration) != string(registration) {
+		t.Fatalf("registration changed during setup:\ngot:  %s\nwant: %s", gotRegistration, registration)
+	}
+	if err := loop.RenewLease(lease); !errors.Is(err, loop.ErrFenced) {
+		t.Fatalf("old lease after setup = %v, want ErrFenced", err)
 	}
 	for _, keep := range []string{"codex.example.md", "README.md"} {
 		if _, err := os.Stat(filepath.Join(agentsDir, keep)); err != nil {
@@ -585,7 +599,7 @@ func TestSetupWrapperNarrowingRemovesDroppedHooksAndShims(t *testing.T) {
 // hooks, shims, PATH block, saved setup state) must all land BEFORE the
 // destructive runtime reset. We inject a failure into the reset seam and assert
 // every wake-infrastructure artifact already exists — so a mid-setup failure can
-// never leave the bus with cleared registrations AND no wake infrastructure. A
+// never leave the bus with invalidated leases AND no wake infrastructure. A
 // pre-reorder build (reset first) leaves these unwritten when the reset fails and
 // this test goes red.
 func TestSetup_TemplatesWrittenBeforeRuntimeReset(t *testing.T) {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -57,12 +57,11 @@ Updates an existing install in one step: self-updates the binary to the target
 release, then re-runs ` + "`setup`" + ` with this control repo's saved wake mode and
 wrappers so hooks, enrollment blocks, and shims re-sync to the new version.
 
-This clears live registrations; you MUST restart every active agent afterward.
+This invalidates every serve lease after the binary swap. Running supervisors
+fence out and exit on their next tick; registration rows are preserved.
 
-Pass --no-resync to swap ONLY the binary and skip the setup re-sync: live
-registrations are preserved and no bus reset happens. Use it for a pure binary
-refresh, or for a pool created by an older binary / via ` + "`init`" + ` that has no
-saved setup state to replay.
+Pass --no-resync to skip the setup re-sync. Lease invalidation still happens,
+because a binary-only update must also force running supervisors to restart.
 
 Flags:
   --version <tag>   release tag to install (default: latest release)
@@ -91,7 +90,7 @@ func cmdUpdate(args []string) error {
 	// 1. Discover the control repo. The setup re-sync replays the saved
 	// wake/wrappers, so it REQUIRES saved pool state — but --no-resync skips the
 	// re-sync entirely (binary-only update), so it neither needs nor reads that
-	// state and never resets the bus.
+	// state. Both paths invalidate serve leases after the binary swap.
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -172,11 +171,11 @@ func cmdUpdate(args []string) error {
 		fmt.Printf("  binary:        %s\n", target)
 		fmt.Printf("  asset:         %s\n", asset)
 		if noResync {
-			fmt.Println("  re-sync:       skipped (--no-resync); binary swap only")
-			fmt.Println("  reset:         skipped (--no-resync); live registrations preserved")
+			fmt.Println("  re-sync:       skipped (--no-resync)")
+			fmt.Println("  restart:       would invalidate serve leases after the binary swap")
 		} else {
 			fmt.Printf("  re-sync:       %s\n", setupCmd)
-			fmt.Printf("  reset:         would stop local agentchute runtimes and clear %d live agent registration(s)\n", len(active))
+			fmt.Println("  restart:       would invalidate serve leases; registrations stay present")
 		}
 		printActiveAgents(active)
 		fmt.Println("(dry-run; no changes made)")
@@ -201,7 +200,6 @@ func cmdUpdate(args []string) error {
 	}
 	defer os.Remove(tmpBin)
 
-	// --no-resync is a pure binary refresh: no bus reset, no restart needed.
 	if !noResync {
 		printRestartWarning(targetTag, active, false)
 	}
@@ -213,10 +211,17 @@ func cmdUpdate(args []string) error {
 	syncDir(filepath.Dir(target))
 	fmt.Printf("Updated agentchute %s -> %s (%s)\n", current, targetTag, target)
 
+	invalidated, err := loop.InvalidateAllServeLeases(cfg)
+	if err != nil {
+		return fmt.Errorf("binary updated to %s but serve-lease invalidation failed: %w; rerun `agentchute setup --yes` before relaunching lanes", targetTag, err)
+	}
+	fmt.Printf("Invalidated %d serve lease(s); running supervisors will exit on their next tick.\n", invalidated)
+
 	if noResync {
-		// Binary-only update: skip the destructive setup re-sync entirely. Live
-		// registrations and wake infrastructure are left untouched.
-		fmt.Println("(--no-resync: skipped setup re-sync; live registrations preserved)")
+		// Binary-only update: hooks/templates stay untouched, but the wire-break
+		// forcing function still fences every running supervisor.
+		fmt.Println("(--no-resync: skipped setup re-sync; registrations preserved)")
+		printRestartWarning(targetTag, active, true)
 		return nil
 	}
 
@@ -501,12 +506,12 @@ func printRestartWarning(tag string, active []string, done bool) {
 	bar := strings.Repeat("=", 70)
 	fmt.Fprintln(os.Stderr, bar)
 	if done {
-		fmt.Fprintf(os.Stderr, "agentchute updated to %s and re-ran setup.\n\n", tag)
+		fmt.Fprintf(os.Stderr, "agentchute updated to %s; serve leases were invalidated.\n\n", tag)
 	} else {
-		fmt.Fprintf(os.Stderr, "agentchute is updating to %s and will re-run setup.\n\n", tag)
+		fmt.Fprintf(os.Stderr, "agentchute is updating to %s; serve leases will be invalidated immediately after the binary swap.\n\n", tag)
 	}
-	fmt.Fprintln(os.Stderr, "setup stops local agentchute pollers/runners and clears live registrations.")
-	fmt.Fprintln(os.Stderr, "Each wrapper re-enrolls on its next start; until then it is absent from the pool.")
+	fmt.Fprintln(os.Stderr, "Running supervisors are fenced and will exit with a restart notice on their next tick.")
+	fmt.Fprintln(os.Stderr, "Registration rows stay present. Relaunch each lane with `ac serve <wrapper>`.")
 	if len(active) > 0 {
 		fmt.Fprintf(os.Stderr, "\nRESTART every active agent now (%d): %s\n", len(active), strings.Join(active, ", "))
 	}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -270,10 +271,9 @@ func TestUpdate_NoResyncAllowsBinaryOnlyWhenNoSetupState(t *testing.T) {
 	})
 }
 
-// With --no-resync the apply path swaps the binary but must NEVER invoke the
-// destructive setup re-sync seam (no bus reset, registrations preserved). We
-// assert via the updateRunResync seam: a stub that records invocation must stay
-// untouched, while the binary is replaced by the served archive.
+// With --no-resync the apply path swaps the binary and invalidates leases, but
+// must NEVER invoke the setup re-sync seam. We assert via updateRunResync: a
+// stub that records invocation must stay untouched, while the old lease fences.
 func TestUpdate_NoResyncSkipsSetupReSync(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("root bypasses directory permissions used by the writable probe")
@@ -323,15 +323,24 @@ func TestUpdate_NoResyncSkipsSetupReSync(t *testing.T) {
 		updateRunResync = oldResync
 	})
 
+	var lease *loop.ServeLease
 	withCwd(t, root, func() {
 		mustExampleRepo(t, root) // deliberately NO saved setup state
+		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		lease, err = loop.AcquireServeLease(cfg, "codex-agentchute")
+		if err != nil {
+			t.Fatal(err)
+		}
 		if err := cmdUpdate([]string{"--version", "v0.5.0", "--no-resync"}); err != nil {
 			t.Fatalf("--no-resync binary-only update failed: %v", err)
 		}
 	})
 
 	if resyncCalled {
-		t.Fatal("--no-resync must NOT invoke the destructive setup re-sync")
+		t.Fatal("--no-resync must NOT invoke the setup re-sync")
 	}
 	got, err := os.ReadFile(bin)
 	if err != nil {
@@ -339,6 +348,78 @@ func TestUpdate_NoResyncSkipsSetupReSync(t *testing.T) {
 	}
 	if string(got) != "NEW-BINARY-BYTES" {
 		t.Fatalf("binary should be swapped to the served archive; got %q", got)
+	}
+	if err := loop.RenewLease(lease); !errors.Is(err, loop.ErrFenced) {
+		t.Fatalf("old lease after --no-resync update = %v, want ErrFenced", err)
+	}
+}
+
+func TestUpdateInvalidatesLeaseBeforeSetupResync(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions used by the writable probe")
+	}
+	root := t.TempDir()
+	installDir := t.TempDir()
+	bin := filepath.Join(installDir, "agentchute")
+	if err := os.WriteFile(bin, []byte{0x7f, 'E', 'L', 'F', 0, 0, 0, 0}, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	asset := fmt.Sprintf("agentchute_0.5.0_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	archive := makeTarGz(t, map[string][]byte{"agentchute": []byte("NEW-BINARY-BYTES")})
+	sum := sha256.Sum256(archive)
+	checksum := hex.EncodeToString(sum[:])
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			fmt.Fprintf(w, "%s  %s\n", checksum, asset)
+		case strings.HasSuffix(r.URL.Path, asset):
+			w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	oldBase := updateGitHubBase
+	oldTarget := resolveUpdateTargetForTest
+	oldResync := updateRunResync
+	updateGitHubBase = srv.URL
+	resolveUpdateTargetForTest = bin
+	t.Cleanup(func() {
+		updateGitHubBase = oldBase
+		resolveUpdateTargetForTest = oldTarget
+		updateRunResync = oldResync
+	})
+
+	var lease *loop.ServeLease
+	resyncCalled := false
+	withCwd(t, root, func() {
+		mustExampleRepo(t, root)
+		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writeSetupPoolState(cfg, "runner", nil); err != nil {
+			t.Fatal(err)
+		}
+		lease, err = loop.AcquireServeLease(cfg, "codex-agentchute")
+		if err != nil {
+			t.Fatal(err)
+		}
+		updateRunResync = func(target string, setupArgs []string, controlRepo string) error {
+			resyncCalled = true
+			if err := loop.RenewLease(lease); !errors.Is(err, loop.ErrFenced) {
+				t.Fatalf("lease at setup re-sync = %v, want ErrFenced", err)
+			}
+			return nil
+		}
+		if err := cmdUpdate([]string{"--version", "v0.5.0"}); err != nil {
+			t.Fatalf("update with re-sync failed: %v", err)
+		}
+	})
+	if !resyncCalled {
+		t.Fatal("normal update did not invoke setup re-sync")
 	}
 }
 

--- a/internal/loop/lease.go
+++ b/internal/loop/lease.go
@@ -93,6 +93,11 @@ var mintServeToken = func() (string, error) {
 // while the reclaim holds it. nil in production.
 var afterReclaimWriteHook func()
 
+// afterInvalidateSnapshotHook runs after InvalidateAllServeLeases snapshots a
+// claim and before it takes that agent's lock. Test-only: lets a test replace
+// the claim in the exact enumeration-to-lock window. nil in production.
+var afterInvalidateSnapshotHook func(string)
+
 func readClaim(path string) (*ServeClaim, error) {
 	data, err := ReadFileLimit(path, MaxClaimBytes)
 	if err != nil {
@@ -378,40 +383,94 @@ func InvalidateAllServeLeases(cfg *Config) (int, error) {
 		return 0, fmt.Errorf("list serve leases in %s: %w", stateDir, err)
 	}
 
-	invalidated := 0
+	type claimSnapshot struct {
+		id         string
+		path       string
+		token      string
+		tokenKnown bool
+		info       os.FileInfo
+	}
+
+	var (
+		snapshots []claimSnapshot
+		failures  []error
+	)
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
 		id := entry.Name()
 		path := claimPath(cfg, id)
-		if _, err := os.Lstat(path); err != nil {
+		info, err := os.Lstat(path)
+		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
 				continue
 			}
-			return invalidated, fmt.Errorf("inspect serve lease %s: %w", path, err)
+			failures = append(failures, fmt.Errorf("%s: inspect serve claim: %w", id, err))
+			continue
 		}
 		if err := ValidateAgentID(id); err != nil {
-			return invalidated, fmt.Errorf("serve lease directory %q has invalid agent id: %w", id, err)
+			failures = append(failures, fmt.Errorf("%q: invalid serve-lease directory: %w", id, err))
+			continue
+		}
+		if !info.Mode().IsRegular() {
+			failures = append(failures, fmt.Errorf("%s: serve claim is not a regular file", id))
+			continue
 		}
 
+		snapshot := claimSnapshot{id: id, path: path, info: info}
+		if claim, err := readClaim(path); err == nil {
+			snapshot.token = claim.ServeToken
+			snapshot.tokenKnown = true
+		}
+		snapshots = append(snapshots, snapshot)
+		if afterInvalidateSnapshotHook != nil {
+			afterInvalidateSnapshotHook(id)
+		}
+	}
+
+	invalidated := 0
+	for _, snapshot := range snapshots {
 		removed := false
-		err := withAgentLock(cfg, id, func() error {
-			if err := os.Remove(path); err != nil {
+		err := withAgentLock(cfg, snapshot.id, func() error {
+			currentInfo, err := os.Lstat(snapshot.path)
+			if err != nil {
 				if errors.Is(err, os.ErrNotExist) {
 					return nil
 				}
-				return fmt.Errorf("remove serve lease %s: %w", path, err)
+				return fmt.Errorf("inspect current serve claim: %w", err)
+			}
+			if !currentInfo.Mode().IsRegular() {
+				return fmt.Errorf("current serve claim is not a regular file")
+			}
+
+			if snapshot.tokenKnown {
+				current, err := readClaim(snapshot.path)
+				switch {
+				case err == nil && current.ServeToken != snapshot.token:
+					return nil
+				case err != nil && !os.SameFile(snapshot.info, currentInfo):
+					return fmt.Errorf("current serve claim changed and is unreadable: %w", err)
+				}
+			} else if !os.SameFile(snapshot.info, currentInfo) {
+				return nil
+			}
+
+			if err := os.Remove(snapshot.path); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return nil
+				}
+				return fmt.Errorf("remove serve claim: %w", err)
 			}
 			removed = true
-			return syncDir(filepath.Dir(path))
+			return syncDir(filepath.Dir(snapshot.path))
 		})
-		if err != nil {
-			return invalidated, err
-		}
 		if removed {
 			invalidated++
 		}
+		if err != nil {
+			failures = append(failures, fmt.Errorf("%s: invalidate serve lease: %w", snapshot.id, err))
+		}
 	}
-	return invalidated, nil
+	return invalidated, errors.Join(failures...)
 }

--- a/internal/loop/lease.go
+++ b/internal/loop/lease.go
@@ -359,3 +359,59 @@ func ReleaseLease(l *ServeLease) error {
 		return syncDir(filepath.Dir(path))
 	})
 }
+
+// InvalidateAllServeLeases fences every currently-running supervisor in this
+// pool by removing its serve.claim under that agent's lock. The next
+// RenewLease or VerifyFence by an old holder returns ErrFenced. Registration
+// rows are deliberately preserved; setup/update use lease invalidation, not
+// row deletion, as the wire-break forcing function.
+func InvalidateAllServeLeases(cfg *Config) (int, error) {
+	if cfg == nil {
+		return 0, fmt.Errorf("InvalidateAllServeLeases: nil config")
+	}
+	stateDir := filepath.Join(cfg.LoopDir, "state")
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("list serve leases in %s: %w", stateDir, err)
+	}
+
+	invalidated := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		id := entry.Name()
+		path := claimPath(cfg, id)
+		if _, err := os.Lstat(path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return invalidated, fmt.Errorf("inspect serve lease %s: %w", path, err)
+		}
+		if err := ValidateAgentID(id); err != nil {
+			return invalidated, fmt.Errorf("serve lease directory %q has invalid agent id: %w", id, err)
+		}
+
+		removed := false
+		err := withAgentLock(cfg, id, func() error {
+			if err := os.Remove(path); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return nil
+				}
+				return fmt.Errorf("remove serve lease %s: %w", path, err)
+			}
+			removed = true
+			return syncDir(filepath.Dir(path))
+		})
+		if err != nil {
+			return invalidated, err
+		}
+		if removed {
+			invalidated++
+		}
+	}
+	return invalidated, nil
+}

--- a/internal/loop/lease_test.go
+++ b/internal/loop/lease_test.go
@@ -204,6 +204,95 @@ func TestVerifyFence(t *testing.T) {
 	}
 }
 
+func TestInvalidateAllServeLeasesFencesAllAndAllowsFreshAcquire(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	alice, err := AcquireServeLease(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bob, err := AcquireServeLease(cfg, "bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cfg.LoopDir, "state", "setup"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := InvalidateAllServeLeases(cfg)
+	if err != nil {
+		t.Fatalf("invalidate leases: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("invalidated = %d, want 2", got)
+	}
+	for _, lease := range []*ServeLease{alice, bob} {
+		if err := RenewLease(lease); err != ErrFenced {
+			t.Fatalf("RenewLease(%s) after invalidation = %v, want ErrFenced", lease.ID, err)
+		}
+		if _, err := os.Stat(claimPath(cfg, lease.ID)); !os.IsNotExist(err) {
+			t.Fatalf("%s claim still exists after invalidation: %v", lease.ID, err)
+		}
+		if _, err := AcquireServeLease(cfg, lease.ID); err != nil {
+			t.Fatalf("fresh acquire(%s) after invalidation: %v", lease.ID, err)
+		}
+	}
+}
+
+func TestInvalidateAllServeLeasesEmptyPool(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	got, err := InvalidateAllServeLeases(cfg)
+	if err != nil {
+		t.Fatalf("invalidate empty pool: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("invalidated = %d, want 0", got)
+	}
+}
+
+func TestInvalidateAllServeLeasesTakesAgentLock(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	if _, err := AcquireServeLease(cfg, "alice"); err != nil {
+		t.Fatal(err)
+	}
+
+	lockHeld := make(chan struct{})
+	releaseLock := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- withAgentLock(cfg, "alice", func() error {
+			close(lockHeld)
+			<-releaseLock
+			return nil
+		})
+	}()
+	<-lockHeld
+
+	invalidationDone := make(chan error, 1)
+	go func() {
+		_, err := InvalidateAllServeLeases(cfg)
+		invalidationDone <- err
+	}()
+	select {
+	case err := <-invalidationDone:
+		t.Fatalf("invalidation completed while agent lock was held: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if _, err := os.Stat(claimPath(cfg, "alice")); err != nil {
+		t.Fatalf("claim changed while agent lock was held: %v", err)
+	}
+
+	close(releaseLock)
+	if err := <-lockDone; err != nil {
+		t.Fatalf("lock holder: %v", err)
+	}
+	if err := <-invalidationDone; err != nil {
+		t.Fatalf("invalidation after lock release: %v", err)
+	}
+	if _, err := os.Stat(claimPath(cfg, "alice")); !os.IsNotExist(err) {
+		t.Fatalf("claim should be removed after lock release: %v", err)
+	}
+}
+
 func TestDistinctIDsNeverCollide(t *testing.T) {
 	cfg := newLeaseTestConfig(t)
 	a, err := AcquireServeLease(cfg, "alice")

--- a/internal/loop/lease_test.go
+++ b/internal/loop/lease_test.go
@@ -3,6 +3,7 @@ package loop
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -246,6 +247,68 @@ func TestInvalidateAllServeLeasesEmptyPool(t *testing.T) {
 	}
 	if got != 0 {
 		t.Fatalf("invalidated = %d, want 0", got)
+	}
+}
+
+func TestInvalidateAllServeLeasesContinuesPastPoisonedStateEntry(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	alice, err := AcquireServeLease(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bob, err := AcquireServeLease(cfg, "bob")
+	if err != nil {
+		t.Fatal(err)
+	}
+	poisonDir := filepath.Join(cfg.LoopDir, "state", "bad id")
+	if err := os.MkdirAll(poisonDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(poisonDir, "serve.claim"), []byte("poison"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := InvalidateAllServeLeases(cfg)
+	if got != 2 {
+		t.Fatalf("invalidated = %d, want 2", got)
+	}
+	if err == nil || !strings.Contains(err.Error(), `"bad id"`) {
+		t.Fatalf("error = %v, want named poisoned id", err)
+	}
+	for _, lease := range []*ServeLease{alice, bob} {
+		if err := RenewLease(lease); err != ErrFenced {
+			t.Fatalf("RenewLease(%s) after partial-error pass = %v, want ErrFenced", lease.ID, err)
+		}
+	}
+}
+
+func TestInvalidateAllServeLeasesPreservesPostSnapshotClaim(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	old, err := AcquireServeLease(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prev := afterInvalidateSnapshotHook
+	afterInvalidateSnapshotHook = func(id string) {
+		if id == "alice" {
+			overwriteClaimToken(t, cfg, id, "NEW-OWNER-TOKEN")
+		}
+	}
+	t.Cleanup(func() { afterInvalidateSnapshotHook = prev })
+
+	got, err := InvalidateAllServeLeases(cfg)
+	if err != nil {
+		t.Fatalf("invalidate leases: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("invalidated = %d, want 0 for post-snapshot owner", got)
+	}
+	if err := RenewLease(old); err != ErrFenced {
+		t.Fatalf("old lease = %v, want ErrFenced", err)
+	}
+	if err := VerifyFence(cfg, "alice", "NEW-OWNER-TOKEN"); err != nil {
+		t.Fatalf("post-snapshot owner was fenced: %v", err)
 	}
 }
 

--- a/tests/upgrade_smoke.sh
+++ b/tests/upgrade_smoke.sh
@@ -1,0 +1,293 @@
+#!/bin/sh
+# Rehearse the old-to-v2.5 wire break: an old updater swaps in the current
+# binary, the new setup invalidates the old supervisor's lease, and an explicit
+# relaunch resumes heartbeats under the new binary.
+
+set -eu
+
+# ---------------------------------------------------------------------------
+# SAFETY: this rehearsal invalidates EVERY serve lease in whatever pool it
+# resolves, which fences every supervisor in that pool. That is the point of
+# the test — and it is catastrophic if the pool is a real one.
+#
+# The isolation below (temp HOME, temp shim dir, temp installed binary, temp
+# --control-repo fixture, local download server) is NOT sufficient on its own:
+# `ac serve` pins AGENTCHUTE_CONTROL_REPO / AGENTCHUTE_LOOP_DIR into every
+# child's environment, and the binary resolves the pool from those env vars.
+# An agent running this script under serve therefore aims the rehearsal at the
+# LIVE bus despite every flag pointing at the fixture. That is exactly what
+# happened on 2026-07-31: the whole fleet was fenced mid-slice, including the
+# agent running the test.
+#
+# Two guards, both mandatory:
+#   1. strip every AGENTCHUTE_* var from this script's own environment, so
+#      nothing inherited can redirect the binary;
+#   2. refuse to run if a live-looking pool is reachable from the environment
+#      we were handed, so a stripped-but-still-dangerous context (e.g. a cwd
+#      inside a control repo) cannot slip through.
+# ---------------------------------------------------------------------------
+
+live_control_repo="${AGENTCHUTE_CONTROL_REPO:-}"
+live_loop_dir="${AGENTCHUTE_LOOP_DIR:-}"
+
+for _var in $(env | sed -n 's/^\(AGENTCHUTE_[A-Za-z0-9_]*\)=.*/\1/p'); do
+	unset "$_var" || true
+done
+
+refuse_live_pool() {
+	candidate=$1
+	label=$2
+	[ -n "$candidate" ] || return 0
+	loop=$candidate
+	[ -d "$loop/agents" ] || loop="$candidate/.agentchute/loop"
+	[ -d "$loop/agents" ] || return 0
+	if ls "$loop"/agents/*.md >/dev/null 2>&1 || ls "$loop"/state/*/serve.claim >/dev/null 2>&1; then
+		printf 'REFUSING TO RUN: %s points at a real agentchute pool (%s).\n' "$label" "$loop" >&2
+		printf 'This rehearsal invalidates every serve lease in the pool it resolves and would fence that fleet.\n' >&2
+		printf 'Run it from a shell with no AGENTCHUTE_* env and no live pool in scope (CI, or a scratch dir).\n' >&2
+		exit 2
+	fi
+}
+
+refuse_live_pool "$live_control_repo" "AGENTCHUTE_CONTROL_REPO"
+refuse_live_pool "$live_loop_dir" "AGENTCHUTE_LOOP_DIR"
+refuse_live_pool "$(pwd)" "the current working directory"
+
+repo=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+refuse_live_pool "$repo" "the repo under test"
+tmp=$(mktemp -d)
+old_pid=
+new_pid=
+server_pid=
+
+cleanup() {
+	if [ -n "$old_pid" ]; then
+		kill -CONT "$old_pid" 2>/dev/null || true
+		kill "$old_pid" 2>/dev/null || true
+		wait "$old_pid" 2>/dev/null || true
+	fi
+	if [ -n "$new_pid" ]; then
+		kill "$new_pid" 2>/dev/null || true
+		wait "$new_pid" 2>/dev/null || true
+	fi
+	if [ -n "$server_pid" ]; then
+		kill "$server_pid" 2>/dev/null || true
+		wait "$server_pid" 2>/dev/null || true
+	fi
+	rm -rf "$tmp"
+}
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+	printf 'FAIL  %s\n' "$*" >&2
+	exit 1
+}
+
+wait_for_file() {
+	path=$1
+	label=$2
+	i=0
+	while [ "$i" -lt 100 ]; do
+		[ -f "$path" ] && return 0
+		i=$((i + 1))
+		sleep 0.1
+	done
+	fail "timed out waiting for $label: $path"
+}
+
+wait_for_exit() {
+	pid=$1
+	label=$2
+	i=0
+	while [ "$i" -lt 100 ]; do
+		if ! kill -0 "$pid" 2>/dev/null; then
+			wait "$pid" 2>/dev/null || true
+			return 0
+		fi
+		i=$((i + 1))
+		sleep 0.1
+	done
+	fail "timed out waiting for $label pid=$pid to exit"
+}
+
+last_seen() {
+	python3 - "$1" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print(json.load(handle)["last_seen"])
+PY
+}
+
+wait_for_heartbeat_change() {
+	path=$1
+	before=$2
+	label=$3
+	i=0
+	while [ "$i" -lt 50 ]; do
+		after=$(last_seen "$path")
+		[ "$after" != "$before" ] && return 0
+		i=$((i + 1))
+		sleep 0.2
+	done
+	fail "$label heartbeat did not advance from $before"
+}
+
+old_source="$tmp/old-source"
+new_build="$tmp/new-build"
+http_root="$tmp/http"
+fixture="$tmp/fixture"
+home="$tmp/home"
+shim_dir="$tmp/shims"
+installed="$tmp/bin/agentchute"
+mkdir -p "$old_source" "$new_build" "$http_root" "$fixture" "$home" "$shim_dir" "$(dirname "$installed")"
+
+base=$(git -C "$repo" merge-base HEAD origin/main)
+git -C "$repo" archive "$base" | tar -x -C "$old_source"
+
+(
+	cd "$repo"
+	go build -ldflags '-X main.version=2.5.0' -o "$new_build/agentchute" .
+)
+
+goos=$(go env GOOS)
+goarch=$(go env GOARCH)
+asset="agentchute_2.5.0_${goos}_${goarch}.tar.gz"
+release_dir="$http_root/releases/download/v2.5.0"
+mkdir -p "$release_dir"
+tar -C "$new_build" -czf "$release_dir/$asset" agentchute
+if command -v sha256sum >/dev/null 2>&1; then
+	checksum=$(sha256sum "$release_dir/$asset" | awk '{print $1}')
+else
+	checksum=$(shasum -a 256 "$release_dir/$asset" | awk '{print $1}')
+fi
+printf '%s  %s\n' "$checksum" "$asset" >"$release_dir/checksums.txt"
+
+port_file="$tmp/http.port"
+python3 - "$http_root" "$port_file" <<'PY' &
+import http.server
+import os
+import sys
+
+os.chdir(sys.argv[1])
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), http.server.SimpleHTTPRequestHandler)
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    handle.write(str(server.server_port))
+server.serve_forever()
+PY
+server_pid=$!
+wait_for_file "$port_file" "local release server port"
+port=$(cat "$port_file")
+
+(
+	cd "$old_source"
+	go build \
+		-ldflags "-X main.version=1.0.0 -X github.com/agentchute/agentchute/internal/cli.updateGitHubBase=http://127.0.0.1:$port" \
+		-o "$installed" .
+)
+
+env \
+	HOME="$home" \
+	XDG_CONFIG_HOME="$home/.config" \
+	SHELL=/bin/sh \
+	PATH="$shim_dir:/usr/bin:/bin" \
+	"$installed" setup \
+		--control-repo "$fixture" \
+		--init \
+		--wake runner \
+		--wrappers none \
+		--shim-dir "$shim_dir" \
+		--no-profile \
+		--yes >"$tmp/setup-old.log" 2>&1
+
+env \
+	HOME="$home" \
+	XDG_CONFIG_HOME="$home/.config" \
+	SHELL=/bin/sh \
+	PATH="$shim_dir:/usr/bin:/bin" \
+	"$installed" serve \
+		--as upgrade-smoke \
+		--vendor openai \
+		--control-repo "$fixture" \
+		--interval 1 \
+		-- /bin/sh -c 'trap "exit 0" TERM INT; while :; do sleep 1; done' \
+		>"$tmp/serve-old.log" 2>&1 &
+old_pid=$!
+
+loop_dir="$fixture/.agentchute/loop"
+claim="$loop_dir/state/upgrade-smoke/serve.claim"
+runner_state="$loop_dir/state/upgrade-smoke/runner.json"
+registration="$loop_dir/agents/upgrade-smoke.md"
+live="$loop_dir/live/upgrade-smoke.live"
+wait_for_file "$claim" "old serve claim"
+wait_for_file "$runner_state" "old runner state"
+wait_for_file "$registration" "old registration"
+wait_for_file "$live" "old live heartbeat"
+old_seen=$(last_seen "$live")
+wait_for_heartbeat_change "$live" "$old_seen" "old supervisor"
+
+# Freeze the old supervisor and mark its diagnostic state foreign-host so the
+# new setup cannot politely stop it. Lease invalidation must be what fences it.
+kill -STOP "$old_pid"
+python3 - "$runner_state" <<'PY'
+import json
+import os
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    state = json.load(handle)
+state["host"] = "upgrade-smoke-foreign-host"
+tmp = path + ".upgrade-smoke"
+with open(tmp, "w", encoding="utf-8") as handle:
+    json.dump(state, handle)
+    handle.write("\n")
+os.replace(tmp, path)
+PY
+
+env \
+	HOME="$home" \
+	XDG_CONFIG_HOME="$home/.config" \
+	SHELL=/bin/sh \
+	PATH="$shim_dir:/usr/bin:/bin" \
+	"$installed" update \
+		--control-repo "$fixture" \
+		--version v2.5.0 >"$tmp/update.log" 2>&1
+
+[ ! -e "$claim" ] || fail "new setup left the old serve claim in place"
+[ -f "$registration" ] || fail "new setup deleted the registration row"
+
+kill -CONT "$old_pid"
+wait_for_exit "$old_pid" "old fenced supervisor"
+old_pid=
+
+stopped_one=$(last_seen "$live")
+sleep 2
+stopped_two=$(last_seen "$live")
+[ "$stopped_one" = "$stopped_two" ] || fail "old last_seen continued after supervisor exit: $stopped_one -> $stopped_two"
+
+env \
+	HOME="$home" \
+	XDG_CONFIG_HOME="$home/.config" \
+	SHELL=/bin/sh \
+	PATH="$shim_dir:/usr/bin:/bin" \
+	"$installed" serve \
+		--as upgrade-smoke \
+		--vendor openai \
+		--control-repo "$fixture" \
+		--interval 1 \
+		-- /bin/sh -c 'trap "exit 0" TERM INT; while :; do sleep 1; done' \
+		>"$tmp/serve-new.log" 2>&1 &
+new_pid=$!
+
+wait_for_file "$claim" "new serve claim"
+new_seen=$(last_seen "$live")
+wait_for_heartbeat_change "$live" "$new_seen" "new supervisor"
+expected_protocol=$(awk '/CurrentProtocolVersion =/ {print $3; exit}' "$repo/internal/loop/registration.go")
+grep -Eq "^v: ${expected_protocol}$" "$registration" ||
+	fail "new registration does not report protocol $expected_protocol"
+
+printf 'PASS  old updater swapped in v2.5 and new setup invalidated the old serve lease\n'
+printf 'PASS  old supervisor exited and last_seen stopped across two samples\n'
+printf 'PASS  explicit new-binary relaunch published protocol %s and resumed heartbeats\n' "$expected_protocol"


### PR DESCRIPTION
## Summary

- add locked, idempotent pool-wide serve-lease invalidation
- invalidate leases immediately after update swaps the binary on normal and `--no-resync` paths
- make setup invalidate leases while preserving registration rows; delete `clearSetupLiveRegistrations`
- emit the exact C15 fenced-supervisor restart notice
- add old-to-v2.5 upgrade smoke coverage and run it only on pushes to `release/v2.5`

## Verification

- `gofmt -w .`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `go build ./...`
- `(cd conformance && go test ./...)`
- `shellcheck -s sh install.sh tests/install_test.sh tests/upgrade_smoke.sh`
- `sh tests/install_test.sh`
- focused revert verification: neutralizing `InvalidateAllServeLeases` made the new loop/setup/update/runner tests fail; restoring it made them pass
- `rg clearSetupLiveRegistrations` finds only the implementation-plan references

## Deviations

- The upgrade rehearsal was not executed locally after the operator explicitly prohibited running it. It is statically shellchecked and is gated to release-branch pushes, not PRs.
- B1 remains outside this branch as required.