### PR TITLE
feat(identity): explicit agent id only, delete contextual derivation (v2.5 plan B4)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,11 +39,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} boot --vendor anthropic --context-only"
+            "command": "${AGENTCHUTE_BIN:-agentchute} boot --context-only"
           }
         ]
       }
@@ -53,15 +53,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} pending --vendor anthropic --claude-hook UserPromptSubmit"
+            "command": "${AGENTCHUTE_BIN:-agentchute} pending --claude-hook UserPromptSubmit"
           }
         ]
       }
@@ -71,15 +71,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} ack --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} ack --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} gate --vendor anthropic --before finish --json"
+            "command": "${AGENTCHUTE_BIN:-agentchute} gate --before finish --json"
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,24 +18,18 @@ agentchute setup --wake runner --wrappers all --yes
 
 Start sessions with `ac serve <wrapper>` from a control repo. The dispatcher routes through `agentchute serve`, which registers you, acquires a serve lease (id-uniqueness + fencing token), refreshes `last_seen` and your `.live` presence, polls your OWN inbox, exports your resolved id as `AGENTCHUTE_AGENT_ID` into the wrapper, and injects `[agentchute] check inbox` when mail arrives. The runner publishes no wake target — peers never poke it (pull-only). Hookless wrappers such as Grok still need the dispatcher for startup because they have no lifecycle hook that can run `boot`; `ac serve <wrapper>` enrolls them. Treat the bracketed prefix as machine metadata: the injection is only a CUE — you must actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"` to claim mail (then `ack` to commit); the runner does NOT consume it for you.
 
-**The project is the communication boundary**: agents by default only see and talk to peers in the same discovered project pool. Unrelated projects on one host or tmux server are isolated because each project has its own pool and, when identity is not explicit, the CLI derives project-scoped IDs from the folder name (for example, `codex-agentchute`).
+**The project is the communication boundary**: agents by default only see and talk to peers in the same discovered project pool. Unrelated projects on one host or tmux server are isolated because each project has its own pool.
 
-If a session starts and you do not see agentchute boot/enrolled context, run the wrapper with its vendor so the CLI can derive the contextual identity:
-
-```sh
-agentchute serve --vendor <vendor> -- <wrapper>
-```
-
-As a manual fallback, pin your identity ONCE and then enroll under it before doing any work:
+As a manual fallback, choose and export your identity before enrolling:
 
 ```sh
-export AGENTCHUTE_AGENT_ID="$(agentchute identity --vendor <vendor>)"   # or a named roster id
+export AGENTCHUTE_AGENT_ID="<roster-id>"
 agentchute boot --as "$AGENTCHUTE_AGENT_ID" --vendor <vendor>
 agentchute poller ensure --as "$AGENTCHUTE_AGENT_ID" --vendor <vendor>
 agentchute check --as "$AGENTCHUTE_AGENT_ID"
 ```
 
-If a first `check` says you are not registered, do this fallback immediately instead of stopping. Capture the id with `identity` (or pick a roster id) BEFORE `boot`, because once a live registration reserves the base id a later bare resolve returns a different `-N` suffix.
+If a first `check` says you are not registered, run this fallback immediately instead of stopping.
 
 Known wrappers and their canonical IDs:
 
@@ -46,17 +40,14 @@ Known wrappers and their canonical IDs:
 | Gemini CLI   | `gemini-cli`  | `google`    |
 | grok CLI     | `grok`        | `xai`       |
 
-The IDs above are wrapper bases. With no explicit identity, the reference CLI derives `<base>-<folder>` and reserves live conflicts with `-2`, `-3`, etc. **When several agents of one vendor share a bus** (e.g. `claude-l1`/`claude-l2`/`merger` all on the `claude-code` wrapper), each process must still enroll under its own id. Use contextual defaults for ordinary project/worktree lanes; use `AGENTCHUTE_AGENT_ID=<roster-id>` or `--as <roster-id>` for named lanes.
+`ac serve <wrapper>` uses the wrapper's canonical ID when neither `--as` nor `AGENTCHUTE_AGENT_ID` is set. A second lane with that ID refuses to start; give every additional lane its own explicit ID, for example `ac --as claude-l2 serve claude`.
 
 **Identity precedence** (the reference CLI resolves your `agent_id` in this exact order, first match wins):
 
-1. `--as <id>` flag
+1. `--as <id>` / `--from <id>` flag
 2. `AGENTCHUTE_AGENT_ID` env var
-3. contextual default → `<canonical-base>-<folder-slug>`, suffixed `-2`, `-3`, … past live conflicts
 
-(Pull-only registrations carry no wake target, so there is no longer a herdr/tmux pane to map back to a prior registration — id comes from `--as` / `$AGENTCHUTE_AGENT_ID` or the contextual default.)
-
-**Pin it once.** Resolve your id ONE time at startup and reuse the SAME id on every command. The `ac` dispatcher does this for you (it exports `AGENTCHUTE_AGENT_ID`). Otherwise export it yourself before `boot` (precedence step 2 then shadows the contextual default for the whole session). A bare `--vendor` with no `--as`/env is NOT a stable identity: it re-derives the contextual default (step 3) on every call, so as live lanes come and go the resolved `-N` suffix can change between calls and you silently `check` / `gate` the WRONG inbox. `agentchute identity --vendor <vendor>` prints the currently-resolved id — use it for one-time discovery, not as a per-call identity.
+Without either source, the command fails with an enrollment fix hint. The `ac` dispatcher passes its chosen ID explicitly and exports it to the wrapper; otherwise export the ID yourself before `boot`.
 
 **Verify at session start** (read-only — refreshes nothing, archives nothing; confirms you are enrolled AND present via a fresh `.live`):
 
@@ -69,7 +60,7 @@ agentchute doctor --as <your-id>
 
 **3. Recipient Polling Fallback**
 Senders only deliver to your inbox (pull-only; nobody pokes you). If you are not launched through `agentchute serve`, keep recipient polling alive so your `.live` presence stays fresh:
-- **Runner default**: `agentchute serve --vendor <vendor> -- <wrapper>` polls your own inbox, keeps `.live` fresh, and injects the `check inbox` cue.
+- **Runner default**: `ac serve <wrapper>` polls your own inbox, keeps `.live` fresh, and injects the `check inbox` cue.
 - **Hook-managed fallback**: `agentchute poller ensure --as <id> --vendor <vendor>` starts/verifies heartbeat-only `poller run` and writes `state/<agent_id>/poller.json` + `.live`; it does not launch wrappers or consume mail unless explicitly run with `--launch`.
 - **Native loops**: if your wrapper has a recurring task feature, it may replace `poller run` only if it keeps a fresh heartbeat.
 
@@ -154,7 +145,7 @@ Apply to every response, all contexts:
 
 agentchute dogfoods itself: agents working on agentchute coordinate through agentchute. The loop lives at `.agentchute/loop/`. **The project is the communication boundary**: agents by default only see and talk to peers in the same pool. Enrollment commands are at the top of this file. After enrolling:
 
-- **Each turn:** run `agentchute check --vendor <vendor>` first (claims + displays), or pass `--as <id>` for a custom/non-wrapper lane. If it says you are not registered, immediately run `agentchute boot --vendor <vendor>` plus `agentchute poller ensure --vendor <vendor>`, then rerun `check`. Process any messages, then `agentchute ack` to commit (the Stop hook does this for you).
+- **Each turn:** run `agentchute check --as "$AGENTCHUTE_AGENT_ID"` first (claims + displays). If it says you are not registered, immediately run `agentchute boot --as "$AGENTCHUTE_AGENT_ID" --vendor <vendor>` plus `agentchute poller ensure --as "$AGENTCHUTE_AGENT_ID" --vendor <vendor>`, then rerun `check`. Process any messages, then `agentchute ack` to commit (the Stop hook does this for you).
 - **Sending:** `agentchute send --to <peer> --body ...` from a registered lane, or pass `--from <id>` explicitly (or follow `AGENTCHUTE.md` §6 directly — the binary just makes it ergonomic). Sending only writes the recipient's inbox; it never wakes them.
 - **No watchdog / cooperative waking:** coordination is pull-only. There is no watchdog and no sender-side or cooperative poke — a recipient discovers its own mail via the runner / its native loop, and a dead recipient is detected via stale `.live` + the asker's expired `.owed` (not by a liveness daemon). The `watchdog` command was removed.
 - **Gitignore check:** `git check-ignore .agentchute/loop/agents/<your-id>.md` should print the path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,17 +5,16 @@
 
 Spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
 
-**1. Pin your identity — once.** Base `agent_id=claude-code`, `vendor=anthropic`. Resolve your lane id ONCE at startup and reuse the SAME id on every call:
+**1. Pin your identity.** Default `agent_id=claude-code`, `vendor=anthropic`. Reuse the same explicit id on every call:
 
 - Launched via the `ac` dispatcher (`ac serve <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
 - Otherwise set it yourself, before `boot`:
 
 ```sh
-export AGENTCHUTE_AGENT_ID="<roster-id>"                                 # named lane, or…
-export AGENTCHUTE_AGENT_ID="$(agentchute identity --vendor anthropic)"  # accept the contextual default (run once, before boot)
+export AGENTCHUTE_AGENT_ID="<roster-id>"
 ```
 
-Then pass `--as "$AGENTCHUTE_AGENT_ID"` (or rely on the env) on every command. **Do NOT** drive `check`/`gate`/`send` with a bare `--vendor` and no `--as`/env: with no pinned id the CLI re-derives the contextual default each call and can land on a DIFFERENT `-N` suffix (e.g. `claude-code-<folder>-2`), checking the WRONG inbox and missing your finish-gate. `identity --vendor` is one-time discovery, NOT a per-call identity. Running several agents of this vendor on one bus? Give EACH process its own id — a shared id routes every lane to one inbox and defeats the finish-gate.
+Then pass `--as "$AGENTCHUTE_AGENT_ID"` (or rely on the env) on every command. Commands fail with an enrollment fix hint when neither a flag nor the env provides an id. Running several agents of this vendor on one bus? Give each process its own id; a shared id is refused while another live serve owns it.
 
 **2. Verify at session start** (read-only; confirms you are enrolled AND present via a fresh `.live`):
 

--- a/CODEX.md
+++ b/CODEX.md
@@ -5,17 +5,16 @@
 
 Spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
 
-**1. Pin your identity — once.** Base `agent_id=codex`, `vendor=openai`. Resolve your lane id ONCE at startup and reuse the SAME id on every call:
+**1. Pin your identity.** Default `agent_id=codex`, `vendor=openai`. Reuse the same explicit id on every call:
 
 - Launched via the `ac` dispatcher (`ac serve <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
 - Otherwise set it yourself, before `boot`:
 
 ```sh
-export AGENTCHUTE_AGENT_ID="<roster-id>"                                 # named lane, or…
-export AGENTCHUTE_AGENT_ID="$(agentchute identity --vendor openai)"  # accept the contextual default (run once, before boot)
+export AGENTCHUTE_AGENT_ID="<roster-id>"
 ```
 
-Then pass `--as "$AGENTCHUTE_AGENT_ID"` (or rely on the env) on every command. **Do NOT** drive `check`/`gate`/`send` with a bare `--vendor` and no `--as`/env: with no pinned id the CLI re-derives the contextual default each call and can land on a DIFFERENT `-N` suffix (e.g. `codex-<folder>-2`), checking the WRONG inbox and missing your finish-gate. `identity --vendor` is one-time discovery, NOT a per-call identity. Running several agents of this vendor on one bus? Give EACH process its own id — a shared id routes every lane to one inbox and defeats the finish-gate.
+Then pass `--as "$AGENTCHUTE_AGENT_ID"` (or rely on the env) on every command. Commands fail with an enrollment fix hint when neither a flag nor the env provides an id. Running several agents of this vendor on one bus? Give each process its own id; a shared id is refused while another live serve owns it.
 
 **2. Verify at session start** (read-only; confirms you are enrolled AND present via a fresh `.live`):
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -5,17 +5,16 @@
 
 Spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
 
-**1. Pin your identity — once.** Base `agent_id=gemini-cli`, `vendor=google`. Resolve your lane id ONCE at startup and reuse the SAME id on every call:
+**1. Pin your identity.** Default `agent_id=gemini-cli`, `vendor=google`. Reuse the same explicit id on every call:
 
 - Launched via the `ac` dispatcher (`ac serve <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
 - Otherwise set it yourself, before `boot`:
 
 ```sh
-export AGENTCHUTE_AGENT_ID="<roster-id>"                                 # named lane, or…
-export AGENTCHUTE_AGENT_ID="$(agentchute identity --vendor google)"  # accept the contextual default (run once, before boot)
+export AGENTCHUTE_AGENT_ID="<roster-id>"
 ```
 
-Then pass `--as "$AGENTCHUTE_AGENT_ID"` (or rely on the env) on every command. **Do NOT** drive `check`/`gate`/`send` with a bare `--vendor` and no `--as`/env: with no pinned id the CLI re-derives the contextual default each call and can land on a DIFFERENT `-N` suffix (e.g. `gemini-cli-<folder>-2`), checking the WRONG inbox and missing your finish-gate. `identity --vendor` is one-time discovery, NOT a per-call identity. Running several agents of this vendor on one bus? Give EACH process its own id — a shared id routes every lane to one inbox and defeats the finish-gate.
+Then pass `--as "$AGENTCHUTE_AGENT_ID"` (or rely on the env) on every command. Commands fail with an enrollment fix hint when neither a flag nor the env provides an id. Running several agents of this vendor on one bus? Give each process its own id; a shared id is refused while another live serve owns it.
 
 **2. Verify at session start** (read-only; confirms you are enrolled AND present via a fresh `.live`):
 
@@ -71,7 +70,7 @@ Hand-protocol path (no binary, manual inbox/archive): see [`AGENTCHUTE.md`](AGEN
 
 ## Coordination & Identity
 
-- **Identity Resolution**: Identity resolves in this exact order, first match wins: explicit `--as`, then `AGENTCHUTE_AGENT_ID`, then a contextual `<wrapper>-<folder>` default (suffixed `-2`, `-3`, … past live conflicts in different lanes). Pull-only registrations carry no wake target, so there is no pane to map back to — id comes from `--as` / `$AGENTCHUTE_AGENT_ID` or the contextual default. Use `AGENTCHUTE_AGENT_ID` only for custom stable lane names.
+- **Identity Resolution**: Identity resolves from explicit `--as` first, then `AGENTCHUTE_AGENT_ID`; without either, the command fails with an enrollment fix hint.
 - **4-Way Verification**: High-consequence changes (e.g. protocol fixes, namespace migrations) require a "4-way verify" loop across the primary fleet lanes: `claude-code` (implementation), `codex` (shell/wire safety), `gemini-cli` (UX/Docs), and `grok` (manual/no-hooks flow). Do not merge until all four lanes are green.
 
 > Self-description (interests, working style, etc.) belongs in this agent's

--- a/GROK.md
+++ b/GROK.md
@@ -5,17 +5,16 @@
 
 Spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
 
-**1. Pin your identity — once.** Base `agent_id=grok`, `vendor=xai`. Resolve your lane id ONCE at startup and reuse the SAME id on every call:
+**1. Pin your identity.** Default `agent_id=grok`, `vendor=xai`. Reuse the same explicit id on every call:
 
 - Launched via the `ac` dispatcher (`ac serve <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
 - Otherwise set it yourself, before `boot`:
 
 ```sh
-export AGENTCHUTE_AGENT_ID="<roster-id>"                                 # named lane, or…
-export AGENTCHUTE_AGENT_ID="$(agentchute identity --vendor xai)"  # accept the contextual default (run once, before boot)
+export AGENTCHUTE_AGENT_ID="<roster-id>"
 ```
 
-Then pass `--as "$AGENTCHUTE_AGENT_ID"` (or rely on the env) on every command. **Do NOT** drive `check`/`gate`/`send` with a bare `--vendor` and no `--as`/env: with no pinned id the CLI re-derives the contextual default each call and can land on a DIFFERENT `-N` suffix (e.g. `grok-<folder>-2`), checking the WRONG inbox and missing your finish-gate. `identity --vendor` is one-time discovery, NOT a per-call identity. Running several agents of this vendor on one bus? Give EACH process its own id — a shared id routes every lane to one inbox and defeats the finish-gate.
+Then pass `--as "$AGENTCHUTE_AGENT_ID"` (or rely on the env) on every command. Commands fail with an enrollment fix hint when neither a flag nor the env provides an id. Running several agents of this vendor on one bus? Give each process its own id; a shared id is refused while another live serve owns it.
 
 **2. Verify at session start** (read-only; confirms you are enrolled AND present via a fresh `.live`):
 

--- a/examples/hooks/claude-code/.claude/settings.json
+++ b/examples/hooks/claude-code/.claude/settings.json
@@ -40,11 +40,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} boot --vendor anthropic --context-only"
+            "command": "${AGENTCHUTE_BIN:-agentchute} boot --context-only"
           }
         ]
       }
