### PR TITLE
fix(cli): repair release/v2.5 build break from B1/B2 merge overlap

### DIFF
--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -400,7 +400,7 @@ func TestUpdateInvalidatesLeaseBeforeSetupResync(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := writeSetupPoolState(cfg, "runner", nil); err != nil {
+		if err := writeSetupPoolState(cfg, "runner", nil, ""); err != nil {
 			t.Fatal(err)
 		}
 		lease, err = loop.AcquireServeLease(cfg, "codex-agentchute")


### PR DESCRIPTION
## Summary

`release/v2.5`'s CI has been failing since B2 (#92) merged one minute after B1 (#91): B1 changed `writeSetupPoolState`'s signature to take a 4th `staleAfter string` parameter; B2's branch was cut before that landed, so `TestUpdateInvalidatesLeaseBeforeSetupResync` still calls the old 3-arg form. Both PRs were green against their own base; the combination doesn't compile.

Found while setting up B3's worktree off `release/v2.5` tip (`78fe2a3`) — `go test ./...` failed immediately with a build error, not a test failure.

## Fix

Pass `""` (use the configured/default stale-after) at the one missed call site, matching every other call site in the file (`b1_convergence_test.go:28`, `update_test.go:466`, `:491`).

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- `go test ./...` and `go test -race ./...` green (env stripped of `AGENTCHUTE_*`)

This is a pure test-file fix, zero production code changed. Recommend fast-tracking given it currently blocks everyone building on `release/v2.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)