@@ -54,15 +54,15 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --vendor anthropic --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --quiet"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} pending --vendor anthropic --claude-hook UserPromptSubmit"
+            "command": "${AGENTCHUTE_BIN:-agentchute} pending --claude-hook UserPromptSubmit"
           }
         ]
       }

--- a/examples/hooks/codex/.codex/hooks.json
+++ b/examples/hooks/codex/.codex/hooks.json
@@ -6,12 +6,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --vendor openai --quiet",
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --quiet",
             "statusMessage": "agentchute: poller"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} boot --vendor openai --codex-hook SessionStart",
+            "command": "${AGENTCHUTE_BIN:-agentchute} boot --codex-hook SessionStart",
             "statusMessage": "agentchute: boot"
           }
         ]
@@ -22,17 +22,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --vendor openai --quiet",
+            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --quiet",
             "statusMessage": "agentchute: self-check"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --vendor openai --quiet",
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --quiet",
             "statusMessage": "agentchute: poller"
           },
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} pending --vendor openai --codex-hook UserPromptSubmit",
+            "command": "${AGENTCHUTE_BIN:-agentchute} pending --codex-hook UserPromptSubmit",
             "statusMessage": "agentchute: pending inbox"
           }
         ]

--- a/examples/hooks/gemini/.gemini/settings.json
+++ b/examples/hooks/gemini/.gemini/settings.json
@@ -7,12 +7,12 @@
           {
             "name": "agentchute-poller",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --vendor google --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --quiet"
           },
           {
             "name": "agentchute-boot",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} boot --vendor google --context-only"
+            "command": "${AGENTCHUTE_BIN:-agentchute} boot --context-only"
           }
         ]
       }
@@ -29,12 +29,12 @@
           {
             "name": "agentchute-poller",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --vendor google --quiet"
+            "command": "${AGENTCHUTE_BIN:-agentchute} poller ensure --quiet"
           },
           {
             "name": "agentchute-pending",
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} pending --vendor google --json"
+            "command": "${AGENTCHUTE_BIN:-agentchute} pending --json"
           }
         ]
       }

--- a/internal/cli/ack.go
+++ b/internal/cli/ack.go
@@ -88,7 +88,7 @@ func cmdAck(args []string) error {
 		return err
 	}
 
-	agentID, err = resolveAgentID(agentID, vendor, cfg)
+	agentID, err = resolveAgentID(agentID)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -47,8 +47,9 @@ func cmdBoot(args []string) error {
 	}
 
 	opts := registerOpts{
-		Host: host,
-		Bio:  bio,
+		Host:       host,
+		Bio:        bio,
+		ServeToken: os.Getenv("AGENTCHUTE_SERVE_TOKEN"),
 	}
 	// WI-E3 provenance: boot is a SessionStart-class hook enroll. When it fires
 	// INSIDE the runner (AGENTCHUTE_RUNNER=1 set on the runner's child), the
@@ -79,11 +80,7 @@ func cmdBoot(args []string) error {
 		return err
 	}
 
-	contextualBase, contextual, err := contextualIdentityBase(agentID, vendor)
-	if err != nil {
-		return err
-	}
-	agentID, err = resolveAgentID(agentID, vendor, cfg)
+	agentID, err = resolveAgentID(agentID)
 	if err != nil {
 		return err
 	}
@@ -92,8 +89,6 @@ func cmdBoot(args []string) error {
 	}
 	opts.AgentID = agentID
 	opts.Vendor = resolveAgentVendor(vendor, agentID, cfg)
-	opts.ContextualIdentity = contextual
-	opts.ContextualBaseID = contextualBase
 
 	now := time.Now().UTC()
 	result, err := performRegister(cfg, opts, now)
@@ -119,7 +114,11 @@ func cmdBoot(args []string) error {
 		return fmt.Errorf("list inbox: %w", err)
 	}
 	unread := make([]pendingEntry, 0, len(msgs))
+	inheritedMail := false
 	for _, msg := range msgs {
+		if msg.Timestamp.Before(result.Reg.LastSeen) {
+			inheritedMail = true
+		}
 		entry := pendingEntry{
 			From:      msg.Sender,
 			Filename:  msg.Filename,
@@ -131,6 +130,10 @@ func cmdBoot(args []string) error {
 			}
 		}
 		unread = append(unread, entry)
+	}
+	var notes []string
+	if inheritedMail {
+		notes = append(notes, fmt.Sprintf("inbox contains mail from before this registration — a previous %q may have existed", agentID))
 	}
 
 	// Reply obligations are asker-owned only (v0.9.0): the recipient is never
@@ -146,6 +149,7 @@ func cmdBoot(args []string) error {
 		MalformedCount: len(skipped),
 		Host:           result.ResolvedHost,
 		Warnings:       result.Warnings,
+		Notes:          notes,
 		Blocked:        len(unread) > 0,
 	}
 
@@ -184,6 +188,7 @@ type bootStatus struct {
 	MalformedCount int            `json:"malformed_count,omitempty"`
 	Host           string         `json:"host,omitempty"`
 	Warnings       []string       `json:"warnings,omitempty"`
+	Notes          []string       `json:"notes,omitempty"`
 	Blocked        bool           `json:"blocked"`
 
 	// StaleReg reserved for forward-compat with the boot JSON wire shape's
@@ -221,6 +226,9 @@ func emitBootText(s bootStatus, quiet bool) {
 	}
 	for _, warning := range s.Warnings {
 		fmt.Printf("  warning: %s\n", warning)
+	}
+	for _, note := range s.Notes {
+		fmt.Printf("  note: %s\n", note)
 	}
 }
 
@@ -265,6 +273,9 @@ func writeBootContext(w io.Writer, s bootStatus) {
 	}
 	for _, warning := range s.Warnings {
 		fmt.Fprintf(w, "\nagentchute warning: %s", warning)
+	}
+	for _, note := range s.Notes {
+		fmt.Fprintf(w, "\nagentchute note: %s", note)
 	}
 }
 

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -43,6 +43,8 @@ func setupBootFixture(t *testing.T) string {
 	t.Helper()
 	t.Setenv("AGENTCHUTE_CONTROL_REPO", "")
 	t.Setenv("AGENTCHUTE_LOOP_DIR", "")
+	t.Setenv("AGENTCHUTE_AGENT_ID", "")
+	t.Setenv("AGENTCHUTE_SERVE_TOKEN", "")
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", "")
 	root := t.TempDir()
@@ -193,6 +195,67 @@ func TestBootWithUnreadMailReturnsBlocked(t *testing.T) {
 		if !got.Blocked {
 			t.Error("Blocked = false on unread mail")
 		}
+	})
+}
+
+func TestBootInheritedMailNoteFiresOnlyForPredatingMail(t *testing.T) {
+	const want = `inbox contains mail from before this registration — a previous "claude-code" may have existed`
+
+	t.Run("predating mail", func(t *testing.T) {
+		root := setupBootFixture(t)
+		withCwd(t, root, func() {
+			if _, err := captureStdout(t, func() error { return cmdBoot(bootArgs("--json")) }); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+			if err != nil {
+				t.Fatal(err)
+			}
+			mustWriteAgedInbox(t, cfg.AgentInboxDir("claude-code"), "codex", 1, []byte("---\nfrom: codex\n---\n\nold\n"), time.Hour)
+
+			out, err := captureStdout(t, func() error { return cmdBoot(bootArgs("--json")) })
+			if !errors.Is(err, errBlocked) {
+				t.Fatalf("err = %v, want errBlocked", err)
+			}
+			var got bootStatus
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatal(err)
+			}
+			if len(got.Notes) != 1 || got.Notes[0] != want {
+				t.Fatalf("notes = %q, want [%q]", got.Notes, want)
+			}
+		})
+	})
+
+	t.Run("newer mail", func(t *testing.T) {
+		root := setupBootFixture(t)
+		withCwd(t, root, func() {
+			if _, err := captureStdout(t, func() error { return cmdBoot(bootArgs("--json")) }); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+			if err != nil {
+				t.Fatal(err)
+			}
+			mustWriteSeqInbox(t, cfg.AgentInboxDir("claude-code"), "codex", 1, []byte("---\nfrom: codex\n---\n\nnew\n"))
+			path := filepath.Join(cfg.AgentInboxDir("claude-code"), loop.MsgID{From: "codex", Seq: 1}.Filename())
+			future := time.Now().UTC().Add(time.Hour)
+			if err := os.Chtimes(path, future, future); err != nil {
+				t.Fatal(err)
+			}
+
+			out, err := captureStdout(t, func() error { return cmdBoot(bootArgs("--json")) })
+			if !errors.Is(err, errBlocked) {
+				t.Fatalf("err = %v, want errBlocked", err)
+			}
+			var got bootStatus
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatal(err)
+			}
+			if len(got.Notes) != 0 {
+				t.Fatalf("notes = %q, want none", got.Notes)
+			}
+		})
 	})
 }
 

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -60,7 +60,7 @@ func cmdCheck(args []string) error {
 		return err
 	}
 
-	agentID, err = resolveAgentID(agentID, vendor, cfg)
+	agentID, err = resolveAgentID(agentID)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -73,14 +73,11 @@ func cmdClean(args []string) error {
 
 	if owed {
 		// Destructive command: require EXPLICIT identity (--as or the env
-		// var), never the contextual-guess fallback resolveAgentID otherwise
-		// falls through to (review nit — B4 deletes that fallback fleet-wide
-		// soon, but this command shouldn't guess whose obligations to prune
-		// in the meantime).
+		// var); never guess whose obligations to prune.
 		if strings.TrimSpace(agentID) == "" && strings.TrimSpace(os.Getenv("AGENTCHUTE_AGENT_ID")) == "" {
 			return cleanUsage(fmt.Errorf("--owed requires an explicit identity: pass --as <id> or set AGENTCHUTE_AGENT_ID"))
 		}
-		agentID, err = resolveAgentID(agentID, vendor, cfg)
+		agentID, err = resolveAgentID(agentID)
 		if err != nil {
 			return err
 		}

--- a/internal/cli/clean_test.go
+++ b/internal/cli/clean_test.go
@@ -497,7 +497,7 @@ func TestCleanMailboxApplyTakesTargetLock(t *testing.T) {
 }
 
 // TestCleanOwedRequiresExplicitIdentity is the review's nit: --owed must not
-// fall through to the contextual-guess identity fallback — a destructive
+// fall through to any guessed identity fallback — a destructive
 // command should error rather than guess whose obligations to prune.
 func TestCleanOwedRequiresExplicitIdentity(t *testing.T) {
 	root := setupBootFixture(t)

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -212,6 +212,7 @@ func dispatchExecRun(plan dispatchPlan, shimDir string) error {
 	ctlRepo, g1, _ := extractGlobalFlag(plan.Global, "--control-repo")
 	loopDir, g2, _ := extractGlobalFlag(g1, "--loop-dir")
 	_, forwardGlobal, _ := extractGlobalFlag(g2, "--vendor")
+	forwardGlobal = ensureDispatchIdentity(forwardGlobal, plan.Wrapper.AgentID, os.Getenv("AGENTCHUTE_AGENT_ID"))
 	cfg, err := loop.Discover(loop.DiscoverOpts{
 		ControlRepoFlag: ctlRepo,
 		LoopDirFlag:     loopDir,
@@ -246,6 +247,26 @@ func buildDispatchRunArgs(agentchuteBin, vendor string, forwardGlobal []string, 
 	)
 	runArgs = append(runArgs, wrapperArgs...)
 	return runArgs
+}
+
+func dispatchHasFlag(args []string, name string) bool {
+	for _, arg := range args {
+		if arg == name || strings.HasPrefix(arg, name+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureDispatchIdentity(args []string, defaultID, envID string) []string {
+	if dispatchHasFlag(args, "--as") || strings.TrimSpace(envID) != "" {
+		return args
+	}
+	// `ac serve <wrapper>` is the one intentionally unnamed launch form:
+	// make the wrapper's canonical id explicit on the serve argv. A second
+	// unnamed lane then collides on the serve lease and asks the operator to
+	// choose `ac --as <distinct-id> serve <wrapper>`.
+	return append([]string{"--as", defaultID}, args...)
 }
 
 // extractGlobalFlag removes `name` (in `--name value` or `--name=value` form)

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -242,3 +242,25 @@ func TestBuildDispatchRunArgs_SingleAuthoritativePair(t *testing.T) {
 		}
 	}
 }
+
+func TestEnsureDispatchIdentity(t *testing.T) {
+	t.Run("unnamed uses canonical wrapper id", func(t *testing.T) {
+		got := ensureDispatchIdentity([]string{"--interval", "5"}, "codex", "")
+		want := []string{"--as", "codex", "--interval", "5"}
+		if strings.Join(got, " ") != strings.Join(want, " ") {
+			t.Fatalf("args = %v, want %v", got, want)
+		}
+	})
+	t.Run("explicit flag wins", func(t *testing.T) {
+		got := ensureDispatchIdentity([]string{"--as", "reviewer"}, "codex", "")
+		if strings.Join(got, " ") != "--as reviewer" {
+			t.Fatalf("args = %v, want explicit id unchanged", got)
+		}
+	})
+	t.Run("environment wins", func(t *testing.T) {
+		got := ensureDispatchIdentity([]string{"--interval", "5"}, "codex", "reviewer")
+		if strings.Join(got, " ") != "--interval 5" {
+			t.Fatalf("args = %v, want no injected --as", got)
+		}
+	})
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -609,7 +609,7 @@ func checkLaunchProvenance(cfg *loop.Config, agentID string, opts doctorOptions)
 func acServeHintForAgent(agentID string) string {
 	agentID = strings.TrimSpace(agentID)
 	for _, spec := range wrapperSpecs {
-		// Match contextual ids (codex-agentchute) to their canonical wrapper,
+		// Match explicitly named ids (codex-review) to their canonical wrapper,
 		// not just exact base ids — mirrors shimNamesForAgent.
 		if registrationMatchesCanonical(agentID, spec.AgentID) {
 			return "ac serve " + spec.Key
@@ -622,7 +622,7 @@ func shimNamesForAgent(agentID string) []string {
 	agentID = strings.TrimSpace(agentID)
 	if agentID != "" {
 		for _, spec := range wrapperSpecs {
-			// Match contextual ids (codex-agentchute) to their canonical shim,
+			// Match explicitly named ids (codex-review) to their canonical shim,
 			// not just exact base ids.
 			if registrationMatchesCanonical(agentID, spec.AgentID) {
 				return []string{spec.Name}
@@ -710,8 +710,8 @@ func actingHookDrift(cfg *loop.Config, wrapper string) string {
 }
 
 // hookWrapperForAgent resolves an agent id to its canonical hookable wrapper.
-// Real setups enroll with contextual ids (e.g. codex-agentchute), so match by
-// canonical base — exact or "<base>-" prefix — not exact base id only.
+// Explicit lane names may retain a canonical wrapper prefix (e.g. codex-review),
+// so match by canonical base — exact or "<base>-" prefix — not exact base only.
 // Hookless wrappers (grok) are intentionally absent.
 func hookWrapperForAgent(agentID string) (string, bool) {
 	agentID = strings.TrimSpace(agentID)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -642,9 +642,9 @@ func TestDoctorAcDispatcherResolution(t *testing.T) {
 	}
 }
 
-// hookWrapperForAgent and shimNamesForAgent must resolve contextual ids
-// (codex-agentchute) to their canonical wrapper, not only exact base ids.
-func TestWrapperResolutionHandlesContextualIDs(t *testing.T) {
+// hookWrapperForAgent and shimNamesForAgent must resolve explicitly named
+// wrapper-prefixed ids to their canonical wrapper, not only exact base ids.
+func TestWrapperResolutionHandlesExplicitPrefixedIDs(t *testing.T) {
 	cases := []struct {
 		id          string
 		wantWrapper string
@@ -652,10 +652,10 @@ func TestWrapperResolutionHandlesContextualIDs(t *testing.T) {
 		wantShim    string
 	}{
 		{"codex", "codex", true, "ac-codex"},
-		{"codex-agentchute", "codex", true, "ac-codex"},
-		{"claude-code-agentchute", "claude-code", true, "ac-claude"},
-		{"gemini-cli-agentchute", "gemini-cli", true, "ac-gemini"},
-		{"grok-agentchute", "", false, "ac-grok"}, // hookless, but still shimmed
+		{"codex-review", "codex", true, "ac-codex"},
+		{"claude-code-review", "claude-code", true, "ac-claude"},
+		{"gemini-cli-review", "gemini-cli", true, "ac-gemini"},
+		{"grok-review", "", false, "ac-grok"}, // hookless, but still shimmed
 	}
 	for _, tc := range cases {
 		w, ok := hookWrapperForAgent(tc.id)
@@ -1007,14 +1007,14 @@ func TestDoctorGuardLatchAgeCorruptFileWarns(t *testing.T) {
 	}
 }
 
-func TestAcServeHintForAgent_ContextualIDs(t *testing.T) {
+func TestAcServeHintForAgentExplicitPrefixedIDs(t *testing.T) {
 	cases := map[string]string{
-		"codex":                 "ac serve codex",
-		"codex-agentchute":      "ac serve codex",  // contextual id
-		"gemini-cli-agentchute": "ac serve gemini", // contextual id, aliased wrapper
-		"claude-code":           "ac serve claude",
-		"grok-agentchute":       "ac serve grok",
-		"totally-unknown":       "ac serve <wrapper>",
+		"codex":             "ac serve codex",
+		"codex-review":      "ac serve codex",
+		"gemini-cli-review": "ac serve gemini",
+		"claude-code":       "ac serve claude",
+		"grok-review":       "ac serve grok",
+		"totally-unknown":   "ac serve <wrapper>",
 	}
 	for id, want := range cases {
 		if got := acServeHintForAgent(id); got != want {

--- a/internal/cli/enforced_enrollment_test.go
+++ b/internal/cli/enforced_enrollment_test.go
@@ -73,23 +73,23 @@ func TestStatusAsRefusesMissingSelfRegistration(t *testing.T) {
 		if !strings.Contains(err.Error(), "not registered") {
 			t.Errorf("error missing 'not registered' wording: %v", err)
 		}
-		// status's error also mentions the bare-status escape hatch.
-		if !strings.Contains(err.Error(), "omit --as") {
-			t.Errorf("error missing 'omit --as' escape hatch: %v", err)
+		if !strings.Contains(err.Error(), "agentchute boot --as claude-code") {
+			t.Errorf("error missing boot pointer: %v", err)
 		}
 	})
 }
 
-func TestStatusBareStillWorksWithoutRegistration(t *testing.T) {
-	// Pool-overview status (no --as) is a side-effect-free read; it must
-	// not refuse even when no agent is registered.
+func TestStatusBareRequiresIdentity(t *testing.T) {
 	root := setupBootFixture(t)
 	withCwd(t, root, func() {
 		_, err := captureStdout(t, func() error {
 			return cmdStatus(nil)
 		})
-		if err != nil {
-			t.Errorf("status with no --as should work even with no registrations; got %v", err)
+		if err == nil {
+			t.Fatal("status with no identity returned nil error")
+		}
+		if err.Error() != missingAgentIdentityHint {
+			t.Fatalf("error = %q, want %q", err, missingAgentIdentityHint)
 		}
 	})
 }

--- a/internal/cli/gate.go
+++ b/internal/cli/gate.go
@@ -77,7 +77,7 @@ func cmdGate(args []string) error {
 		return err
 	}
 
-	agentID, err = resolveAgentID(agentID, vendor, cfg)
+	agentID, err = resolveAgentID(agentID)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/hooks_sessionstart_test.go
+++ b/internal/cli/hooks_sessionstart_test.go
@@ -10,8 +10,8 @@ import (
 // At SessionStart, boot already registers/refreshes the agent (it runs
 // performRegister even in --context-only / --codex-hook mode). A redundant
 // self-check in the same SessionStart block doubles the registration write and
-// is the engine of the contextual-identity duplicate race: two writes resolve
-// the same base before either is visible. The fix removes self-check from
+// can race a second write for the same explicit identity. The fix removes
+// self-check from
 // SessionStart (boot owns it there) while keeping it on the per-turn hook,
 // where no boot runs and last_seen/.live presence still need active
 // reconciliation — claude/codex do this via a standalone `self-check` entry
@@ -38,6 +38,9 @@ func TestHookTemplatesSessionStartHasNoRedundantSelfCheck(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: read embedded template: %v", c.wrapper, err)
 			continue
+		}
+		if strings.Contains(string(data), "--vendor") {
+			t.Errorf("%s: hook template still passes --vendor; identity must come from AGENTCHUTE_AGENT_ID", c.wrapper)
 		}
 		cmds := hookCommandsForEvent(t, data, c.sessionStart)
 		if len(cmds) == 0 {

--- a/internal/cli/identity.go
+++ b/internal/cli/identity.go
@@ -3,32 +3,28 @@ package cli
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
 	"strings"
-	"time"
 
 	"github.com/agentchute/agentchute/internal/loop"
 )
 
-func resolveAgentID(flagID, vendor string, cfg *loop.Config) (string, error) {
-	id, err := resolveAgentIDRaw(flagID, vendor, cfg)
+const missingAgentIdentityHint = "missing agent identity: pass --as/--from or set AGENTCHUTE_AGENT_ID (e.g. export AGENTCHUTE_AGENT_ID=claude-code). See AGENTS.md enrollment."
+
+func resolveAgentID(flagID string) (string, error) {
+	id, err := resolveAgentIDRaw(flagID)
 	if err != nil {
 		return "", err
 	}
 	// Structural traversal-safety: every path that produces an agent id flows
 	// through this single validation, so a hostile --as / AGENTCHUTE_AGENT_ID
-	// (e.g. "../../etc/x") can never escape to filesystem resolution. The
-	// contextual-default derivation already yields valid ids; this re-check is
-	// defense in depth and the sole gate for the explicit-input paths.
+	// (e.g. "../../etc/x") can never escape to filesystem resolution.
 	if err := loop.ValidateAgentID(id); err != nil {
 		return "", err
 	}
 	return id, nil
 }
 
-func resolveAgentIDRaw(flagID, vendor string, cfg *loop.Config) (string, error) {
+func resolveAgentIDRaw(flagID string) (string, error) {
 	// 1. Explicit --as flag wins.
 	if strings.TrimSpace(flagID) != "" {
 		return strings.TrimSpace(flagID), nil
@@ -39,68 +35,7 @@ func resolveAgentIDRaw(flagID, vendor string, cfg *loop.Config) (string, error) 
 		return envID, nil
 	}
 
-	// 3. Contextual default: <canonical-wrapper-id>-<folder-slug>.
-	//
-	// Pull-only (Gate 6c): registrations carry no wake target, so there is no
-	// tmux/herdr pane to map back to a prior registration; identity comes from
-	// --as / $AGENTCHUTE_AGENT_ID or the contextual default below.
-	canon := canonicalAgentIDForVendor(vendor)
-	if canon == "" {
-		return "", fmt.Errorf("missing agent identity; pass --as, set AGENTCHUTE_AGENT_ID, or provide a recognized --vendor/--wrapper for a contextual default")
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	baseID := canon + "-" + getFolderSlug(cwd)
-
-	// If we don't have a config yet (e.g. discovery failed elsewhere),
-	// we can't do conflict detection. Just return the base.
-	if cfg == nil {
-		return baseID, nil
-	}
-	id, err := availableContextualAgentID(cfg, baseID, time.Now().UTC())
-	if err != nil {
-		return "", err
-	}
-	return id, nil
-}
-
-func contextualIdentityBase(flagID, vendor string) (string, bool, error) {
-	if strings.TrimSpace(flagID) != "" || strings.TrimSpace(os.Getenv("AGENTCHUTE_AGENT_ID")) != "" {
-		return "", false, nil
-	}
-	canon := canonicalAgentIDForVendor(vendor)
-	if canon == "" {
-		return "", false, nil
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", false, err
-	}
-	return canon + "-" + getFolderSlug(cwd), true, nil
-}
-
-func availableContextualAgentID(cfg *loop.Config, baseID string, now time.Time) (string, error) {
-	regs, _ := loop.ReadRegistrationsLenient(cfg.AgentsDir())
-	reserved := make(map[string]bool)
-	for _, reg := range regs {
-		if registrationReservesIdentity(cfg, reg, now) {
-			reserved[reg.AgentID] = true
-		}
-	}
-
-	candidate := baseID
-	for i := 2; ; i++ {
-		if !reserved[candidate] {
-			return candidate, nil
-		}
-		candidate = fmt.Sprintf("%s-%d", baseID, i)
-		if i > 100 {
-			return "", fmt.Errorf("could not allocate a free agent id for base %q after %d attempts", baseID, 100)
-		}
-	}
+	return "", fmt.Errorf("%s", missingAgentIdentityHint)
 }
 
 func canonicalAgentIDForVendor(vendor string) string {
@@ -144,67 +79,11 @@ func resolveAgentVendor(vendor, agentID string, cfg *loop.Config) string {
 			return strings.TrimSpace(reg.Vendor)
 		}
 	}
-	if preset, ok := vendorPresets[agentID]; ok {
-		return preset.Vendor
-	}
 	return vendorForAgentID(agentID)
-}
-
-func getFolderSlug(cwd string) string {
-	root, err := gitRootForCwd(cwd)
-	if err != nil {
-		root = cwd
-	}
-	slug := slugify(filepath.Base(root))
-	if slug == "" {
-		return "repo"
-	}
-	return slug
-}
-
-func gitRootForCwd(cwd string) (string, error) {
-	cmd := exec.Command("git", "-C", cwd, "rev-parse", "--show-toplevel")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	root := strings.TrimSpace(string(out))
-	if root == "" {
-		return "", fmt.Errorf("git root empty")
-	}
-	return root, nil
-}
-
-var slugifyRE = regexp.MustCompile(`[^a-z0-9]+`)
-
-func slugify(s string) string {
-	s = strings.ToLower(s)
-	s = slugifyRE.ReplaceAllString(s, "-")
-	return strings.Trim(s, "-")
 }
 
 func registrationMatchesCanonical(agentID, canon string) bool {
 	agentID = strings.TrimSpace(agentID)
 	canon = strings.TrimSpace(canon)
 	return agentID == canon || strings.HasPrefix(agentID, canon+"-")
-}
-
-func registrationReservesIdentity(cfg *loop.Config, reg *loop.Registration, now time.Time) bool {
-	if reg == nil || strings.TrimSpace(reg.AgentID) == "" {
-		return false
-	}
-	if reg.RestartAt != nil && reg.RestartAt.After(now) {
-		return true
-	}
-	if reg.Status == loop.StatusOffline || reg.Status == loop.StatusExhausted {
-		return false
-	}
-	if reg.LastSeen.IsZero() {
-		return true
-	}
-	age := now.Sub(reg.LastSeen.UTC())
-	if age < 0 {
-		age = 0
-	}
-	return age < StaleRegThreshold
 }

--- a/internal/cli/identity_cmd.go
+++ b/internal/cli/identity_cmd.go
@@ -4,9 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
-
-	"github.com/agentchute/agentchute/internal/loop"
 )
 
 func cmdIdentity(args []string) error {
@@ -24,26 +21,7 @@ func cmdIdentity(args []string) error {
 		return identityUsage(err)
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-	cfg, err := loop.Discover(loop.DiscoverOpts{
-		ControlRepoFlag: controlRepo,
-		LoopDirFlag:     loopDir,
-		Cwd:             cwd,
-		EnvControlRepo:  os.Getenv("AGENTCHUTE_CONTROL_REPO"),
-		EnvLoopDir:      os.Getenv("AGENTCHUTE_LOOP_DIR"),
-	})
-	// If discovery fails, we still try to resolve the ID without cfg (no conflict check)
-	if err != nil {
-		cfg = nil
-	}
-
-	if vendor == "" {
-		vendor = wrapper
-	}
-	id, err := resolveAgentID(agentID, vendor, cfg)
+	id, err := resolveAgentID(agentID)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/identity_test.go
+++ b/internal/cli/identity_test.go
@@ -1,50 +1,13 @@
 package cli
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-	"time"
-
-	"github.com/agentchute/agentchute/internal/loop"
 )
 
-func TestSlugify(t *testing.T) {
-	cases := []struct {
-		in   string
-		want string
-	}{
-		{"agentchute", "agentchute"},
-		{"AgentChute", "agentchute"},
-		{"agent-chute", "agent-chute"},
-		{"agent_chute", "agent-chute"},
-		{"agent chute", "agent-chute"},
-		{"agent.chute", "agent-chute"},
-		{"-agent-chute-", "agent-chute"},
-		{"!@#agent$%^", "agent"},
-	}
-	for _, c := range cases {
-		got := slugify(c.in)
-		if got != c.want {
-			t.Errorf("slugify(%q) = %q, want %q", c.in, got, c.want)
-		}
-	}
-}
-
-func TestResolveAgentID_RejectsTraversal(t *testing.T) {
-	root := t.TempDir()
-	cwd := filepath.Join(root, "proj")
-	_ = os.MkdirAll(cwd, 0o700)
-	origCwd, _ := os.Getwd()
-	_ = os.Chdir(cwd)
-	defer os.Chdir(origCwd)
+func TestResolveAgentIDRejectsTraversal(t *testing.T) {
 	t.Setenv("AGENTCHUTE_AGENT_ID", "")
-
-	// Hostile explicit --as values must be rejected structurally — never
-	// returned for downstream filesystem resolution.
-	flagAttacks := []string{
+	for _, bad := range []string{
 		"../../etc/x",
 		"../sibling",
 		"a/b",
@@ -52,245 +15,78 @@ func TestResolveAgentID_RejectsTraversal(t *testing.T) {
 		"UPPER",
 		".hidden",
 		"-leading-dash",
-	}
-	for _, bad := range flagAttacks {
-		if got, err := resolveAgentID(bad, "anthropic", nil); err == nil {
+	} {
+		if got, err := resolveAgentID(bad); err == nil {
 			t.Errorf("resolveAgentID(--as=%q) = %q, want error", bad, got)
 		}
 	}
 
-	// A hostile AGENTCHUTE_AGENT_ID must be rejected too.
 	t.Setenv("AGENTCHUTE_AGENT_ID", "../../etc/passwd")
-	if got, err := resolveAgentID("", "anthropic", nil); err == nil {
+	if got, err := resolveAgentID(""); err == nil {
 		t.Errorf("resolveAgentID(env=../../etc/passwd) = %q, want error", got)
-	}
-	t.Setenv("AGENTCHUTE_AGENT_ID", "")
-
-	// The empty-input → contextual-default path must still succeed and yield a
-	// valid id.
-	got, err := resolveAgentID("", "anthropic", nil)
-	if err != nil {
-		t.Fatalf("contextual default errored: %v", err)
-	}
-	if err := loop.ValidateAgentID(got); err != nil {
-		t.Fatalf("contextual default %q is not a valid agent id: %v", got, err)
 	}
 }
 
-func TestResolveAgentID(t *testing.T) {
-	root := t.TempDir()
-	cwd := filepath.Join(root, "my-Project")
-	_ = os.MkdirAll(cwd, 0700)
-
-	// Set CWD for the test
-	origCwd, _ := os.Getwd()
-	_ = os.Chdir(cwd)
-	defer os.Chdir(origCwd)
-
-	t.Run("ExplicitFlagWins", func(t *testing.T) {
-		got, err := resolveAgentID("explicit-id", "anthropic", nil)
+func TestResolveAgentIDExplicitOnly(t *testing.T) {
+	t.Run("flag wins", func(t *testing.T) {
+		t.Setenv("AGENTCHUTE_AGENT_ID", "env-id")
+		got, err := resolveAgentID("explicit-id")
 		if err != nil {
 			t.Fatal(err)
 		}
 		if got != "explicit-id" {
-			t.Errorf("got %q, want 'explicit-id'", got)
+			t.Fatalf("got %q, want explicit-id", got)
 		}
 	})
 
-	t.Run("EnvVarWinsOverDefault", func(t *testing.T) {
+	t.Run("env fallback", func(t *testing.T) {
 		t.Setenv("AGENTCHUTE_AGENT_ID", "env-id")
-		got, err := resolveAgentID("", "anthropic", nil)
+		got, err := resolveAgentID("")
 		if err != nil {
 			t.Fatal(err)
 		}
 		if got != "env-id" {
-			t.Errorf("got %q, want 'env-id'", got)
+			t.Fatalf("got %q, want env-id", got)
 		}
 	})
 
-	t.Run("ContextualDefault", func(t *testing.T) {
+	t.Run("missing has exact fix hint", func(t *testing.T) {
 		t.Setenv("AGENTCHUTE_AGENT_ID", "")
-		got, err := resolveAgentID("", "anthropic", nil)
-		if err != nil {
-			t.Fatal(err)
+		_, err := resolveAgentID("")
+		if err == nil {
+			t.Fatal("missing identity returned nil error")
 		}
-		// "my-Project" -> "my-project", "anthropic" -> "claude-code"
-		if got != "claude-code-my-project" {
-			t.Errorf("got %q, want 'claude-code-my-project'", got)
-		}
-	})
-
-	t.Run("ConflictDetectionSuffixes", func(t *testing.T) {
-		t.Setenv("AGENTCHUTE_AGENT_ID", "")
-		t.Setenv("TMUX_PANE", "%99")
-
-		cfg := &loop.Config{
-			LoopDir: filepath.Join(root, ".agentchute", "loop"),
-		}
-		agentsDir := cfg.AgentsDir()
-		_ = os.MkdirAll(agentsDir, 0700)
-
-		// Create an active registration for the base ID
-		reg := &loop.Registration{
-			AgentID:  "claude-code-my-project",
-			Vendor:   "anthropic",
-			LastSeen: time.Now().UTC(),
-			Status:   loop.StatusActive,
-		}
-		hostname, _ := os.Hostname()
-		reg.Host = hostname
-		reg.ControlRepo = root
-		_ = loop.WriteRegistration(filepath.Join(agentsDir, reg.AgentID+".md"), reg)
-
-		got, err := resolveAgentID("", "anthropic", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got != "claude-code-my-project-2" {
-			t.Errorf("got %q, want 'claude-code-my-project-2' (collision with active ID)", got)
-		}
-	})
-
-	t.Run("CollidingActiveIDSuffixes", func(t *testing.T) {
-		// Pull-only (Gate 6c): there is no tmux/herdr pane-adoption. A fresh active
-		// registration for the base id always reserves it, so the contextual
-		// default suffixes to -2 rather than reusing the colliding id.
-		t.Setenv("AGENTCHUTE_AGENT_ID", "")
-		t.Setenv("TMUX_PANE", "%1")
-
-		cfg := &loop.Config{
-			LoopDir: filepath.Join(root, ".agentchute", "loop"),
-		}
-		agentsDir := cfg.AgentsDir()
-		_ = os.MkdirAll(agentsDir, 0700)
-
-		reg := &loop.Registration{
-			AgentID:  "claude-code-my-project",
-			Vendor:   "anthropic",
-			LastSeen: time.Now().UTC(),
-			Status:   loop.StatusActive,
-		}
-		hostname, _ := os.Hostname()
-		reg.Host = hostname
-		reg.ControlRepo = root
-		_ = loop.WriteRegistration(filepath.Join(agentsDir, reg.AgentID+".md"), reg)
-
-		got, err := resolveAgentID("", "anthropic", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got != "claude-code-my-project-2" {
-			t.Errorf("got %q, want 'claude-code-my-project-2' (no pane reuse under pull-only)", got)
-		}
-	})
-
-	t.Run("ReuseStaleID", func(t *testing.T) {
-		t.Setenv("AGENTCHUTE_AGENT_ID", "")
-		t.Setenv("TMUX_PANE", "%99")
-
-		cfg := &loop.Config{
-			LoopDir: filepath.Join(root, ".agentchute", "loop"),
-		}
-		agentsDir := cfg.AgentsDir()
-		_ = os.MkdirAll(agentsDir, 0700)
-
-		// Create a STALE registration for the base ID (older than StaleRegThreshold
-		// so it does not reserve the id; pull-only reserves any FRESH active reg).
-		reg := &loop.Registration{
-			AgentID:  "claude-code-my-project",
-			Vendor:   "anthropic",
-			LastSeen: time.Now().UTC().Add(-2 * time.Hour), // genuinely stale
-			Status:   loop.StatusActive,
-		}
-		hostname, _ := os.Hostname()
-		reg.Host = hostname
-		reg.ControlRepo = root
-		_ = loop.WriteRegistration(filepath.Join(agentsDir, reg.AgentID+".md"), reg)
-
-		got, err := resolveAgentID("", "anthropic", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got != "claude-code-my-project" {
-			t.Errorf("got %q, want 'claude-code-my-project' (reused stale ID)", got)
-		}
-	})
-
-	t.Run("FreshActiveRegistrationReservesContextualID", func(t *testing.T) {
-		// Pull-only (Gate 6c): with no wake state there is no "pokable vs
-		// poller-only" distinction — any fresh, active registration reserves its
-		// id, so a colliding contextual default suffixes to -2.
-		t.Setenv("AGENTCHUTE_AGENT_ID", "")
-		t.Setenv("TMUX_PANE", "")
-
-		cfg := &loop.Config{
-			LoopDir: filepath.Join(root, ".agentchute", "loop"),
-		}
-		agentsDir := cfg.AgentsDir()
-		_ = os.MkdirAll(agentsDir, 0700)
-
-		reg := &loop.Registration{
-			AgentID:     "claude-code-my-project",
-			Vendor:      "anthropic",
-			ControlRepo: root,
-			Host:        "test-host",
-			LastSeen:    time.Now().UTC(),
-			Status:      loop.StatusActive,
-		}
-		_ = loop.WriteRegistration(filepath.Join(agentsDir, reg.AgentID+".md"), reg)
-		mustWriteFreshPollerHeartbeat(t, cfg, reg.AgentID)
-
-		got, err := resolveAgentID("", "anthropic", cfg)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got != "claude-code-my-project-2" {
-			t.Errorf("got %q, want 'claude-code-my-project-2' (fresh active reg reserves its id)", got)
+		if err.Error() != missingAgentIdentityHint {
+			t.Fatalf("error = %q, want %q", err, missingAgentIdentityHint)
 		}
 	})
 }
 
-// TestAvailableContextualAgentID_ErrorsPastCap: per WI-8, past cap must error
-// rather than return a colliding id (e.g. base-101 when 100 taken).
-func TestAvailableContextualAgentID_ErrorsPastCap(t *testing.T) {
-	root := t.TempDir()
-	cfg := &loop.Config{
-		LoopDir: filepath.Join(root, ".agentchute", "loop"),
-	}
-	agentsDir := cfg.AgentsDir()
-	_ = os.MkdirAll(agentsDir, 0700)
-
-	base := "claude-code-testcap"
-	now := time.Now().UTC()
-	hostname, _ := os.Hostname()
-
-	// Pre-create registrations for base and base-2 through base-101.
-	// All must reserve identity so loop exhausts candidates.
-	for i := 0; i <= 101; i++ {
-		id := base
-		if i >= 2 {
-			id = fmt.Sprintf("%s-%d", base, i)
-		} else if i == 1 {
-			// skip 1, cap logic uses -2+
-			continue
+func TestCommandsWithoutIdentityFailWithHint(t *testing.T) {
+	root := setupBootFixture(t)
+	t.Setenv("AGENTCHUTE_AGENT_ID", "")
+	t.Setenv("AGENTCHUTE_SERVE_TOKEN", "")
+	withCwd(t, root, func() {
+		cases := []struct {
+			name string
+			run  func() error
+		}{
+			{"boot", func() error { return cmdBoot([]string{"--vendor", "anthropic"}) }},
+			{"serve", func() error { return cmdServe([]string{"--vendor", "openai", "--", filepath.Join(root, "codex")}) }},
+			{"check", func() error { return cmdCheck(nil) }},
+			{"send", func() error { return cmdSend([]string{"--to", "recipient", "--body", "body"}) }},
+			{"status", func() error { return cmdStatus(nil) }},
 		}
-		reg := &loop.Registration{
-			AgentID:     id,
-			Vendor:      "anthropic",
-			LastSeen:    now,
-			Status:      loop.StatusActive,
-			Host:        hostname,
-			ControlRepo: root,
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				err := tc.run()
+				if err == nil {
+					t.Fatal("command returned nil error")
+				}
+				if err.Error() != missingAgentIdentityHint {
+					t.Fatalf("error = %q, want %q", err, missingAgentIdentityHint)
+				}
+			})
 		}
-		_ = loop.WriteRegistration(filepath.Join(agentsDir, id+".md"), reg)
-	}
-
-	// Must error, not return e.g. base-102 or any suffixed colliding id.
-	_, err := availableContextualAgentID(cfg, base, now)
-	if err == nil {
-		t.Fatalf("availableContextualAgentID past cap returned no error (would have collided)")
-	}
-	if !strings.Contains(err.Error(), "could not allocate a free agent id") {
-		t.Errorf("error = %v, want message about allocation failure", err)
-	}
+	})
 }

--- a/internal/cli/pending.go
+++ b/internal/cli/pending.go
@@ -60,7 +60,7 @@ func cmdPending(args []string) error {
 		return err
 	}
 
-	agentID, err = resolveAgentID(agentID, vendor, cfg)
+	agentID, err = resolveAgentID(agentID)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/poller.go
+++ b/internal/cli/poller.go
@@ -82,7 +82,7 @@ func resolvePollerCommon(p *pollerCommon) (*loop.Config, error) {
 		return nil, err
 	}
 
-	p.AgentID, err = resolveAgentID(p.AgentID, p.Vendor, cfg)
+	p.AgentID, err = resolveAgentID(p.AgentID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/provenance.go
+++ b/internal/cli/provenance.go
@@ -20,8 +20,8 @@ func hookLaunchProvenance(event string) (launchedBy, hookEvent string) {
 }
 
 // wrapperCandidatesForAgent returns the real wrapper-binary names for the given
-// agent id (matched by canonical base, so contextual ids like
-// gemini-cli-agentchute resolve), used by the launch-bypass shadowing probe.
+// agent id (matched by canonical base, so explicitly named ids like
+// gemini-cli-review resolve), used by the launch-bypass shadowing probe.
 // With no/unknown agent id it returns every known candidate.
 func wrapperCandidatesForAgent(agentID string) []string {
 	if agentID != "" {

--- a/internal/cli/provenance_test.go
+++ b/internal/cli/provenance_test.go
@@ -85,7 +85,7 @@ func TestRunnerSetsRunnerProvenance(t *testing.T) {
 		t.Fatal(err)
 	}
 	opts := runnerOptions{AgentID: "claude-code", Vendor: "anthropic", ShimName: "ac-claude"}
-	if err := registerRunner(cfg, opts, time.Now().UTC()); err != nil {
+	if err := registerRunner(cfg, opts, "", time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
 	reg, err := loop.ReadRegistration(cfg.AgentRegistrationPath(opts.AgentID))

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -76,9 +76,9 @@ type registerResult struct {
 // Pull-only (simple-again Gate 6c): a registration carries no wake state, so
 // there is no wake autodetect, no tmux pane lock, and no same-pane/stale-peer
 // dedup. The retained behavior is: write the registration record + the initial
-// `.live` presence (Gate 3). A fresh row plus a fresh serve lease owned by
-// another process refuses the registration; stale same-id state is merged as
-// crash recovery.
+// `.live` presence (Gate 3). A fresh serve lease owned by another process
+// refuses the registration regardless of row age or presence; stale same-id
+// state is merged as crash recovery.
 func performRegister(cfg *loop.Config, opts registerOpts, now time.Time) (*registerResult, error) {
 	if err := loop.ValidateAgentID(opts.AgentID); err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func publishRegistrationOnce(cfg *loop.Config, opts registerOpts, host string, n
 		} else if !os.IsNotExist(rerr) {
 			return fmt.Errorf("read existing registration: %w", rerr)
 		}
-		if existingFound && registrationLiveElsewhere(cfg, existing, opts.ServeToken, now) {
+		if registrationLiveElsewhere(cfg, opts.AgentID, opts.ServeToken, now) {
 			return fmt.Errorf("agent id %q is live elsewhere; pick a distinct name (--as %s-2?)", opts.AgentID, opts.AgentID)
 		}
 
@@ -234,11 +234,8 @@ func publishRegistrationOnce(cfg *loop.Config, opts registerOpts, host string, n
 	}, nil
 }
 
-func registrationLiveElsewhere(cfg *loop.Config, reg *loop.Registration, serveToken string, now time.Time) bool {
-	if reg == nil {
-		return false
-	}
-	claim, err := loop.ReadServeClaim(cfg, reg.AgentID)
+func registrationLiveElsewhere(cfg *loop.Config, agentID, serveToken string, now time.Time) bool {
+	claim, err := loop.ReadServeClaim(cfg, agentID)
 	if err != nil || loop.ClaimIsStale(claim, now) {
 		return false
 	}

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -37,11 +37,10 @@ type registerOpts struct {
 	Host            string
 	Bio             string
 	WorkingRepos    []string
+	ServeToken      string
 
-	ContextualIdentity bool
-	ContextualBaseID   string
-	HostProvided       bool
-	BioProvided        bool
+	HostProvided bool
+	BioProvided  bool
 
 	// WI-E3 launch provenance (advisory). When non-empty these are written into
 	// the registration so verify views are truthful and the launch-bypass warning
@@ -77,7 +76,9 @@ type registerResult struct {
 // Pull-only (simple-again Gate 6c): a registration carries no wake state, so
 // there is no wake autodetect, no tmux pane lock, and no same-pane/stale-peer
 // dedup. The retained behavior is: write the registration record + the initial
-// `.live` presence (Gate 3) + the -N contextual-id-collision suffix retry.
+// `.live` presence (Gate 3). A fresh row plus a fresh serve lease owned by
+// another process refuses the registration; stale same-id state is merged as
+// crash recovery.
 func performRegister(cfg *loop.Config, opts registerOpts, now time.Time) (*registerResult, error) {
 	if err := loop.ValidateAgentID(opts.AgentID); err != nil {
 		return nil, err
@@ -96,35 +97,21 @@ func performRegister(cfg *loop.Config, opts registerOpts, now time.Time) (*regis
 	}
 
 	result, err := publishRegistrationOnce(cfg, opts, host, now)
-	if err == nil {
-		return result, nil
+	if os.IsExist(err) {
+		// WriteRegistrationExclusive closed a creation race with a writer that
+		// did not take our agent lock. Re-read once through the normal merge
+		// path; its live-owner check decides whether this caller may adopt the
+		// now-existing row.
+		return publishRegistrationOnce(cfg, opts, host, now)
 	}
-	for attempts := 0; opts.ContextualIdentity && os.IsExist(err) && attempts < 100; attempts++ {
-		// A concurrent startup command (e.g. boot + self-check fired from the
-		// same SessionStart hook) may have just created the contextual id we were
-		// about to claim exclusively. Both processes resolved the same contextual
-		// base before either write was visible. Under pull-only there is no live
-		// pane to map back to a registration, so the colliding id is always a
-		// distinct lane: suffix to the next free `<base>-N` and retry.
-		nextID, nextErr := nextContextualAgentIDByFilesystem(cfg, opts.ContextualBaseID, opts.AgentID)
-		if nextErr != nil {
-			return nil, nextErr
-		}
-		opts.AgentID = nextID
-		result, err = publishRegistrationOnce(cfg, opts, host, now)
-		if err == nil {
-			return result, nil
-		}
-	}
-	return nil, err
+	return result, err
 }
 
 // publishRegistrationOnce writes one registration under the per-agent lock and
 // publishes the initial `.live` presence. The write is: re-read the existing
 // registration (for the field merge), build the no-wake record, ensure the inbox
-// dir, then write — exclusively (create-if-not-exists) on the fresh-contextual
-// path so a concurrent same-id create surfaces as os.ErrExist for the caller's
-// suffix retry, otherwise a plain atomic write.
+// dir, then write — exclusively (create-if-not-exists) on a fresh row so a
+// concurrent same-id create is re-read before this process may merge it.
 func publishRegistrationOnce(cfg *loop.Config, opts registerOpts, host string, now time.Time) (*registerResult, error) {
 	regPath := cfg.AgentRegistrationPath(opts.AgentID)
 	inboxDir := cfg.AgentInboxDir(opts.AgentID)
@@ -143,6 +130,9 @@ func publishRegistrationOnce(cfg *loop.Config, opts registerOpts, host string, n
 			existingFound = true
 		} else if !os.IsNotExist(rerr) {
 			return fmt.Errorf("read existing registration: %w", rerr)
+		}
+		if existingFound && registrationLiveElsewhere(cfg, existing, opts.ServeToken, now) {
+			return fmt.Errorf("agent id %q is live elsewhere; pick a distinct name (--as %s-2?)", opts.AgentID, opts.AgentID)
 		}
 
 		reg = &loop.Registration{
@@ -200,11 +190,10 @@ func publishRegistrationOnce(cfg *loop.Config, opts registerOpts, host string, n
 			return fmt.Errorf("create inbox dir: %w", err)
 		}
 
-		if !existingFound && opts.ContextualIdentity {
-			// Atomic create-if-not-exists for the fresh-contextual collision path.
-			// EEXIST propagates (via os.IsExist) so performRegister's retry loop
-			// can suffix. The exclusive link guards against a different process
-			// that never took our lock.
+		if !existingFound {
+			// Atomic create-if-not-exists. EEXIST propagates so performRegister
+			// can re-read the winner and apply the same live-owner refusal before
+			// deciding whether a same-id merge is safe.
 			if werr := loop.WriteRegistrationExclusive(regPath, reg); werr != nil {
 				if os.IsExist(werr) {
 					return werr
@@ -217,9 +206,8 @@ func publishRegistrationOnce(cfg *loop.Config, opts registerOpts, host string, n
 		return nil
 	})
 	if err != nil {
-		// err is returned verbatim so the contextual-collision retry loop in
-		// performRegister can detect the exclusive-create race via os.IsExist
-		// (WriteRegistrationExclusive returns the raw os.ErrExist).
+		// Preserve raw os.ErrExist so performRegister can re-read an
+		// exclusive-create race exactly once.
 		return nil, err
 	}
 
@@ -246,26 +234,22 @@ func publishRegistrationOnce(cfg *loop.Config, opts registerOpts, host string, n
 	}, nil
 }
 
-func nextContextualAgentIDByFilesystem(cfg *loop.Config, baseID, current string) (string, error) {
-	if strings.TrimSpace(baseID) == "" {
-		baseID = current
+func registrationLiveElsewhere(cfg *loop.Config, reg *loop.Registration, serveToken string, now time.Time) bool {
+	if reg == nil {
+		return false
 	}
-	for i := 2; ; i++ {
-		candidate := fmt.Sprintf("%s-%d", baseID, i)
-		if candidate == current {
-			continue
-		}
-		// Enforce the cap BEFORE checking whether the candidate is free —
-		// otherwise a free past-cap candidate (e.g. base-101 absent while
-		// base-2..base-100 are taken) would be handed out, defeating the cap
-		// (codex WI-8 review). Mirrors availableContextualAgentID's ordering.
-		if i > 100 {
-			return "", fmt.Errorf("could not allocate a free agent id for base %q after %d attempts", baseID, 100)
-		}
-		if _, err := os.Stat(cfg.AgentRegistrationPath(candidate)); os.IsNotExist(err) {
-			return candidate, nil
-		}
+	age := now.Sub(reg.LastSeen.UTC())
+	if age < 0 {
+		age = 0
 	}
+	if age > loop.StaleAfter(cfg) {
+		return false
+	}
+	claim, err := loop.ReadServeClaim(cfg, reg.AgentID)
+	if err != nil || loop.ClaimIsStale(claim, now) {
+		return false
+	}
+	return strings.TrimSpace(serveToken) == "" || claim.ServeToken != strings.TrimSpace(serveToken)
 }
 
 func cmdRegister(args []string) error {
@@ -295,6 +279,7 @@ func cmdRegister(args []string) error {
 		Host:         host,
 		Bio:          bio,
 		WorkingRepos: workingRepos,
+		ServeToken:   os.Getenv("AGENTCHUTE_SERVE_TOKEN"),
 		// A hand-run `agentchute register` is the manual/raw enroll path.
 		LaunchedBy: loop.LaunchedByManual,
 	}
@@ -326,18 +311,12 @@ func cmdRegister(args []string) error {
 		return err
 	}
 
-	contextualBase, contextual, err := contextualIdentityBase(agentID, vendor)
-	if err != nil {
-		return err
-	}
-	agentID, err = resolveAgentID(agentID, vendor, cfg)
+	agentID, err = resolveAgentID(agentID)
 	if err != nil {
 		return err
 	}
 	opts.AgentID = agentID
 	opts.Vendor = resolveAgentVendor(vendor, agentID, cfg)
-	opts.ContextualIdentity = contextual
-	opts.ContextualBaseID = contextualBase
 
 	now := time.Now().UTC()
 	result, err := performRegister(cfg, opts, now)

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -238,13 +238,6 @@ func registrationLiveElsewhere(cfg *loop.Config, reg *loop.Registration, serveTo
 	if reg == nil {
 		return false
 	}
-	age := now.Sub(reg.LastSeen.UTC())
-	if age < 0 {
-		age = 0
-	}
-	if age > loop.StaleAfter(cfg) {
-		return false
-	}
 	claim, err := loop.ReadServeClaim(cfg, reg.AgentID)
 	if err != nil || loop.ClaimIsStale(claim, now) {
 		return false

--- a/internal/cli/register_test.go
+++ b/internal/cli/register_test.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,7 +15,7 @@ import (
 // tmux-pane-dedup / same-pane-prune / pane-lock / defer-to-existing register
 // tests were removed with the apparatus they exercised. A registration carries
 // no wake state; register's retained behavior is: write the record + the initial
-// `.live` presence + the -N contextual-id-collision suffix retry.
+// `.live` presence + explicit-id duplicate-owner refusal.
 
 func TestRegister_RMWUnderAgentLock(t *testing.T) {
 	root := t.TempDir()
@@ -56,7 +55,7 @@ func TestRegister_RMWUnderAgentLock(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				opts := registerOpts{AgentID: agentID, Vendor: "anthropic"}
+				opts := registerOpts{AgentID: agentID, Vendor: "anthropic", ServeToken: lease.Token}
 				if _, err := performRegister(cfg, opts, now.Add(time.Duration(i)*time.Second)); err != nil {
 					errs <- err
 				}
@@ -339,110 +338,74 @@ func TestRegisterBioFlagSetsAndOverwritesBody(t *testing.T) {
 	})
 }
 
-// Pull-only: a contextual register (no --as) whose base id is already held by a
-// fresh, active registration suffixes to the next free `<base>-N` and still
-// publishes its own initial `.live`. This is the retained -N collision behavior.
-func TestRegister_ContextualCollisionSuffixesAndWritesLive(t *testing.T) {
+func TestRegisterRefusesLiveDuplicateID(t *testing.T) {
 	root := t.TempDir()
 	withCwd(t, root, func() {
 		mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
 		mustMkdir(t, filepath.Join(root, ".agentchute", "loop"))
-		t.Setenv("AGENTCHUTE_AGENT_ID", "")
 		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
 		if err != nil {
 			t.Fatal(err)
 		}
-		base := "claude-code-" + getFolderSlug(root)
+		const agentID = "claude-code"
+		now := time.Now().UTC()
+		if _, err := performRegister(cfg, registerOpts{AgentID: agentID, Vendor: "anthropic"}, now); err != nil {
+			t.Fatalf("seed registration: %v", err)
+		}
+		lease, err := loop.AcquireServeLease(cfg, agentID)
+		if err != nil {
+			t.Fatalf("acquire serve lease: %v", err)
+		}
+		defer loop.ReleaseLease(lease)
 
-		// First contextual register claims the base id.
-		if err := cmdRegister([]string{"--vendor", "anthropic"}); err != nil {
-			t.Fatalf("first contextual register: %v", err)
+		_, err = performRegister(cfg, registerOpts{AgentID: agentID, Vendor: "anthropic"}, now.Add(time.Second))
+		if err == nil {
+			t.Fatal("live duplicate registration returned nil error")
 		}
-		if _, err := loop.ReadRegistration(cfg.AgentRegistrationPath(base)); err != nil {
-			t.Fatalf("base registration not written: %v", err)
+		want := `agent id "claude-code" is live elsewhere; pick a distinct name (--as claude-code-2?)`
+		if err.Error() != want {
+			t.Fatalf("error = %q, want %q", err, want)
 		}
 
-		// Second contextual register collides with the fresh base id and suffixes.
-		if err := cmdRegister([]string{"--vendor", "anthropic"}); err != nil {
-			t.Fatalf("second contextual register: %v", err)
-		}
-		suffixed := base + "-2"
-		if _, err := loop.ReadRegistration(cfg.AgentRegistrationPath(suffixed)); err != nil {
-			t.Fatalf("collision did not suffix to %q: %v", suffixed, err)
-		}
-		// The suffixed lane gets its own initial `.live`.
-		liveSeen, ok := loop.LiveLastSeen(cfg, suffixed)
-		if !ok || liveSeen.IsZero() {
-			t.Fatalf("suffixed lane %q missing initial .live (ok=%v seen=%v)", suffixed, ok, liveSeen)
+		if _, err := os.Stat(cfg.AgentRegistrationPath(agentID + "-2")); !os.IsNotExist(err) {
+			t.Fatalf("duplicate registration created suffixed id: stat err = %v", err)
 		}
 	})
 }
 
-// WI-8: nextContextualAgentIDByFilesystem and callers must error (not collide) past cap.
-func TestNextContextualAgentIDByFilesystem_ErrorsPastCap(t *testing.T) {
+func TestRegisterMergesOverStaleSameID(t *testing.T) {
 	root := t.TempDir()
 	withCwd(t, root, func() {
 		mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
 		mustMkdir(t, filepath.Join(root, ".agentchute", "loop"))
-
 		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
 		if err != nil {
 			t.Fatal(err)
 		}
-		base := "claude-code-" + getFolderSlug(root)
-
-		agentsDir := cfg.AgentsDir()
-		_ = os.MkdirAll(agentsDir, 0700)
-
-		for i := 2; i <= 101; i++ {
-			id := fmt.Sprintf("%s-%d", base, i)
-			path := cfg.AgentRegistrationPath(id)
-			_ = os.MkdirAll(filepath.Dir(path), 0700)
-			_ = os.WriteFile(path, []byte("{}"), 0644)
+		const agentID = "claude-code"
+		now := time.Now().UTC()
+		stale := now.Add(-2 * loop.DefaultStaleAfter)
+		if _, err := performRegister(cfg, registerOpts{AgentID: agentID, Vendor: "anthropic", Bio: "old", BioProvided: true}, stale); err != nil {
+			t.Fatalf("seed stale registration: %v", err)
 		}
-
-		_, err = nextContextualAgentIDByFilesystem(cfg, base, base)
-		if err == nil {
-			t.Fatal("next... past cap returned no error")
-		}
-		if !strings.Contains(err.Error(), "could not allocate a free agent id") {
-			t.Errorf("err=%v, want cap error", err)
-		}
-	})
-}
-
-// Regression (codex WI-8 review): the cap must error even when the past-cap
-// candidate is FREE. Occupy base-2..base-100 but leave base-101 ABSENT; the
-// allocator must NOT hand out base-101 — it must return the cap error.
-func TestNextContextualAgentIDByFilesystem_ErrorsPastCapWhenCandidateFree(t *testing.T) {
-	root := t.TempDir()
-	withCwd(t, root, func() {
-		mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
-		mustMkdir(t, filepath.Join(root, ".agentchute", "loop"))
-
-		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+		lease, err := loop.AcquireServeLease(cfg, agentID)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("acquire fresh lease: %v", err)
 		}
-		base := "claude-code-" + getFolderSlug(root)
+		defer loop.ReleaseLease(lease)
 
-		agentsDir := cfg.AgentsDir()
-		_ = os.MkdirAll(agentsDir, 0700)
-
-		// base-2..base-100 occupied; base-101 deliberately left FREE.
-		for i := 2; i <= 100; i++ {
-			id := fmt.Sprintf("%s-%d", base, i)
-			path := cfg.AgentRegistrationPath(id)
-			_ = os.MkdirAll(filepath.Dir(path), 0700)
-			_ = os.WriteFile(path, []byte("{}"), 0644)
+		result, err := performRegister(cfg, registerOpts{AgentID: agentID, Vendor: "anthropic"}, now)
+		if err != nil {
+			t.Fatalf("merge stale same id: %v", err)
 		}
-
-		got, err := nextContextualAgentIDByFilesystem(cfg, base, base)
-		if err == nil {
-			t.Fatalf("past cap with free base-101 returned id %q, want cap error", got)
+		if !result.ExistingFound {
+			t.Fatal("stale same-id merge did not report existing row")
 		}
-		if !strings.Contains(err.Error(), "could not allocate a free agent id") {
-			t.Errorf("err=%v, want cap error", err)
+		if !result.Reg.LastSeen.Equal(now) {
+			t.Fatalf("last_seen = %s, want %s", result.Reg.LastSeen, now)
+		}
+		if !strings.Contains(result.Reg.Body, "old") {
+			t.Fatalf("stale merge lost existing body: %q", result.Reg.Body)
 		}
 	})
 }

--- a/internal/cli/register_test.go
+++ b/internal/cli/register_test.go
@@ -405,6 +405,69 @@ func TestRegisterRefusesFreshForeignLeaseWithStaleRow(t *testing.T) {
 	})
 }
 
+func TestRegisterRefusesFreshForeignLeaseWithoutRow(t *testing.T) {
+	root := t.TempDir()
+	withCwd(t, root, func() {
+		mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
+		mustMkdir(t, filepath.Join(root, ".agentchute", "loop"))
+		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		const agentID = "claude-code"
+		lease, err := loop.AcquireServeLease(cfg, agentID)
+		if err != nil {
+			t.Fatalf("acquire fresh foreign lease: %v", err)
+		}
+		defer loop.ReleaseLease(lease)
+
+		_, err = performRegister(cfg, registerOpts{AgentID: agentID, Vendor: "anthropic"}, time.Now().UTC())
+		if err == nil {
+			t.Fatal("registration with no row and fresh foreign lease returned nil error")
+		}
+		want := `agent id "claude-code" is live elsewhere; pick a distinct name (--as claude-code-2?)`
+		if err.Error() != want {
+			t.Fatalf("error = %q, want %q", err, want)
+		}
+		if _, err := os.Stat(cfg.AgentRegistrationPath(agentID)); !os.IsNotExist(err) {
+			t.Fatalf("foreign lease registration created a row: stat err = %v", err)
+		}
+	})
+}
+
+func TestRegisterCreatesMissingRowWithMatchingLeaseToken(t *testing.T) {
+	root := t.TempDir()
+	withCwd(t, root, func() {
+		mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
+		mustMkdir(t, filepath.Join(root, ".agentchute", "loop"))
+		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		const agentID = "claude-code"
+		lease, err := loop.AcquireServeLease(cfg, agentID)
+		if err != nil {
+			t.Fatalf("acquire own lease: %v", err)
+		}
+		defer loop.ReleaseLease(lease)
+
+		result, err := performRegister(cfg, registerOpts{
+			AgentID:    agentID,
+			Vendor:     "anthropic",
+			ServeToken: lease.Token,
+		}, time.Now().UTC())
+		if err != nil {
+			t.Fatalf("register under own lease: %v", err)
+		}
+		if result.ExistingFound {
+			t.Fatal("missing-row registration reported an existing row")
+		}
+		if result.Reg.AgentID != agentID {
+			t.Fatalf("agent id = %q, want %q", result.Reg.AgentID, agentID)
+		}
+	})
+}
+
 func TestRegisterMergesOverStaleSameID(t *testing.T) {
 	root := t.TempDir()
 	withCwd(t, root, func() {

--- a/internal/cli/register_test.go
+++ b/internal/cli/register_test.go
@@ -373,6 +373,38 @@ func TestRegisterRefusesLiveDuplicateID(t *testing.T) {
 	})
 }
 
+func TestRegisterRefusesFreshForeignLeaseWithStaleRow(t *testing.T) {
+	root := t.TempDir()
+	withCwd(t, root, func() {
+		mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
+		mustMkdir(t, filepath.Join(root, ".agentchute", "loop"))
+		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		const agentID = "claude-code"
+		now := time.Now().UTC()
+		stale := now.Add(-2 * loop.DefaultStaleAfter)
+		if _, err := performRegister(cfg, registerOpts{AgentID: agentID, Vendor: "anthropic"}, stale); err != nil {
+			t.Fatalf("seed stale registration: %v", err)
+		}
+		lease, err := loop.AcquireServeLease(cfg, agentID)
+		if err != nil {
+			t.Fatalf("acquire fresh foreign lease: %v", err)
+		}
+		defer loop.ReleaseLease(lease)
+
+		_, err = performRegister(cfg, registerOpts{AgentID: agentID, Vendor: "anthropic"}, now)
+		if err == nil {
+			t.Fatal("registration with stale row and fresh foreign lease returned nil error")
+		}
+		want := `agent id "claude-code" is live elsewhere; pick a distinct name (--as claude-code-2?)`
+		if err.Error() != want {
+			t.Fatalf("error = %q, want %q", err, want)
+		}
+	})
+}
+
 func TestRegisterMergesOverStaleSameID(t *testing.T) {
 	root := t.TempDir()
 	withCwd(t, root, func() {
@@ -388,11 +420,6 @@ func TestRegisterMergesOverStaleSameID(t *testing.T) {
 		if _, err := performRegister(cfg, registerOpts{AgentID: agentID, Vendor: "anthropic", Bio: "old", BioProvided: true}, stale); err != nil {
 			t.Fatalf("seed stale registration: %v", err)
 		}
-		lease, err := loop.AcquireServeLease(cfg, agentID)
-		if err != nil {
-			t.Fatalf("acquire fresh lease: %v", err)
-		}
-		defer loop.ReleaseLease(lease)
 
 		result, err := performRegister(cfg, registerOpts{AgentID: agentID, Vendor: "anthropic"}, now)
 		if err != nil {

--- a/internal/cli/self_check.go
+++ b/internal/cli/self_check.go
@@ -39,8 +39,9 @@ func cmdSelfCheck(args []string) error {
 	}
 
 	opts := registerOpts{
-		Host: host,
-		Bio:  bio,
+		Host:       host,
+		Bio:        bio,
+		ServeToken: os.Getenv("AGENTCHUTE_SERVE_TOKEN"),
 	}
 	// WI-E3 provenance: self-check is a lifecycle hook enroll. Under the runner
 	// (AGENTCHUTE_RUNNER=1) it records `runner` so the runner lane is not demoted.
@@ -103,8 +104,8 @@ func cmdSelfCheck(args []string) error {
 // between the two entry points.
 //
 // opts must already carry the caller's Host/Bio/LaunchedBy/HookEvent; this
-// fills in AgentID/Vendor/ContextualIdentity/ContextualBaseID on it (hence the
-// pointer — callers that need the resolved opts.Vendor afterward, like
+// fills in AgentID/Vendor on it (hence the pointer — callers that need the
+// resolved opts.Vendor afterward, like
 // cmdSelfCheck's status report, see it without a second resolve) and returns
 // the resolved agent id alongside performRegister's result.
 //
@@ -118,11 +119,7 @@ func cmdSelfCheck(args []string) error {
 // determined at all) returns "" — that is the one case nothing downstream can
 // proceed on.
 func selfRepairRegistration(cfg *loop.Config, opts *registerOpts, agentIDFlag, vendorFlag, source string, now time.Time) (string, *registerResult, error) {
-	contextualBase, contextual, err := contextualIdentityBase(agentIDFlag, vendorFlag)
-	if err != nil {
-		return "", nil, err
-	}
-	agentID, err := resolveAgentID(agentIDFlag, vendorFlag, cfg)
+	agentID, err := resolveAgentID(agentIDFlag)
 	if err != nil {
 		return "", nil, err
 	}
@@ -131,8 +128,6 @@ func selfRepairRegistration(cfg *loop.Config, opts *registerOpts, agentIDFlag, v
 	}
 	opts.AgentID = agentID
 	opts.Vendor = resolveAgentVendor(vendorFlag, agentID, cfg)
-	opts.ContextualIdentity = contextual
-	opts.ContextualBaseID = contextualBase
 
 	result, err := performRegister(cfg, *opts, now)
 	if err != nil {

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -98,9 +98,9 @@ func cmdSend(args []string) error {
 	if err != nil {
 		return err
 	}
-	fromID, err = resolveAgentID(fromID, "", cfg)
+	fromID, err = resolveAgentID(fromID)
 	if err != nil {
-		return fmt.Errorf("missing --from; pass --from explicitly or set AGENTCHUTE_AGENT_ID")
+		return err
 	}
 	if err := loop.ValidateAgentID(fromID); err != nil {
 		return fmt.Errorf("--from: %w", err)

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -64,8 +64,6 @@ type runnerOptions struct {
 	IdleGrace       time.Duration
 	BusyGrace       time.Duration
 	WrapperArgs     []string
-	ContextualID    bool
-	ContextualBase  string
 	ShimName        string // ac-* launcher shim that started this lane (provenance).
 	Guarded         bool   // wrapper's hooks can clear the guard latch (v2.5 A7/C22); serve exports AGENTCHUTE_GUARD=1 only when true.
 }
@@ -137,11 +135,7 @@ func cmdServe(args []string) error {
 	if err != nil {
 		return err
 	}
-	contextualBase, contextual, err := contextualIdentityBase(opts.AgentID, opts.Vendor)
-	if err != nil {
-		return err
-	}
-	opts.AgentID, err = resolveAgentID(opts.AgentID, opts.Vendor, cfg)
+	opts.AgentID, err = resolveAgentID(opts.AgentID)
 	if err != nil {
 		return err
 	}
@@ -155,8 +149,6 @@ func cmdServe(args []string) error {
 	if err := loop.ValidateAgentID(opts.Vendor); err != nil {
 		return fmt.Errorf("--vendor: %w", err)
 	}
-	opts.ContextualID = contextual
-	opts.ContextualBase = contextualBase
 	return runWrapper(cfg, opts, cwd)
 }
 
@@ -388,7 +380,7 @@ func runWrapper(cfg *loop.Config, opts runnerOptions, cwd string) error {
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 
-	if err := registerRunner(cfg, opts, time.Now().UTC()); err != nil {
+	if err := registerRunner(cfg, opts, lease.Token, time.Now().UTC()); err != nil {
 		_ = ptmx.Close()
 		_ = cmd.Process.Kill()
 		<-done
@@ -502,18 +494,17 @@ func runnerChildEnv(cfg *loop.Config, opts runnerOptions, serveToken string) []s
 	return env
 }
 
-func registerRunner(cfg *loop.Config, opts runnerOptions, now time.Time) error {
+func registerRunner(cfg *loop.Config, opts runnerOptions, serveToken string, now time.Time) error {
 	// Pull-only (Gate 6c): the runner publishes no wake target — it owns the wake
 	// path via the PTY supervisor, not a registration field. The registration is
 	// a plain no-wake record.
 	_, err := performRegister(cfg, registerOpts{
-		AgentID:            opts.AgentID,
-		Vendor:             opts.Vendor,
-		WorkingRepos:       []string{cfg.ControlRepo},
-		Host:               localHostname(),
-		HostProvided:       true,
-		ContextualIdentity: opts.ContextualID,
-		ContextualBaseID:   opts.ContextualBase,
+		AgentID:      opts.AgentID,
+		Vendor:       opts.Vendor,
+		WorkingRepos: []string{cfg.ControlRepo},
+		Host:         localHostname(),
+		HostProvided: true,
+		ServeToken:   serveToken,
 		// WI-E3 provenance: the runner owns this lane. ShimName is threaded from
 		// the launcher shim (cmdShimsExec passes --shim-name) when present.
 		LaunchedBy: loop.LaunchedByRunner,

--- a/internal/cli/setup_reset.go
+++ b/internal/cli/setup_reset.go
@@ -56,16 +56,13 @@ func resetSetupRuntimeState(root string, cfg *loop.Config, wrappers []string) se
 	return result
 }
 
-func setupResetAgentIDs(root string, cfg *loop.Config, wrappers []string) ([]string, []string) {
+func setupResetAgentIDs(root string, cfg *loop.Config, _ []string) ([]string, []string) {
 	ids := map[string]bool{}
 	var warnings []string
 	for _, id := range setupRegistrationAgentIDs(cfg) {
 		ids[id] = true
 	}
 	for _, id := range setupStateAgentIDs(cfg) {
-		ids[id] = true
-	}
-	for _, id := range setupExpectedContextualAgentIDs(root, wrappers) {
 		ids[id] = true
 	}
 	for _, id := range setupHerdrAgentIDsForRepo(root) {
@@ -115,27 +112,6 @@ func setupStateAgentIDs(cfg *loop.Config) []string {
 		id := entry.Name()
 		if err := loop.ValidateAgentID(id); err == nil {
 			ids = append(ids, id)
-		}
-	}
-	return ids
-}
-
-func setupExpectedContextualAgentIDs(root string, wrappers []string) []string {
-	if len(wrappers) == 0 {
-		wrappers = setupWrapperNames()
-	}
-	slug := getFolderSlug(root)
-	ids := make([]string, 0, len(wrappers))
-	seen := map[string]bool{}
-	for _, wrapper := range wrappers {
-		canon := canonicalAgentIDForVendor(wrapper)
-		if canon == "" {
-			continue
-		}
-		id := canon + "-" + slug
-		if !seen[id] {
-			ids = append(ids, id)
-			seen[id] = true
 		}
 	}
 	return ids
@@ -246,10 +222,10 @@ func stopSetupRunner(cfg *loop.Config, agentID string) (bool, string) {
 	cmdline := setupProcessCommandLine(st.RunnerPID)
 	// Runner attribution = the runner.json pid->id binding (loaded above) +
 	// setupProcessAlive (checked above) + this being an `agentchute serve` for THIS
-	// pool. A runner is launched WITHOUT --as (contextual id), so its cmdline never
-	// carries the agent id; requiring it here was a false-negative that left every
-	// live runner un-stopped. The state file binds pid->id; the cmdline only proves
-	// the pool. Simple-again Gate 6b (pull-only): the runner owns no receive socket,
+	// pool. A runner may receive its explicit id through AGENTCHUTE_AGENT_ID rather
+	// than --as, so its cmdline need not carry the agent id. The state file binds
+	// pid->id; the cmdline only proves the pool. Simple-again Gate 6b (pull-only):
+	// the runner owns no receive socket,
 	// so SIGTERM is the stop — its signal handler marks the registration offline and
 	// releases its serve lease on exit.
 	if !setupCommandMatchesRunnerPool(cmdline, cfg) {

--- a/internal/cli/setup_reset.go
+++ b/internal/cli/setup_reset.go
@@ -257,10 +257,10 @@ func setupCommandMatches(cmdline, agentID, subcommand string, cfg *loop.Config) 
 
 // setupCommandMatchesRunnerPool attributes a live RUNNER to THIS pool. Unlike a
 // poller (which is launched with --as <id> and so carries its agent id in the
-// cmdline), a runner is launched with the CONTEXTUAL id — it has NO --as — so its
-// cmdline never contains the agent id. The pid->id binding therefore comes from
-// the runner.json state file (state/<id>/runner.json recorded this pid for <id>),
-// and the cmdline only needs to prove the process is an `agentchute serve` for THIS
+// cmdline), a runner may receive its explicit id through AGENTCHUTE_AGENT_ID, so
+// its cmdline need not contain the agent id. The pid->id binding therefore comes
+// from the runner.json state file (state/<id>/runner.json recorded this pid for
+// <id>), and the cmdline only needs to prove the process is an `agentchute serve` for THIS
 // pool (its --control-repo/--loop-dir resolves to this pool). Requiring the agent
 // id in a runner cmdline is the false-negative this fixes: every live runner was
 // reported "ambiguous ... cmdline did not match this pool; refusing (fail closed)".

--- a/internal/cli/setup_wipe.go
+++ b/internal/cli/setup_wipe.go
@@ -562,8 +562,8 @@ func scanWipeLiveSignals(cfg *loop.Config, agentIDs []string) []string {
 				cmdline := setupProcessCommandLine(st.RunnerPID)
 				// Runner attribution: runner.json binds this pid to <id>, the pid is
 				// alive, and the cmdline is an `agentchute serve` for THIS pool. A runner
-				// has NO --as (contextual id), so we must NOT require the agent id in the
-				// cmdline — doing so reported every live runner as ambiguous. The poller
+				// may receive its explicit id through AGENTCHUTE_AGENT_ID, so we must NOT
+				// require the agent id in the cmdline. The poller
 				// case below keeps the agent-id check (pollers DO carry --as).
 				if setupCommandMatchesRunnerPool(cmdline, cfg) {
 					reasons = append(reasons, fmt.Sprintf("live runner for %s (pid=%d) is still running; stop it before wiping", id, st.RunnerPID))

--- a/internal/cli/setup_wipe_test.go
+++ b/internal/cli/setup_wipe_test.go
@@ -277,7 +277,7 @@ func TestScanWipeLiveSignalsRefusesLiveRunner(t *testing.T) {
 	oldAlive := setupProcessAlive
 	oldCmd := setupProcessCommandLine
 	setupProcessAlive = func(pid int) bool { return pid == 4242 }
-	// Realistic runner cmdline: NO --as (runners use the contextual id), so the
+	// Realistic runner cmdline: NO --as (the id may come from env), so the
 	// pool proof is the exact --control-repo/--loop-dir value match.
 	setupProcessCommandLine = func(pid int) string {
 		return "/usr/local/bin/agentchute serve --vendor openai --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir + " --shim-name ac -- /usr/bin/codex"
@@ -368,7 +368,7 @@ func TestSetupCommandMatchesRunnerPool(t *testing.T) {
 		LoopDir:     filepath.Join(root, ".agentchute", "loop"),
 	}
 
-	// A runner is launched WITHOUT --as (contextual id), but DOES carry the pool
+	// A runner may be launched WITHOUT --as (explicit id from env), but DOES carry the pool
 	// path. It must match — this is the false-negative the fix repairs.
 	runnerNoAs := "/usr/local/bin/agentchute serve --control-repo " + root + " --loop-dir " + cfg.LoopDir
 	if !setupCommandMatchesRunnerPool(runnerNoAs, cfg) {
@@ -419,7 +419,7 @@ func TestScanWipeLiveSignalsRunnerWithoutAsIsLiveNotAmbiguous(t *testing.T) {
 	oldCmd := setupProcessCommandLine
 	setupProcessAlive = func(pid int) bool { return pid == 4711 }
 	setupProcessCommandLine = func(pid int) string {
-		// NO --as: runners launch with the contextual id.
+		// NO --as: the runner receives its explicit id through env.
 		return "/usr/local/bin/agentchute serve --control-repo " + cfg.ControlRepo + " --loop-dir " + cfg.LoopDir
 	}
 	t.Cleanup(func() { setupProcessAlive = oldAlive; setupProcessCommandLine = oldCmd })

--- a/internal/cli/shims.go
+++ b/internal/cli/shims.go
@@ -303,8 +303,9 @@ func cmdShimsExec(args []string) error {
 		"--control-repo", cfg.ControlRepo,
 		"--loop-dir", cfg.LoopDir,
 		"--shim-name", spec.Name,
-		"--",
 	}
+	runArgs = append(runArgs, ensureDispatchIdentity(nil, spec.AgentID, os.Getenv("AGENTCHUTE_AGENT_ID"))...)
+	runArgs = append(runArgs, "--")
 	runArgs = append(runArgs, wrapperArgs...)
 	return execReplace(agentchuteBin, runArgs, os.Environ())
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -31,17 +31,10 @@ func cmdStatus(args []string) error {
 		return statusUsage(fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")))
 	}
 
-	// --as / $AGENTCHUTE_AGENT_ID is now optional. When omitted, status
-	// behaves as a pool-overview operator command: it prints the registry
-	// without claiming an agent identity and without ticking anyone's
-	// last_seen. The acting-agent mode (caller IS one of the pool agents,
-	// wants their last_seen refreshed as a side effect) is preserved when
-	// --as / env is set. v0.1.2 UX nit per codex review.
-	agentID = strings.TrimSpace(firstNonEmpty(agentID, os.Getenv("AGENTCHUTE_AGENT_ID")))
-	if agentID != "" {
-		if err := loop.ValidateAgentID(agentID); err != nil {
-			return err
-		}
+	var err error
+	agentID, err = resolveAgentID(agentID)
+	if err != nil {
+		return err
 	}
 
 	cwd, err := os.Getwd()
@@ -60,22 +53,16 @@ func cmdStatus(args []string) error {
 	}
 
 	now := time.Now().UTC()
-	if agentID != "" {
-		// v0.2.1 "Enforced Enrollment" (AGENTCHUTE.md §5.3): status --as
-		// acts AS the agent (refreshes its last_seen). Refuse for an
-		// unregistered id. Pool-overview status (no --as) stays
-		// unaffected and remains a side-effect-free read.
-		// B1: CLI touches no longer refresh liveness — only serve's
-		// lease-gated heartbeat does (HeartbeatRegistration). This preflight
-		// only confirms the agent is enrolled at all.
-		selfPath := cfg.AgentRegistrationPath(agentID)
-		if _, err := os.Stat(selfPath); err == nil {
-			// registered; proceed.
-		} else if os.IsNotExist(err) {
-			return fmt.Errorf("agent %q is not registered. Run `agentchute boot --as %s --vendor <vendor>` first, or omit --as to view the pool overview (AGENTCHUTE.md §5.3)", agentID, agentID)
-		} else {
-			return fmt.Errorf("stat own registration: %w", err)
-		}
+	// v0.2.1 "Enforced Enrollment" (AGENTCHUTE.md §5.3): status acts AS
+	// the explicitly identified agent. B1: this preflight confirms enrollment
+	// but does not refresh liveness.
+	selfPath := cfg.AgentRegistrationPath(agentID)
+	if _, err := os.Stat(selfPath); err == nil {
+		// registered; proceed.
+	} else if os.IsNotExist(err) {
+		return fmt.Errorf("agent %q is not registered. Run `agentchute boot --as %s --vendor <vendor>` first (AGENTCHUTE.md §5.3)", agentID, agentID)
+	} else {
+		return fmt.Errorf("stat own registration: %w", err)
 	}
 
 	regs, err := readRegistrations(cfg)
@@ -107,7 +94,7 @@ func printUnenrolledSection(w io.Writer, cfg *loop.Config) {
 }
 
 func statusUsage(err error) error {
-	return fmt.Errorf("%w\nusage: agentchute status [--as <agent-id>] [--control-repo <path>] [--loop-dir <path>]\n\n  --as is optional. With it set, the caller's last_seen is refreshed as a side effect\n  (the historical \"acting-agent\" mode). Without it, status prints a pool overview only.", err)
+	return fmt.Errorf("%w\nusage: agentchute status --as <agent-id> [--control-repo <path>] [--loop-dir <path>]", err)
 }
 
 func readRegistrations(cfg *loop.Config) (map[string]*loop.Registration, error) {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -240,68 +240,22 @@ func TestStatus_PresentButNotEnrolledSectionQuietWhenClean(t *testing.T) {
 	}
 }
 
-// v0.1.2 UX nit: status without --as / $AGENTCHUTE_AGENT_ID prints the
-// pool overview without claiming an agent identity and without touching
-// anyone's last_seen. Codex review aligned: diagnostic command, not a
-// lifecycle event.
-func TestCmdStatusWithoutAgentIDPrintsPoolWithoutSideEffects(t *testing.T) {
+func TestCmdStatusWithoutAgentIDFailsWithHint(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
 	mustMkdir(t, filepath.Join(root, ".agentchute", "loop"))
-
-	withCwd(t, root, func() {
-		t.Setenv("TMUX_PANE", "%1")
-		if err := cmdRegister([]string{"--as", "codex", "--vendor", "openai"}); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Backdate codex's last_seen so we can detect a side-effecting update.
-	regPath := cfg.AgentRegistrationPath("codex")
-	reg, err := loop.ReadRegistration(regPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Registration stores last_seen at second precision; use a wall-second
-	// timestamp so the post-write read compares equal.
-	backdated := time.Now().UTC().Add(-1 * time.Hour).Truncate(time.Second)
-	reg.LastSeen = backdated
-	if err := loop.WriteRegistration(regPath, reg); err != nil {
-		t.Fatal(err)
-	}
-
-	// Make sure no env var is set; otherwise --as would be implicit.
-	// Use t.Setenv with empty value so test cleanup restores any prior
-	// shell state (codex review on 37d87e1).
 	t.Setenv("AGENTCHUTE_AGENT_ID", "")
-
 	withCwd(t, root, func() {
-		out, err := captureStdout(t, func() error { return cmdStatus(nil) })
-		if err != nil {
-			t.Fatalf("cmdStatus with no --as returned err: %v", err)
+		_, err := captureStdout(t, func() error { return cmdStatus(nil) })
+		if err == nil {
+			t.Fatal("cmdStatus with no identity returned nil error")
 		}
-		if !strings.Contains(out, "codex") {
-			t.Errorf("pool overview missing codex agent: %q", out)
+		if err.Error() != missingAgentIdentityHint {
+			t.Fatalf("error = %q, want %q", err, missingAgentIdentityHint)
 		}
 	})
-
-	// last_seen must not have been touched by the no-flag invocation.
-	after, err := loop.ReadRegistration(regPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !after.LastSeen.Equal(backdated) {
-		t.Errorf("status without --as updated last_seen: %v -> %v", backdated, after.LastSeen)
-	}
 }
 
-// With --as set, status still ticks the caller's last_seen (preserves the
-// historical acting-agent mode).
 // B1: CLI touches no longer refresh liveness — only serve's lease-gated
 // HeartbeatRegistration does. `status --as` still requires the agent to be
 // enrolled (the registration-exists preflight stays), but no longer bumps

--- a/internal/cli/traversal_test.go
+++ b/internal/cli/traversal_test.go
@@ -61,14 +61,6 @@ func TestCommandsRejectPathTraversalAgentIDs(t *testing.T) {
 			})
 		})
 		t.Run("status/"+id, func(t *testing.T) {
-			// Empty --as is legitimate for status (pool-overview mode);
-			// v0.1.2 explicitly made --as optional and treats "" the
-			// same as "flag omitted". Path-traversal security is
-			// preserved: every non-empty bad id is rejected by
-			// ValidateAgentID before any filesystem access.
-			if id == "" {
-				t.Skip("empty --as is pool-overview mode for status (by design)")
-			}
 			withCwd(t, root, func() {
 				args := []string{"--as", id}
 				if err := cmdStatus(args); err == nil {
@@ -125,6 +117,8 @@ func withCwd(t *testing.T, dir string, fn func()) {
 	t.Setenv("AGENTCHUTE_CONTROL_REPO", "")
 	t.Setenv("AGENTCHUTE_LOOP_DIR", "")
 	t.Setenv("AGENTCHUTE_AGENT_ID", "")
+	t.Setenv("AGENTCHUTE_SERVE_TOKEN", "")
+	t.Setenv("AGENTCHUTE_GUARD", "")
 	t.Setenv("AGENTCHUTE_RUNNER", "")
 	t.Setenv("AGENTCHUTE_RUNNER_PID", "")
 	t.Setenv("HERDR_ENV", "")

--- a/internal/cli/turn_end.go
+++ b/internal/cli/turn_end.go
@@ -80,7 +80,7 @@ func cmdTurnEnd(args []string) error {
 		return turnEndUsage(fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")))
 	}
 
-	opts := registerOpts{Host: host, Bio: bio}
+	opts := registerOpts{Host: host, Bio: bio, ServeToken: os.Getenv("AGENTCHUTE_SERVE_TOKEN")}
 	// WI-E3 provenance: turn-end is a lifecycle hook enroll, same as
 	// self-check. Under the runner (AGENTCHUTE_RUNNER=1) it records `runner`
 	// so the runner lane is not demoted.

--- a/internal/loop/registration.go
+++ b/internal/loop/registration.go
@@ -165,16 +165,16 @@ func WriteRegistration(path string, r *Registration) error {
 }
 
 // WriteRegistrationExclusive writes a fresh registration and fails with
-// os.ErrExist if the path already exists. Used by contextual identity startup
-// so two simultaneous agents do not silently claim the same first ID.
+// os.ErrExist if the path already exists. Registration startup uses it so a
+// concurrent creator is re-read before a same-id merge is allowed.
 //
 // The destination is published atomically: content is written to a temp file
 // first, then hard-linked into place. os.Link fails with EEXIST (recognized by
 // os.IsExist) when the target already exists, preserving exclusive semantics —
 // but unlike an O_EXCL create followed by a separate write, the visible file is
-// never observed empty. That matters under the SessionStart race: a losing
-// racer that reads the just-created registration must see its full record
-// before deciding whether to adopt it or suffix to a fresh id.
+// never observed empty. A losing racer that reads the just-created
+// registration must see its full record before deciding whether it may adopt
+// the id.
 func WriteRegistrationExclusive(path string, r *Registration) error {
 	if err := r.Validate(); err != nil {
 		return err
@@ -207,7 +207,7 @@ func WriteRegistrationExclusive(path string, r *Registration) error {
 		return err
 	}
 	if err := os.Link(tmpName, path); err != nil {
-		return err // EEXIST surfaces as os.IsExist for the contextual-collision loop.
+		return err // EEXIST surfaces as os.IsExist for the registration retry.
 	}
 	_ = syncDir(dir)
 	return nil
@@ -624,7 +624,7 @@ func (e RegistrationReadError) Error() string {
 // the existing layout convention).
 //
 // Use this when one bad registration must NOT abort a multi-peer scan —
-// notably contextual-identity allocation (`identity`) and the update/setup
+// notably identity checks and the update/setup
 // re-sync (`update`), which enumerate every peer and must log/warn a single
 // unparseable entry and continue. Strict callers (single-registration ops,
 // the `status` command) should keep using ReadRegistration directly.

--- a/templates/enrollment/agents.md
+++ b/templates/enrollment/agents.md
@@ -12,24 +12,18 @@ agentchute setup --wake runner --wrappers all --yes
 
 Start sessions with `ac serve <wrapper>` from a control repo. The dispatcher routes through `agentchute serve`, which registers you, acquires a serve lease (id-uniqueness + fencing token), refreshes `last_seen` and your `.live` presence, polls your OWN inbox, exports your resolved id as `AGENTCHUTE_AGENT_ID` into the wrapper, and injects `[agentchute] check inbox` when mail arrives. The runner publishes no wake target — peers never poke it (pull-only). Hookless wrappers such as Grok still need the dispatcher for startup because they have no lifecycle hook that can run `boot`; `ac serve <wrapper>` enrolls them. Treat the bracketed prefix as machine metadata: the injection is only a CUE — you must actually RUN `agentchute check --as "$AGENTCHUTE_AGENT_ID"` to claim mail (then `ack` to commit); the runner does NOT consume it for you.
 
-**The project is the communication boundary**: agents by default only see and talk to peers in the same discovered project pool. Unrelated projects on one host or tmux server are isolated because each project has its own pool and, when identity is not explicit, the CLI derives project-scoped IDs from the folder name (for example, `codex-agentchute`).
+**The project is the communication boundary**: agents by default only see and talk to peers in the same discovered project pool. Unrelated projects on one host or tmux server are isolated because each project has its own pool.
 
-If a session starts and you do not see agentchute boot/enrolled context, run the wrapper with its vendor so the CLI can derive the contextual identity:
-
-```sh
-agentchute serve --vendor <vendor> -- <wrapper>
-```
-
-As a manual fallback, pin your identity ONCE and then enroll under it before doing any work:
+As a manual fallback, choose and export your identity before enrolling:
 
 ```sh
-export AGENTCHUTE_AGENT_ID="$(agentchute identity --vendor <vendor>)"   # or a named roster id
+export AGENTCHUTE_AGENT_ID="<roster-id>"
 agentchute boot --as "$AGENTCHUTE_AGENT_ID" --vendor <vendor>
 agentchute poller ensure --as "$AGENTCHUTE_AGENT_ID" --vendor <vendor>
 agentchute check --as "$AGENTCHUTE_AGENT_ID"
 ```
 
-If a first `check` says you are not registered, do this fallback immediately instead of stopping. Capture the id with `identity` (or pick a roster id) BEFORE `boot`, because once a live registration reserves the base id a later bare resolve returns a different `-N` suffix.
+If a first `check` says you are not registered, run this fallback immediately instead of stopping.
 
 Known wrappers and their canonical IDs:
 
@@ -40,17 +34,14 @@ Known wrappers and their canonical IDs:
 | Gemini CLI   | `gemini-cli`  | `google`    |
 | grok CLI     | `grok`        | `xai`       |
 
-The IDs above are wrapper bases. With no explicit identity, the reference CLI derives `<base>-<folder>` and reserves live conflicts with `-2`, `-3`, etc. **When several agents of one vendor share a bus** (e.g. `claude-l1`/`claude-l2`/`merger` all on the `claude-code` wrapper), each process must still enroll under its own id. Use contextual defaults for ordinary project/worktree lanes; use `AGENTCHUTE_AGENT_ID=<roster-id>` or `--as <roster-id>` for named lanes.
+`ac serve <wrapper>` uses the wrapper's canonical ID when neither `--as` nor `AGENTCHUTE_AGENT_ID` is set. A second lane with that ID refuses to start; give every additional lane its own explicit ID, for example `ac --as claude-l2 serve claude`.
 
 **Identity precedence** (the reference CLI resolves your `agent_id` in this exact order, first match wins):
 
-1. `--as <id>` flag
+1. `--as <id>` / `--from <id>` flag
 2. `AGENTCHUTE_AGENT_ID` env var
-3. contextual default → `<canonical-base>-<folder-slug>`, suffixed `-2`, `-3`, … past live conflicts
 
-(Pull-only registrations carry no wake target, so there is no longer a herdr/tmux pane to map back to a prior registration — id comes from `--as` / `$AGENTCHUTE_AGENT_ID` or the contextual default.)
-
-**Pin it once.** Resolve your id ONE time at startup and reuse the SAME id on every command. The `ac` dispatcher does this for you (it exports `AGENTCHUTE_AGENT_ID`). Otherwise export it yourself before `boot` (precedence step 2 then shadows the contextual default for the whole session). A bare `--vendor` with no `--as`/env is NOT a stable identity: it re-derives the contextual default (step 3) on every call, so as live lanes come and go the resolved `-N` suffix can change between calls and you silently `check` / `gate` the WRONG inbox. `agentchute identity --vendor <vendor>` prints the currently-resolved id — use it for one-time discovery, not as a per-call identity.
+Without either source, the command fails with an enrollment fix hint. The `ac` dispatcher passes its chosen ID explicitly and exports it to the wrapper; otherwise export the ID yourself before `boot`.
 
 **Verify at session start** (read-only — refreshes nothing, archives nothing; confirms you are enrolled AND present via a fresh `.live`):
 
@@ -63,7 +54,7 @@ agentchute doctor --as <your-id>
 
 **3. Recipient Polling Fallback**
 Senders only deliver to your inbox (pull-only; nobody pokes you). If you are not launched through `agentchute serve`, keep recipient polling alive so your `.live` presence stays fresh:
-- **Runner default**: `agentchute serve --vendor <vendor> -- <wrapper>` polls your own inbox, keeps `.live` fresh, and injects the `check inbox` cue.
+- **Runner default**: `ac serve <wrapper>` polls your own inbox, keeps `.live` fresh, and injects the `check inbox` cue.
 - **Hook-managed fallback**: `agentchute poller ensure --as <id> --vendor <vendor>` starts/verifies heartbeat-only `poller run` and writes `state/<agent_id>/poller.json` + `.live`; it does not launch wrappers or consume mail unless explicitly run with `--launch`.
 - **Native loops**: if your wrapper has a recurring task feature, it may replace `poller run` only if it keeps a fresh heartbeat.
 

--- a/templates/enrollment/wrapper.md
+++ b/templates/enrollment/wrapper.md
@@ -3,17 +3,16 @@
 
 Spec: [`AGENTS.md`](AGENTS.md) (full identity precedence, polling, hooks). This file is a thin pointer.
 
-**1. Pin your identity — once.** Base `agent_id={{AGENT_ID}}`, `vendor={{VENDOR}}`. Resolve your lane id ONCE at startup and reuse the SAME id on every call:
+**1. Pin your identity.** Default `agent_id={{AGENT_ID}}`, `vendor={{VENDOR}}`. Reuse the same explicit id on every call:
 
 - Launched via the `ac` dispatcher (`ac serve <wrapper>`)? Your id is already pinned in `$AGENTCHUTE_AGENT_ID` — use it as-is.
 - Otherwise set it yourself, before `boot`:
 
 ```sh
-export AGENTCHUTE_AGENT_ID="<roster-id>"                                 # named lane, or…
-export AGENTCHUTE_AGENT_ID="$(agentchute identity --vendor {{VENDOR}})"  # accept the contextual default (run once, before boot)
+export AGENTCHUTE_AGENT_ID="<roster-id>"
 ```
 
-Then pass `--as "$AGENTCHUTE_AGENT_ID"` (or rely on the env) on every command. **Do NOT** drive `check`/`gate`/`send` with a bare `--vendor` and no `--as`/env: with no pinned id the CLI re-derives the contextual default each call and can land on a DIFFERENT `-N` suffix (e.g. `{{AGENT_ID}}-<folder>-2`), checking the WRONG inbox and missing your finish-gate. `identity --vendor` is one-time discovery, NOT a per-call identity. Running several agents of this vendor on one bus? Give EACH process its own id — a shared id routes every lane to one inbox and defeats the finish-gate.
+Then pass `--as "$AGENTCHUTE_AGENT_ID"` (or rely on the env) on every command. Commands fail with an enrollment fix hint when neither a flag nor the env provides an id. Running several agents of this vendor on one bus? Give each process its own id; a shared id is refused while another live serve owns it.
 
 **2. Verify at session start** (read-only; confirms you are enrolled AND present via a fresh `.live`):
 


### PR DESCRIPTION
## Summary
- require agent ids from --as/--from or AGENTCHUTE_AGENT_ID, with the exact enrollment fix hint
- delete contextual derivation, reservation, and -N retry machinery; refuse fresh duplicate owners while preserving stale same-id recovery
- add inherited-mail boot notes, explicit dispatcher defaults, and remove vendor guessing from hook/enrollment templates

## Verification
- gofmt -w .
- go vet ./...
- go test ./...
- go build ./...
- revert/mutation proof: implicit fallback and duplicate-owner bypass each make focused regression tests fail
- grep gates: no contextual references under internal; no --vendor in shipped hook configs

## Deviations
- none