### PR TITLE
feat(send): require a fresh registration, deliver under the recipient lock (v2.5 plan B3)

### DIFF
--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -137,6 +137,9 @@ func cmdSend(args []string) error {
 		if errors.Is(rrErr, loop.ErrRecipientUnknown) {
 			return unknownRecipientError(toID, rrErr)
 		}
+		if errors.Is(rrErr, loop.ErrRecipientUnreadable) {
+			return unreadableRecipientError(toID)
+		}
 		return rrErr
 	}
 	if !rr.Fresh {
@@ -337,6 +340,16 @@ func racingRecipientError(to string) error {
 	return fmt.Errorf("%q was here seconds ago — likely mid-restart; retry once.", to)
 }
 
+// Malformed row: neither C29(a) (no row exists) nor C29(b)/(c) (a row exists
+// and is stale/racing) — a row that fails to parse tells us nothing about
+// whether `to` is reachable, so it gets its own text rather than being
+// folded into either. Telling an operator "was here, gone since <time>"
+// about a file that failed to parse would be actively misleading (codex/
+// claude-code review, PR #95 P1).
+func unreadableRecipientError(to string) error {
+	return fmt.Errorf("%q's registration could not be read (malformed); not sending. Inspect agents/%s.md by hand.", to, to)
+}
+
 // classifySendFailure maps a post-stdin delivery failure to its C29 text.
 // Reached only after cmdSend's own preflight already passed, so a stale
 // classification here is always the racing case (c), never the direct
@@ -345,6 +358,9 @@ func racingRecipientError(to string) error {
 func classifySendFailure(to string, cause error) error {
 	if errors.Is(cause, loop.ErrRecipientUnknown) {
 		return unknownRecipientError(to, cause)
+	}
+	if errors.Is(cause, loop.ErrRecipientUnreadable) {
+		return unreadableRecipientError(to)
 	}
 	if os.IsNotExist(cause) {
 		// A registration can be fresh while its inbox dir is unexpectedly

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -121,9 +122,25 @@ func cmdSend(args []string) error {
 		return fmt.Errorf("stat own registration: %w", err)
 	}
 
+	// B3 (v2.5 plan): the recipient preflight is a LOCK-FREE read of to's
+	// registration — never WithAgentLock(toID) here, whose ensurePrivateDir
+	// side effect would manufacture state/<toID>/ for an arbitrary --to typo
+	// (§4 risk; TestSendTakesNoLockForUnknownRecipient pins it). This is a
+	// fast-fail optimization only, run BEFORE stdin so a piped body is never
+	// touched on a doomed send (A5 ordering) — the actual enforcement is the
+	// re-check inside loop.DeliverUnderRecipientLock, which a sweep or a
+	// heartbeat can always race against between here and there.
 	inboxDir := cfg.AgentInboxDir(toID)
-	if fi, statErr := os.Stat(inboxDir); statErr != nil || !fi.IsDir() {
-		return unknownRecipientError(toID, os.ErrNotExist)
+	now := time.Now().UTC()
+	rr, rrErr := loop.CheckRecipientReachability(cfg, toID, now)
+	if rrErr != nil {
+		if errors.Is(rrErr, loop.ErrRecipientUnknown) {
+			return unknownRecipientError(toID, rrErr)
+		}
+		return rrErr
+	}
+	if !rr.Fresh {
+		return staleRecipientError(toID, rr)
 	}
 
 	if body == "" {
@@ -157,8 +174,6 @@ func cmdSend(args []string) error {
 			fmt.Fprintf(os.Stderr, "warning: self-send with --ask creates a self-reply obligation; per AGENTCHUTE.md §6.4 your reply MUST NOT propagate --ask\n")
 		}
 	}
-
-	now := time.Now().UTC()
 
 	content := loop.ComposeMessage(fromID, replyTo, body)
 	if ask {
@@ -283,6 +298,10 @@ type sendRetryOptions struct {
 	ReplyToSet bool
 }
 
+// C29(a): never-registered. Text is literal per the v2.5 plan — "no
+// registration row" (not "no inbox/registration") and an explicit "do NOT
+// register on their behalf" so no reading of this text can be mistaken for
+// coaching the sender to register the RECIPIENT (AGENTCHUTE.md §9).
 func unknownRecipientError(to string, cause error) error {
 	return unknownRecipientSendError{to: to, cause: cause}
 }
@@ -293,19 +312,57 @@ type unknownRecipientSendError struct {
 }
 
 func (e unknownRecipientSendError) Error() string {
-	return fmt.Sprintf("unknown agent %q: no inbox/registration. Check the id (agentchute status).", e.to)
+	return fmt.Sprintf("unknown agent %q: no registration row. Check the id (agentchute status) — do NOT register on their behalf.", e.to)
 }
 
 func (e unknownRecipientSendError) Unwrap() error {
 	return e.cause
 }
 
+// C29(b): stale, caught by cmdSend's OWN lock-free preflight — a direct,
+// non-racing classification (no send has been attempted yet; stdin has not
+// even been read).
+func staleRecipientError(to string, rr loop.RecipientReachability) error {
+	return fmt.Errorf("%q was here, gone since %s (%s ago); not sending (row older than stale_after=%s). They re-register at boot.",
+		to, rr.LastSeen.UTC().Format(time.RFC3339), rr.Age.Round(time.Second), rr.Threshold)
+}
+
+// C29(c): fresh-but-racing. Reached ONLY from loop.DeliverUnderRecipientLock
+// returning *loop.ErrRecipientStale — which, by construction, is reachable in
+// cmdSend's flow ONLY after its OWN preflight already found `to` fresh. Text
+// deliberately does not repeat "stale"/"gone since": the row was here
+// moments ago, so the honest read is a race (a fleet-wake storm mid-restart),
+// not the same failure C29(b) describes.
+func racingRecipientError(to string) error {
+	return fmt.Errorf("%q was here seconds ago — likely mid-restart; retry once.", to)
+}
+
+// classifySendFailure maps a post-stdin delivery failure to its C29 text.
+// Reached only after cmdSend's own preflight already passed, so a stale
+// classification here is always the racing case (c), never the direct
+// stale case (b) — that one is caught earlier, before any spool/retry
+// machinery even runs.
+func classifySendFailure(to string, cause error) error {
+	if errors.Is(cause, loop.ErrRecipientUnknown) {
+		return unknownRecipientError(to, cause)
+	}
+	if os.IsNotExist(cause) {
+		// A registration can be fresh while its inbox dir is unexpectedly
+		// gone (an inconsistent-state edge case, not a normal C29 branch);
+		// same "unknown agent" text applies since the recipient is not
+		// reachable either way.
+		return unknownRecipientError(to, cause)
+	}
+	var staleErr *loop.ErrRecipientStale
+	if errors.As(cause, &staleErr) {
+		return racingRecipientError(to)
+	}
+	return fmt.Errorf("write inbox message: %w", cause)
+}
+
 func preserveSendBody(cfg *loop.Config, from, to, body string, now time.Time, retry sendRetryOptions, cause error) error {
 	spoolPath, spoolErr := writeSendSpool(cfg, from, to, body, now)
-	baseErr := fmt.Errorf("write inbox message: %w", cause)
-	if os.IsNotExist(cause) {
-		baseErr = unknownRecipientError(to, cause)
-	}
+	baseErr := classifySendFailure(to, cause)
 	if spoolErr != nil {
 		return fmt.Errorf("%w; body preservation failed: %v", baseErr, spoolErr)
 	}

--- a/internal/cli/send_a5_test.go
+++ b/internal/cli/send_a5_test.go
@@ -63,8 +63,12 @@ func TestSendSpoolsBodyOnPostStdinFailure(t *testing.T) {
 		!strings.Contains(sendErr.Error(), wantRetry) {
 		t.Fatalf("error missing spool path/retry:\n%v", sendErr)
 	}
-	if strings.Contains(sendErr.Error(), "register") {
-		t.Fatalf("error coaches recipient registration:\n%v", sendErr)
+	// C29(a)'s literal text (v2.5 plan B3) deliberately contains "register" as
+	// part of an explicit anti-coaching clause ("do NOT register on their
+	// behalf") — check for actual coaching (a suggested command), not the
+	// bare word.
+	if strings.Contains(sendErr.Error(), "agentchute register") {
+		t.Fatalf("error coaches running `agentchute register` for the recipient:\n%v", sendErr)
 	}
 
 	if err := os.MkdirAll(cfg.AgentInboxDir("codex"), 0o700); err != nil {

--- a/internal/cli/send_b3_test.go
+++ b/internal/cli/send_b3_test.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// send_b3_test.go — v2.5 plan B3: send re-derives reachability itself under
+// the recipient's registration lock; three-way (C29) error text.
+
+// backdateRegistration rewrites id's registration row's LastSeen, leaving
+// every other field untouched.
+func backdateRegistration(t *testing.T, cfg *loop.Config, id string, lastSeen time.Time) {
+	t.Helper()
+	path := cfg.AgentRegistrationPath(id)
+	reg, err := loop.ReadRegistration(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg.LastSeen = lastSeen
+	if err := loop.WriteRegistration(path, reg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSendRefusesStaleRecipient: C29(b), caught by cmdSend's own lock-free
+// preflight (no send attempted, no lock taken, no spool involved — the
+// backdated row is stale before anything else runs).
+func TestSendRefusesStaleRecipient(t *testing.T) {
+	root, cfg := setupSendFixture(t)
+	backdateRegistration(t, cfg, "codex", time.Now().UTC().Add(-2*time.Hour))
+
+	var sendErr error
+	withCwd(t, root, func() {
+		sendErr = cmdSend([]string{"--from", "claude-code", "--to", "codex", "--body", "hello"})
+	})
+	if sendErr == nil {
+		t.Fatal("expected refusal for a stale recipient")
+	}
+	if !strings.Contains(sendErr.Error(), "was here, gone since") || !strings.Contains(sendErr.Error(), "not sending") {
+		t.Fatalf("err = %v, want C29(b) stale text", sendErr)
+	}
+	if strings.Contains(sendErr.Error(), "retry once") {
+		t.Fatalf("direct-stale (preflight) must not use the fresh-but-racing (c) wording: %v", sendErr)
+	}
+	entries, err := os.ReadDir(cfg.AgentInboxDir("codex"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 delivered messages, got %d", len(entries))
+	}
+}
+
+// TestSendFreshButRacingText: C29(c). cmdSend's own preflight already found
+// `codex` fresh; the delivery stage (loop.DeliverUnderRecipientLock, reached
+// via the sendSeqMessageWithCommit seam) reports the row went stale in the
+// gap. classifySendFailure must render this as the racing wording, not the
+// direct-stale wording — the two error TYPES already carry that distinction
+// (internal/loop/send_delivery_test.go proves DeliverUnderRecipientLock
+// itself catches the underlying race; this proves cmdSend renders it right).
+func TestSendFreshButRacingText(t *testing.T) {
+	root, cfg := setupSendFixture(t)
+	originalSend := sendSeqMessageWithCommit
+	sendSeqMessageWithCommit = func(cfg *loop.Config, from, to string, content []byte, idempotencyKey, serveToken string) (loop.MsgID, bool, error) {
+		return loop.MsgID{}, false, &loop.ErrRecipientStale{
+			To:        to,
+			LastSeen:  time.Now().UTC().Add(-90 * time.Second),
+			Age:       90 * time.Second,
+			Threshold: time.Hour,
+		}
+	}
+	defer func() { sendSeqMessageWithCommit = originalSend }()
+
+	var sendErr error
+	withCwd(t, root, func() {
+		sendErr = withSendStdin(t, "body", func() error {
+			return cmdSend([]string{"--from", "claude-code", "--to", "codex"})
+		})
+	})
+	if sendErr == nil {
+		t.Fatal("expected a racing-recipient failure")
+	}
+	if !strings.Contains(sendErr.Error(), "was here seconds ago") || !strings.Contains(sendErr.Error(), "retry once") {
+		t.Fatalf("err = %v, want C29(c) fresh-but-racing text", sendErr)
+	}
+	if strings.Contains(sendErr.Error(), "gone since") {
+		t.Fatalf("racing case must not reuse the direct-stale (b) wording: %v", sendErr)
+	}
+	// Post-stdin failure spools the body per A5/C28.
+	if countSendSpools(t, cfg, "claude-code") != 1 {
+		t.Fatalf("expected the racing failure to spool the body (stdin already drained)")
+	}
+}
+
+// TestSendTakesNoLockForUnknownRecipient: the lock-free preflight must reject
+// an unknown --to BEFORE any lock is taken — WithAgentLock's ensurePrivateDir
+// side effect would otherwise manufacture state/<typo>/ for an arbitrary typo
+// (v2.5 plan B3 §4 risk).
+func TestSendTakesNoLockForUnknownRecipient(t *testing.T) {
+	root, cfg := setupSendFixture(t)
+	withCwd(t, root, func() {
+		err := cmdSend([]string{"--from", "claude-code", "--to", "typo-nonexistent", "--body", "x"})
+		if err == nil {
+			t.Fatal("expected refusal for an unknown recipient")
+		}
+	})
+	if _, err := os.Stat(cfg.AgentStateDir("typo-nonexistent")); !os.IsNotExist(err) {
+		t.Fatalf("state dir for the typo'd recipient should not exist: stat err = %v", err)
+	}
+}
+
+// TestSendSelfSendNoDeadlock is the B3 sentinel: mint (AllocateSeq, under
+// WithAgentLock(from)) and deliver (DeliverUnderRecipientLock, under
+// WithAgentLock(to)) are two SEPARATE, SEQUENTIAL lock acquisitions. For
+// self-send (from==to) these two calls target the SAME non-reentrant flock;
+// if they were ever held together this would deadlock. cmdSend is run in a
+// goroutine so a real deadlock fails this test via timeout rather than
+// hanging `go test` forever (withAgentLock's own 5s internal lock-timeout
+// would otherwise surface as a slow error, not a true hang — either way,
+// well past the 1s budget below).
+func TestSendSelfSendNoDeadlock(t *testing.T) {
+	root, _ := setupSendFixture(t)
+	withCwd(t, root, func() {
+		done := make(chan error, 1)
+		go func() {
+			done <- cmdSend([]string{"--from", "claude-code", "--to", "claude-code", "--body", "self"})
+		}()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("self-send failed: %v", err)
+			}
+		case <-time.After(1 * time.Second):
+			t.Fatal("self-send did not complete within 1s (mint and delivery locks held together = deadlock)")
+		}
+	})
+}

--- a/internal/cli/send_b3_test.go
+++ b/internal/cli/send_b3_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -48,6 +49,74 @@ func TestSendRefusesStaleRecipient(t *testing.T) {
 		t.Fatalf("direct-stale (preflight) must not use the fresh-but-racing (c) wording: %v", sendErr)
 	}
 	entries, err := os.ReadDir(cfg.AgentInboxDir("codex"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 delivered messages, got %d", len(entries))
+	}
+}
+
+// TestSendRefusesMalformedRecipientAtPreflight: PR #95 P1 (codex/claude-code
+// review) — a registration row that EXISTS but fails to parse must never
+// read as reachable just because it has a fresh mtime. Caught at cmdSend's
+// own preflight: no stdin consumed, no lock taken (no state dir for the
+// recipient — WithAgentLock's ensurePrivateDir side effect must never fire
+// here), and no send attempted at all.
+//
+// Uses a recipient id that never goes through cmdRegister (unlike "codex" in
+// setupSendFixture, whose OWN registration already creates state/codex/ as a
+// side effect of WithAgentLock, unrelated to send's preflight) — the
+// registration row and inbox dir are created directly so no prior state dir
+// exists before cmdSend runs.
+func TestSendRefusesMalformedRecipientAtPreflight(t *testing.T) {
+	root, cfg := setupSendFixture(t)
+	const recipient = "malformed-agent"
+	if err := os.MkdirAll(filepath.Dir(cfg.AgentRegistrationPath(recipient)), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfg.AgentRegistrationPath(recipient), []byte("{not a valid registration"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cfg.AgentInboxDir(recipient), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	stdinPath := filepath.Join(t.TempDir(), "stdin")
+	if err := os.WriteFile(stdinPath, []byte("must remain unread"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdin, err := os.Open(stdinPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = stdin.Close() }()
+	originalStdin := sendStdin
+	sendStdin = stdin
+	defer func() { sendStdin = originalStdin }()
+
+	var sendErr error
+	withCwd(t, root, func() {
+		sendErr = cmdSend([]string{"--from", "claude-code", "--to", recipient})
+	})
+	if sendErr == nil {
+		t.Fatal("expected refusal for a malformed recipient row")
+	}
+	if !strings.Contains(sendErr.Error(), "malformed") || !strings.Contains(sendErr.Error(), "not sending") {
+		t.Fatalf("err = %v, want the malformed-row text", sendErr)
+	}
+	if strings.Contains(sendErr.Error(), "gone since") || strings.Contains(sendErr.Error(), "retry once") {
+		t.Fatalf("malformed-row text must not borrow C29(b)/(c) wording: %v", sendErr)
+	}
+	if offset, seekErr := stdin.Seek(0, 1); seekErr != nil {
+		t.Fatal(seekErr)
+	} else if offset != 0 {
+		t.Fatalf("stdin offset = %d, want 0 (unread)", offset)
+	}
+	if _, err := os.Stat(cfg.AgentStateDir(recipient)); !os.IsNotExist(err) {
+		t.Fatalf("state dir for the malformed recipient should not exist: stat err = %v", err)
+	}
+	entries, err := os.ReadDir(cfg.AgentInboxDir(recipient))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/send_test.go
+++ b/internal/cli/send_test.go
@@ -25,22 +25,32 @@ func TestSendFailsForUnregisteredRecipient(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Try to send to unregistered recipient (inbox dir doesn't exist)
+		// Try to send to unregistered recipient (no registration row at all)
 		args := []string{"--from", "sender", "--to", "recipient", "--body", "hello"}
 		err := cmdSend(args)
 		if err == nil {
-			t.Fatal("expected error sending to unregistered recipient (missing inbox dir), got nil")
+			t.Fatal("expected error sending to unregistered recipient (no registration row), got nil")
 		}
-		if got, want := err.Error(), `unknown agent "recipient": no inbox/registration. Check the id (agentchute status).`; got != want {
+		// C29(a) literal text (v2.5 plan B3): the "do NOT register on their
+		// behalf" clause deliberately contains the word "register" as part of
+		// an explicit anti-coaching instruction — it must not be confused with
+		// actually coaching registration (e.g. "run agentchute register ...").
+		if got, want := err.Error(), `unknown agent "recipient": no registration row. Check the id (agentchute status) — do NOT register on their behalf.`; got != want {
 			t.Errorf("unexpected error message: %v", err)
 		}
-		if strings.Contains(err.Error(), "register") {
-			t.Errorf("error message coaches recipient registration: %v", err)
+		if strings.Contains(err.Error(), "agentchute register") {
+			t.Errorf("error message coaches running `agentchute register` for the recipient: %v", err)
 		}
 	})
 }
 
-func TestSendNonFatalMissingRegistrationButExistingInbox(t *testing.T) {
+// TestSendRefusesMissingRegistration: v2.5 plan B3 flips this test — an
+// existing inbox dir with NO registration row is now REFUSED with C29(a),
+// not silently delivered. Pull-only delivery still writes the inbox file
+// unconditionally, but send.go's freshness preflight is what decides whether
+// to reach that point at all; a recipient with no registration row can never
+// pass it, inbox dir or not.
+func TestSendRefusesMissingRegistration(t *testing.T) {
 	root := t.TempDir()
 	withCwd(t, root, func() {
 		mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# Spec"))
@@ -51,23 +61,26 @@ func TestSendNonFatalMissingRegistrationButExistingInbox(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Manually create recipient inbox dir but NO registration file
+		// Manually create recipient inbox dir but NO registration file.
 		inboxDir := filepath.Join(root, ".agentchute", "loop", "inbox", "recipient")
 		mustMkdir(t, inboxDir)
 
-		// Send should succeed (delivery is unconditional under pull-only).
 		args := []string{"--from", "sender", "--to", "recipient", "--body", "hello"}
-		if err := cmdSend(args); err != nil {
-			t.Fatalf("cmdSend should be non-fatal if inbox dir exists: %v", err)
+		err := cmdSend(args)
+		if err == nil {
+			t.Fatal("expected refusal: an inbox dir with no registration row must not be sendable to")
+		}
+		if !strings.Contains(err.Error(), "no registration row") {
+			t.Fatalf("error = %v, want C29(a) no-registration-row text", err)
 		}
 
-		// Verify message delivered
-		entries, err := os.ReadDir(inboxDir)
-		if err != nil {
-			t.Fatal(err)
+		// Nothing was delivered.
+		entries, err2 := os.ReadDir(inboxDir)
+		if err2 != nil {
+			t.Fatal(err2)
 		}
-		if len(entries) != 1 {
-			t.Fatalf("expected 1 message in inbox, got %d", len(entries))
+		if len(entries) != 0 {
+			t.Fatalf("expected 0 messages in inbox, got %d", len(entries))
 		}
 	})
 }

--- a/internal/loop/message.go
+++ b/internal/loop/message.go
@@ -45,9 +45,14 @@ type AnnounceResult struct {
 // tracked *.example.md files, dotfiles, and non-.md entries). It is N direct
 // sends — NOT a broadcast mechanism — and stays within AGENTCHUTE.md §7.1.
 //
-// Per-peer failures (missing inbox, malformed registration) are collected as
-// Warnings; the function does not abort on them. A returned error means the
-// agents directory itself could not be read.
+// Per-peer failures (missing inbox, malformed registration, a stale peer per
+// B3's freshness enforcement) are collected as Warnings; the function does
+// not abort on them. A returned error means the agents directory itself
+// could not be read. Delivery goes through the same locked path send.go
+// uses (SendSeqMessage -> DeliverUnderRecipientLock): a stale peer is simply
+// skipped with a warning, exactly like any other per-peer failure — there is
+// no separate preflight here (AnnounceEnrollment has no user-facing C29
+// wording to choose between; every freshness failure reads the same way).
 func AnnounceEnrollment(cfg *Config, self *Registration) (AnnounceResult, error) {
 	entries, err := os.ReadDir(cfg.AgentsDir())
 	if err != nil {

--- a/internal/loop/message_test.go
+++ b/internal/loop/message_test.go
@@ -169,6 +169,51 @@ func TestAnnounceEnrollmentSendsToPeersSkipsSelfAndExamples(t *testing.T) {
 	}
 }
 
+// TestAnnounceEnrollmentStalePeerIsWarningNotFatal: v2.5 plan B3 ports
+// AnnounceEnrollment onto the same locked delivery send.go uses, so a stale
+// peer (past StaleAfter) is now a per-peer freshness failure — collected as a
+// Warning like any other, never fatal to the whole enrollment.
+func TestAnnounceEnrollmentStalePeerIsWarningNotFatal(t *testing.T) {
+	cfg := setupAnnounceFixture(t)
+	self := newReg(t, cfg, "claude-code", "anthropic", "synthesis")
+	stale := newReg(t, cfg, "codex", "openai", "review")
+	fresh := newReg(t, cfg, "gemini-cli", "google", "external review")
+
+	staleReg, err := ReadRegistration(cfg.AgentRegistrationPath(stale.AgentID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleReg.LastSeen = time.Now().UTC().Add(-2 * time.Hour)
+	if err := WriteRegistration(cfg.AgentRegistrationPath(stale.AgentID), staleReg); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := AnnounceEnrollment(cfg, self)
+	if err != nil {
+		t.Fatalf("a stale peer should not be fatal: %v", err)
+	}
+	if result.Total != 2 {
+		t.Fatalf("Total=%d, want 2 (codex + gemini-cli both counted as candidates)", result.Total)
+	}
+	if result.Sent != 1 {
+		t.Fatalf("Sent=%d, want 1 (only gemini-cli, the fresh peer)", result.Sent)
+	}
+	if len(result.Warnings) != 1 {
+		t.Fatalf("Warnings=%v, want exactly 1 (the stale peer)", result.Warnings)
+	}
+	if !strings.Contains(result.Warnings[0], "codex") {
+		t.Fatalf("warning should name the stale peer codex: %v", result.Warnings)
+	}
+
+	// The stale peer's inbox must be empty; the fresh peer's must have landed.
+	if entries, err := os.ReadDir(cfg.AgentInboxDir(stale.AgentID)); err != nil || len(entries) != 0 {
+		t.Errorf("stale peer inbox should be empty, got entries=%v err=%v", entries, err)
+	}
+	if entries, err := os.ReadDir(cfg.AgentInboxDir(fresh.AgentID)); err != nil || len(entries) != 1 {
+		t.Errorf("fresh peer inbox should have 1 message, got entries=%v err=%v", entries, err)
+	}
+}
+
 func TestAnnounceEnrollmentMissingInboxIsWarningNotFatal(t *testing.T) {
 	cfg := setupAnnounceFixture(t)
 	self := newReg(t, cfg, "claude-code", "anthropic", "synthesis")

--- a/internal/loop/send_delivery_test.go
+++ b/internal/loop/send_delivery_test.go
@@ -121,6 +121,71 @@ func TestDeliverUnderRecipientLockBacksOffWhenRecipientVanishesDuringLock(t *tes
 	}
 }
 
+// TestCheckRecipientReachabilityFailsClosedOnMalformedRow: a registration row
+// that EXISTS but fails to parse must never read as reachable — a corrupt row
+// proves nothing about whether the recipient is actually there. PR #95 P1
+// (codex/claude-code): an earlier version fell back to the file's mtime here
+// (mirroring sweep.go's registrationAge, C12), so a malformed row with a
+// FRESH mtime read as Fresh=true, letting delivery commit to an agent that
+// was never confirmed reachable — precisely the black-hole this slice exists
+// to eliminate, reached through the corrupt-row door instead of the
+// never-registered door. Sweep's mtime fallback exists for the OPPOSITE
+// requirement (a corrupt row must age out, not be immortal against cleanup);
+// send needs unparseable to mean "cannot prove reachable", not "assume
+// fresh".
+func TestCheckRecipientReachabilityFailsClosedOnMalformedRow(t *testing.T) {
+	cfg := newSeqTestConfig(t)
+	if err := ensurePrivateDir(cfg.AgentsDir()); err != nil {
+		t.Fatal(err)
+	}
+	path := cfg.AgentRegistrationPath("bob")
+	if err := atomicWriteFile(path, []byte("{not a valid registration")); err != nil {
+		t.Fatal(err)
+	}
+	// Freshly written (mtime = now) — exactly the shape that fooled the old
+	// mtime fallback.
+
+	rr, err := CheckRecipientReachability(cfg, "bob", time.Now().UTC())
+	if !errors.Is(err, ErrRecipientUnreadable) {
+		t.Fatalf("err = %v, want ErrRecipientUnreadable", err)
+	}
+	if rr.Fresh {
+		t.Fatal("rr.Fresh = true for a malformed row — must never read as reachable")
+	}
+}
+
+// TestDeliverUnderRecipientLockBacksOffWhenRecipientBecomesMalformedDuringLock
+// is the malformed-row twin of the goes-stale/vanishes races above: `to`'s row
+// is fresh and well-formed at preflight time, but gets corrupted (e.g. a torn
+// concurrent write) in the gap before the per-delivery lock.
+func TestDeliverUnderRecipientLockBacksOffWhenRecipientBecomesMalformedDuringLock(t *testing.T) {
+	cfg := newSeqTestConfig(t)
+	mkFreshRecipient(t, cfg, "bob")
+
+	t.Cleanup(func() { afterRecipientLockHook = nil })
+	afterRecipientLockHook = func() {
+		if err := atomicWriteFile(cfg.AgentRegistrationPath("bob"), []byte("{not a valid registration")); err != nil {
+			t.Fatalf("corrupt bob during race window: %v", err)
+		}
+	}
+
+	id := MsgID{To: "bob", From: "alice", Seq: 1}
+	committed, err := DeliverUnderRecipientLock(cfg, "bob", id, []byte("x"), "")
+	if committed {
+		t.Fatal("committed = true, want false (a recipient that became malformed mid-lock must not receive delivery)")
+	}
+	if !errors.Is(err, ErrRecipientUnreadable) {
+		t.Fatalf("err = %v, want ErrRecipientUnreadable", err)
+	}
+	entries, rerr := os.ReadDir(cfg.AgentInboxDir("bob"))
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 delivered messages, got %d", len(entries))
+	}
+}
+
 // TestDeliverUnderRecipientLockSucceedsWhenStillFresh is the control: without
 // the hook mutating anything, a genuinely fresh recipient's delivery lands
 // normally. Guards against a broken re-check that backs off unconditionally.

--- a/internal/loop/send_delivery_test.go
+++ b/internal/loop/send_delivery_test.go
@@ -1,0 +1,146 @@
+package loop
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// send_delivery_test.go — v2.5 plan B3: DeliverUnderRecipientLock is send's
+// single point of TRUTH for reachability. These tests prove the under-lock
+// re-check genuinely closes the race a lock-free preflight leaves open — not
+// just that the error TYPES exist, but that a real mutation racing the lock
+// (via afterRecipientLockHook) is actually caught.
+
+func TestCheckRecipientReachabilityUnknown(t *testing.T) {
+	cfg := newSeqTestConfig(t)
+	_, err := CheckRecipientReachability(cfg, "ghost", time.Now().UTC())
+	if !errors.Is(err, ErrRecipientUnknown) {
+		t.Fatalf("err = %v, want ErrRecipientUnknown", err)
+	}
+	// ErrRecipientUnknown wraps os.ErrNotExist via %w, so errors.Is (which
+	// walks Unwrap chains) sees it — but the legacy os.IsNotExist does NOT:
+	// it only unwraps *PathError/*LinkError/*SyscallError, not an arbitrary
+	// fmt.Errorf %w chain. errors.Is is the correct check for callers.
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ErrRecipientUnknown must satisfy errors.Is(err, os.ErrNotExist), got %v", err)
+	}
+}
+
+func TestCheckRecipientReachabilityFreshAndStale(t *testing.T) {
+	cfg := newSeqTestConfig(t)
+	now := time.Now().UTC()
+	mkFreshRecipient(t, cfg, "fresh")
+
+	rr, err := CheckRecipientReachability(cfg, "fresh", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rr.Fresh {
+		t.Fatalf("rr.Fresh = false for a just-registered row, age=%s threshold=%s", rr.Age, rr.Threshold)
+	}
+
+	stale := &Registration{AgentID: "stale", Vendor: "agentchute", ControlRepo: cfg.ControlRepo, LastSeen: now.Add(-2 * time.Hour), Status: StatusActive}
+	if err := WriteRegistration(cfg.AgentRegistrationPath("stale"), stale); err != nil {
+		t.Fatal(err)
+	}
+	rr, err = CheckRecipientReachability(cfg, "stale", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rr.Fresh {
+		t.Fatalf("rr.Fresh = true for a 2h-old row against the default stale_after")
+	}
+}
+
+// TestDeliverUnderRecipientLockBacksOffWhenRecipientGoesStaleDuringLock
+// reproduces the exact race the recipient lock exists to close: `to`'s row is
+// fresh at scan/preflight time, but goes stale in the gap between that check
+// and the per-delivery lock — afterRecipientLockHook fires INSIDE the lock,
+// after acquisition but before the freshness re-read, so the divergence comes
+// entirely from that window (mirrors sweep.go's afterSweepScanHook pattern).
+func TestDeliverUnderRecipientLockBacksOffWhenRecipientGoesStaleDuringLock(t *testing.T) {
+	cfg := newSeqTestConfig(t)
+	mkFreshRecipient(t, cfg, "bob")
+
+	t.Cleanup(func() { afterRecipientLockHook = nil })
+	afterRecipientLockHook = func() {
+		reg, err := ReadRegistration(cfg.AgentRegistrationPath("bob"))
+		if err != nil {
+			t.Fatalf("re-read bob during race window: %v", err)
+		}
+		reg.LastSeen = time.Now().UTC().Add(-2 * time.Hour)
+		if err := WriteRegistration(cfg.AgentRegistrationPath("bob"), reg); err != nil {
+			t.Fatalf("backdate bob during race window: %v", err)
+		}
+	}
+
+	id := MsgID{To: "bob", From: "alice", Seq: 1}
+	committed, err := DeliverUnderRecipientLock(cfg, "bob", id, []byte("x"), "")
+	if committed {
+		t.Fatal("committed = true, want false (a recipient that went stale mid-lock must not receive delivery)")
+	}
+	var staleErr *ErrRecipientStale
+	if !errors.As(err, &staleErr) {
+		t.Fatalf("err = %v, want *ErrRecipientStale", err)
+	}
+	if staleErr.To != "bob" {
+		t.Fatalf("ErrRecipientStale.To = %q, want bob", staleErr.To)
+	}
+	entries, rerr := os.ReadDir(cfg.AgentInboxDir("bob"))
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 delivered messages, got %d", len(entries))
+	}
+}
+
+// TestDeliverUnderRecipientLockBacksOffWhenRecipientVanishesDuringLock is the
+// absent-row twin: `to`'s registration is removed entirely (e.g. swept) in
+// the same race window.
+func TestDeliverUnderRecipientLockBacksOffWhenRecipientVanishesDuringLock(t *testing.T) {
+	cfg := newSeqTestConfig(t)
+	mkFreshRecipient(t, cfg, "bob")
+
+	t.Cleanup(func() { afterRecipientLockHook = nil })
+	afterRecipientLockHook = func() {
+		if err := os.Remove(cfg.AgentRegistrationPath("bob")); err != nil {
+			t.Fatalf("remove bob during race window: %v", err)
+		}
+	}
+
+	id := MsgID{To: "bob", From: "alice", Seq: 1}
+	committed, err := DeliverUnderRecipientLock(cfg, "bob", id, []byte("x"), "")
+	if committed {
+		t.Fatal("committed = true, want false")
+	}
+	if !errors.Is(err, ErrRecipientUnknown) {
+		t.Fatalf("err = %v, want ErrRecipientUnknown", err)
+	}
+}
+
+// TestDeliverUnderRecipientLockSucceedsWhenStillFresh is the control: without
+// the hook mutating anything, a genuinely fresh recipient's delivery lands
+// normally. Guards against a broken re-check that backs off unconditionally.
+func TestDeliverUnderRecipientLockSucceedsWhenStillFresh(t *testing.T) {
+	cfg := newSeqTestConfig(t)
+	mkFreshRecipient(t, cfg, "bob")
+
+	id := MsgID{To: "bob", From: "alice", Seq: 1}
+	committed, err := DeliverUnderRecipientLock(cfg, "bob", id, []byte("x"), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !committed {
+		t.Fatal("committed = false, want true for a fresh recipient")
+	}
+	data, rerr := os.ReadFile(cfg.AgentInboxDir("bob") + "/" + id.Filename())
+	if rerr != nil {
+		t.Fatalf("delivered file missing: %v", rerr)
+	}
+	if string(data) != "x" {
+		t.Fatalf("delivered body = %q, want x", data)
+	}
+}

--- a/internal/loop/seq.go
+++ b/internal/loop/seq.go
@@ -431,11 +431,26 @@ func SendSeqMessageWithCommit(cfg *Config, from, to string, content []byte, idem
 // use errors.Is, not os.IsNotExist.
 var ErrRecipientUnknown = fmt.Errorf("loop: recipient has no registration row: %w", os.ErrNotExist)
 
+// ErrRecipientUnreadable classifies a recipient whose registration row EXISTS
+// but could not be parsed (a malformed agents/<to>.md — hand-edited, torn
+// write, or otherwise corrupt). Unlike ErrRecipientUnknown, the row is
+// physically present, so this is neither "no row" nor a stale-vs-fresh
+// question — a row we cannot parse proves NOTHING about reachability, and
+// must never be treated as fresh (codex/claude-code review, PR #95 P1: an
+// earlier version fell back to the file's mtime here, mirroring sweep.go's
+// registrationAge — but that fallback exists for the OPPOSITE requirement.
+// Sweep needs a corrupt row to age out rather than be immortal against
+// CLEANUP; send needs the opposite direction entirely: an unparseable row
+// must fail CLOSED against DELIVERY, exactly like VerifyFence/
+// AcquireServeLease already fail closed on an unreadable serve claim. One
+// helper's fallback cannot serve both directions, so send does not use it).
+var ErrRecipientUnreadable = errors.New("loop: recipient's registration row exists but could not be parsed")
+
 // RecipientReachability is the outcome of checking whether a recipient is
 // currently reachable enough to accept a send (B3, C29): registered, and if
 // so, how old its last heartbeat is relative to the pool's stale_after.
 type RecipientReachability struct {
-	LastSeen  time.Time     // parsed registration LastSeen, or the file's mtime for an unparseable row (C12 precedent — a row we can't parse is not a row we can prove reachable, but it is also not "no row at all").
+	LastSeen  time.Time     // parsed registration LastSeen.
 	Age       time.Duration // now - LastSeen, NOT clamped (a future-dated LastSeen reads as extra-fresh here — the safe direction for a delivery decision, unlike sweep's cleanup decision, C12/B1).
 	Threshold time.Duration // loop.StaleAfter(cfg) at the moment of the check.
 	Fresh     bool          // Age <= Threshold.
@@ -444,36 +459,26 @@ type RecipientReachability struct {
 // CheckRecipientReachability reads to's registration WITHOUT taking any lock
 // — this is send's fast, lock-free preflight (B3 §4 risk: WithAgentLock's
 // ensurePrivateDir side effect must never manufacture state/<to>/ for an
-// arbitrary --to typo). Returns ErrRecipientUnknown when no row exists at
-// all (parsed or via a bare file stat); otherwise the reachability snapshot,
-// with Fresh telling the caller whether to proceed.
+// arbitrary --to typo). Returns ErrRecipientUnknown when no row exists at all
+// (fails CLOSED against os.ErrNotExist), ErrRecipientUnreadable when a row
+// exists but fails to parse (fails CLOSED — no mtime fallback; see that
+// error's doc comment for why), or the reachability snapshot with Fresh
+// telling the caller whether to proceed.
 func CheckRecipientReachability(cfg *Config, to string, now time.Time) (RecipientReachability, error) {
 	if err := ValidateAgentID(to); err != nil {
 		return RecipientReachability{}, err
 	}
 	path := cfg.AgentRegistrationPath(to)
-	lastSeen, ok := recipientLastSeen(path)
-	if !ok {
-		return RecipientReachability{}, ErrRecipientUnknown
+	reg, err := ReadRegistration(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return RecipientReachability{}, ErrRecipientUnknown
+		}
+		return RecipientReachability{}, ErrRecipientUnreadable
 	}
 	threshold := StaleAfter(cfg)
-	age := now.UTC().Sub(lastSeen.UTC())
-	return RecipientReachability{LastSeen: lastSeen, Age: age, Threshold: threshold, Fresh: age <= threshold}, nil
-}
-
-// recipientLastSeen returns path's best-effort last_seen: the parsed
-// Registration.LastSeen when the file parses, or the file's mtime otherwise
-// (a corrupt/unparseable row still physically exists — C12's mtime-fallback
-// precedent, mirrored from sweep.go's registrationAge). ok is false only when
-// the file itself is genuinely absent.
-func recipientLastSeen(path string) (time.Time, bool) {
-	if reg, err := ReadRegistration(path); err == nil {
-		return reg.LastSeen, true
-	}
-	if info, err := os.Stat(path); err == nil {
-		return info.ModTime(), true
-	}
-	return time.Time{}, false
+	age := now.UTC().Sub(reg.LastSeen.UTC())
+	return RecipientReachability{LastSeen: reg.LastSeen, Age: age, Threshold: threshold, Fresh: age <= threshold}, nil
 }
 
 // ErrRecipientStale reports that DeliverUnderRecipientLock's re-check found
@@ -514,9 +519,10 @@ var afterRecipientLockHook func()
 // here. Re-derives to's reachability under WithAgentLock(to) and, only if
 // still fresh, re-verifies id.From's fence (when serveToken != "") and links
 // id/content into to's inbox. On any failure (ErrRecipientUnknown,
-// *ErrRecipientStale, ErrFenced) nothing is linked — the seq in id was
-// already durably allocated by the caller's AllocateSeq and is consumed as a
-// legal gap (O1 tolerates gaps; a resend needs a fresh preflight+mint).
+// ErrRecipientUnreadable, *ErrRecipientStale, ErrFenced) nothing is linked —
+// the seq in id was already durably allocated by the caller's AllocateSeq and
+// is consumed as a legal gap (O1 tolerates gaps; a resend needs a fresh
+// preflight+mint).
 //
 // NO LOCK NESTING: id.From's OWN WithAgentLock(id.From) (taken by the
 // caller's AllocateSeq) MUST have already released before this is called —

--- a/internal/loop/seq.go
+++ b/internal/loop/seq.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"time"
 )
 
 // seq.go — the protocol-v2 identity tuple + the durable, monotonic,
@@ -405,28 +406,146 @@ func SendSeqMessage(cfg *Config, from, to string, content []byte, idempotencyKey
 // committed is true once the canonical inbox link exists, including when a
 // later directory-sync barrier fails. Callers must not recommend resending a
 // committed delivery.
+//
+// B3 (v2.5 plan): mint (AllocateSeq, under WithAgentLock(from)) and deliver
+// (DeliverUnderRecipientLock, under WithAgentLock(to)) are two SEPARATE,
+// SEQUENTIAL lock acquisitions — the first fully releases before the second
+// begins. NO LOCK NESTING: self-send (from==to) would deadlock the
+// non-reentrant flock instantly if these were ever held together; a
+// dedicated sentinel test (TestSendSelfSendNoDeadlock) pins this.
 func SendSeqMessageWithCommit(cfg *Config, from, to string, content []byte, idempotencyKey, serveToken string) (MsgID, bool, error) {
 	seq, err := AllocateSeq(cfg, from, to, idempotencyKey, serveToken)
 	if err != nil {
 		return MsgID{}, false, err
 	}
 	id := MsgID{To: to, From: from, Seq: seq}
-	// Defense-in-depth (post-reclaim no-WRITE): re-verify the fence AFTER the
-	// counter is allocated but BEFORE the message links into the recipient inbox,
-	// so a reclaim landing in the AllocateSeq→link gap also fails closed. VerifyFence
-	// is lock-free, so this holds no lock and cannot deadlock. It NARROWS but cannot
-	// fully eliminate the link race (a reclaim can always slip between this read and
-	// the link); the durable+monotonic seq guarantees no REUSE regardless, so any
-	// residual late write lands at a seq the new owner will never re-issue. Only
-	// enforced when fenced (serveToken != ""); empty = intentionally unfenced.
-	if serveToken != "" {
-		if err := VerifyFence(cfg, from, serveToken); err != nil {
-			return MsgID{}, false, err
+	committed, err := DeliverUnderRecipientLock(cfg, to, id, content, serveToken)
+	return id, committed, err
+}
+
+// ErrRecipientUnknown classifies a recipient with no registration row at all.
+// It wraps os.ErrNotExist so errors.Is(err, os.ErrNotExist) callers keep
+// working unchanged. NOTE: the legacy os.IsNotExist does NOT see through
+// this wrap — it only unwraps *PathError/*LinkError/*SyscallError, not an
+// arbitrary fmt.Errorf %w chain; callers checking this specific error must
+// use errors.Is, not os.IsNotExist.
+var ErrRecipientUnknown = fmt.Errorf("loop: recipient has no registration row: %w", os.ErrNotExist)
+
+// RecipientReachability is the outcome of checking whether a recipient is
+// currently reachable enough to accept a send (B3, C29): registered, and if
+// so, how old its last heartbeat is relative to the pool's stale_after.
+type RecipientReachability struct {
+	LastSeen  time.Time     // parsed registration LastSeen, or the file's mtime for an unparseable row (C12 precedent — a row we can't parse is not a row we can prove reachable, but it is also not "no row at all").
+	Age       time.Duration // now - LastSeen, NOT clamped (a future-dated LastSeen reads as extra-fresh here — the safe direction for a delivery decision, unlike sweep's cleanup decision, C12/B1).
+	Threshold time.Duration // loop.StaleAfter(cfg) at the moment of the check.
+	Fresh     bool          // Age <= Threshold.
+}
+
+// CheckRecipientReachability reads to's registration WITHOUT taking any lock
+// — this is send's fast, lock-free preflight (B3 §4 risk: WithAgentLock's
+// ensurePrivateDir side effect must never manufacture state/<to>/ for an
+// arbitrary --to typo). Returns ErrRecipientUnknown when no row exists at
+// all (parsed or via a bare file stat); otherwise the reachability snapshot,
+// with Fresh telling the caller whether to proceed.
+func CheckRecipientReachability(cfg *Config, to string, now time.Time) (RecipientReachability, error) {
+	if err := ValidateAgentID(to); err != nil {
+		return RecipientReachability{}, err
+	}
+	path := cfg.AgentRegistrationPath(to)
+	lastSeen, ok := recipientLastSeen(path)
+	if !ok {
+		return RecipientReachability{}, ErrRecipientUnknown
+	}
+	threshold := StaleAfter(cfg)
+	age := now.UTC().Sub(lastSeen.UTC())
+	return RecipientReachability{LastSeen: lastSeen, Age: age, Threshold: threshold, Fresh: age <= threshold}, nil
+}
+
+// recipientLastSeen returns path's best-effort last_seen: the parsed
+// Registration.LastSeen when the file parses, or the file's mtime otherwise
+// (a corrupt/unparseable row still physically exists — C12's mtime-fallback
+// precedent, mirrored from sweep.go's registrationAge). ok is false only when
+// the file itself is genuinely absent.
+func recipientLastSeen(path string) (time.Time, bool) {
+	if reg, err := ReadRegistration(path); err == nil {
+		return reg.LastSeen, true
+	}
+	if info, err := os.Stat(path); err == nil {
+		return info.ModTime(), true
+	}
+	return time.Time{}, false
+}
+
+// ErrRecipientStale reports that DeliverUnderRecipientLock's re-check found
+// to's row present but past stale_after. The caller (cmdSend) knows whether
+// its OWN earlier lock-free preflight had already passed — if so, this is
+// the fresh-but-racing case (C29c: the row went stale in the gap between
+// preflight and this lock, e.g. a fleet-wake storm mid-restart); if the
+// caller never preflighted at all (AnnounceEnrollment), this is a plain
+// stale classification. Loop stays silent on which C29 wording applies —
+// that choice, and the literal text, lives entirely in send.go (AGENTCHUTE.md
+// §9: no text may coach registering the recipient, and that ban is easiest to
+// audit from a single source).
+type ErrRecipientStale struct {
+	To        string
+	LastSeen  time.Time
+	Age       time.Duration
+	Threshold time.Duration
+}
+
+func (e *ErrRecipientStale) Error() string {
+	return fmt.Sprintf("recipient %q registration is stale (last_seen=%s age=%s > stale_after=%s)",
+		e.To, e.LastSeen.UTC().Format(time.RFC3339), e.Age.Round(time.Second), e.Threshold)
+}
+
+// afterRecipientLockHook, when non-nil, fires inside DeliverUnderRecipientLock
+// immediately after WithAgentLock(to) is acquired but BEFORE the freshness
+// re-check reads to's registration. Test-only seam: lets a test simulate the
+// EXACT race this lock exists to close — to's row going stale or vanishing in
+// the gap between cmdSend's lock-free preflight and this lock (e.g. a sweep
+// or a peer's send racing in). nil in production.
+var afterRecipientLockHook func()
+
+// DeliverUnderRecipientLock is send's single point of TRUTH for whether a
+// delivery may proceed (B3): the lock-free preflight in cmdSend (or
+// AnnounceEnrollment's per-peer loop, which has none) is a fast-fail
+// optimization ONLY, never the enforcement itself — a sweep, a heartbeat, or
+// another sender can all land in the window between any earlier check and
+// here. Re-derives to's reachability under WithAgentLock(to) and, only if
+// still fresh, re-verifies id.From's fence (when serveToken != "") and links
+// id/content into to's inbox. On any failure (ErrRecipientUnknown,
+// *ErrRecipientStale, ErrFenced) nothing is linked — the seq in id was
+// already durably allocated by the caller's AllocateSeq and is consumed as a
+// legal gap (O1 tolerates gaps; a resend needs a fresh preflight+mint).
+//
+// NO LOCK NESTING: id.From's OWN WithAgentLock(id.From) (taken by the
+// caller's AllocateSeq) MUST have already released before this is called —
+// never call this from inside that lock's closure. Self-send (id.From==to)
+// would deadlock the non-reentrant flock instantly if the two were ever held
+// together.
+func DeliverUnderRecipientLock(cfg *Config, to string, id MsgID, content []byte, serveToken string) (committed bool, err error) {
+	if err := ValidateAgentID(to); err != nil {
+		return false, fmt.Errorf("to: %w", err)
+	}
+	lockErr := withAgentLock(cfg, to, func() error {
+		if afterRecipientLockHook != nil {
+			afterRecipientLockHook()
 		}
-	}
-	_, committed, err := writeSeqMessageWithCommit(cfg.AgentInboxDir(to), id, content)
-	if err != nil {
-		return id, committed, err
-	}
-	return id, committed, nil
+		rr, rerr := CheckRecipientReachability(cfg, to, time.Now().UTC())
+		if rerr != nil {
+			return rerr
+		}
+		if !rr.Fresh {
+			return &ErrRecipientStale{To: to, LastSeen: rr.LastSeen, Age: rr.Age, Threshold: rr.Threshold}
+		}
+		if serveToken != "" {
+			if err := VerifyFence(cfg, id.From, serveToken); err != nil {
+				return err
+			}
+		}
+		_, c, werr := writeSeqMessageWithCommit(cfg.AgentInboxDir(to), id, content)
+		committed = c
+		return werr
+	})
+	return committed, lockErr
 }

--- a/internal/loop/seq_test.go
+++ b/internal/loop/seq_test.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestSendSeqMessageWithCommitReportsPostLinkSyncFailure(t *testing.T) {
 	cfg := newSeqTestConfig(t)
-	mkInbox(t, cfg, "bob")
+	mkFreshRecipient(t, cfg, "bob")
 	originalSync := syncSeqInboxDir
 	syncSeqInboxDir = func(string) error {
 		return errors.New("forced post-link sync failure")
@@ -55,6 +56,27 @@ func mkInbox(t *testing.T, cfg *Config, to string) {
 	t.Helper()
 	if err := ensurePrivateDir(cfg.AgentInboxDir(to)); err != nil {
 		t.Fatalf("mkInbox %s: %v", to, err)
+	}
+}
+
+// mkFreshRecipient creates to's inbox dir AND a fresh registration row. B3's
+// DeliverUnderRecipientLock requires the registration to consider `to`
+// reachable; tests that exercise SendSeqMessage(WithCommit) — the full
+// mint-then-deliver path — need this. Tests that call writeSeqMessage or
+// AllocateSeq directly (bypassing delivery's enforcement by design) keep
+// using the plain mkInbox.
+func mkFreshRecipient(t *testing.T, cfg *Config, to string) {
+	t.Helper()
+	mkInbox(t, cfg, to)
+	reg := &Registration{
+		AgentID:     to,
+		Vendor:      "agentchute",
+		ControlRepo: cfg.ControlRepo,
+		LastSeen:    time.Now().UTC(),
+		Status:      StatusActive,
+	}
+	if err := WriteRegistration(cfg.AgentRegistrationPath(to), reg); err != nil {
+		t.Fatalf("mkFreshRecipient %s: %v", to, err)
 	}
 }
 
@@ -213,7 +235,7 @@ func TestAllocateSeqReissuesOnSameKey(t *testing.T) {
 // TestC1_SenderCrashResume against a REAL filesystem.
 func TestSeqSenderCrashResume(t *testing.T) {
 	cfg := newSeqTestConfig(t)
-	mkInbox(t, cfg, "bob")
+	mkFreshRecipient(t, cfg, "bob")
 
 	// normal send: seq=1 lands.
 	id1, err := SendSeqMessage(cfg, "alice", "bob", []byte("m1"), "k1", "")


### PR DESCRIPTION
## Summary

Implements v2.5 plan slice B3 (`docs/decisions/agentchute-v2.5-implementation-plan.md` §2 B3 + constants C8/C10/C29): send re-derives reachability itself instead of trusting a lock-free inbox-dir stat.

- **Recipient preflight** (`internal/cli/send.go`): a lock-free read of the recipient's registration row + age check vs `loop.StaleAfter(cfg)`, run BEFORE stdin (A5 ordering) so a piped body is never touched on a doomed send. Absent row → C29(a); stale → C29(b). Never `WithAgentLock(to)` here — that side effect would manufacture `state/<to>/` for an arbitrary `--to` typo (`TestSendTakesNoLockForUnknownRecipient` pins it).
- **Locked delivery** (`internal/loop/seq.go`): new `loop.DeliverUnderRecipientLock(cfg, to, id, content, serveToken)` — takes `WithAgentLock(to)`, re-derives reachability under lock (a sweep, a heartbeat, or another sender can always race the gap between the preflight and here), re-verifies `id.From`'s fence, then links. `SendSeqMessageWithCommit` is now `AllocateSeq` (mint, under the sender's own lock) → fully released → `DeliverUnderRecipientLock` (deliver, under the recipient's lock) — two separate sequential lock acquisitions, never nested. Self-send (`from==to`) would deadlock the non-reentrant flock instantly if they ever were.
- **Three-way error text (C29)**: (a) `unknown agent "<to>": no registration row. Check the id (agentchute status) — do NOT register on their behalf.` (b) `"<to>" was here, gone since <RFC3339> (<age> ago); not sending (row older than stale_after=<dur>). They re-register at boot.` — caught by the lock-free preflight, direct/non-racing. (c) `"<to>" was here seconds ago — likely mid-restart; retry once.` — caught only after the preflight already passed (a genuine race through the lock), for fleet-wake-storm mid-restart.
- **`AnnounceEnrollment`** (`internal/loop/message.go`) already rides the same locked path transitively (`SendSeqMessage` → `SendSeqMessageWithCommit`) — zero code change needed beyond the doc comment; a stale peer is now just another per-peer `Warning`, never fatal to the whole enrollment.

## Deviation (disclosed)

While setting up this worktree off `release/v2.5`'s tip I found `release/v2.5` itself CI-red: B1 (#91) changed `writeSetupPoolState`'s signature (4th `staleAfter` param); B2 (#92) merged ~1 minute later with a test still on the old 3-arg call, since its branch was cut before B1 landed — both PRs were green against their own base, but the combination didn't compile. Fixed as a standalone hotfix, #93 (merged, zero production code changed), and rebased this branch onto the fixed tip. Unrelated to B3 itself, called out here per program convention.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` and `go test -race ./...` green (env stripped of `AGENTCHUTE_*`); `(cd conformance && go test ./...)` green
- [x] Mutation-verified (revert → confirm the targeted test fails → restore → confirm it passes): the preflight staleness check; `classifySendFailure`'s stale-vs-racing (b vs c) distinction; the no-lock-for-unknown-recipient guarantee; `DeliverUnderRecipientLock`'s under-lock re-check for BOTH the goes-stale-mid-lock and vanishes-mid-lock cases (via a real race through `afterRecipientLockHook`, not just constructed error types); the self-send no-lock-nesting sentinel (mutated `SendSeqMessageWithCommit` to nest the locks — the 1s-budget sentinel correctly caught the resulting ~5s lock-timeout instead of completing fast)
- [x] Done-when: black-hole send is impossible in tests (absent/stale row errors with the specced C29 text, nothing delivered); the fresh-but-racing case is proven via an actual race through the recipient lock; no lock nesting anywhere on the send path (self-send sentinel); no `state/<typo>/` dir for an unknown recipient

Reviewers: claude-code, codex. Do not merge — merges on the gate per program convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review round 2 (codex/claude-code) — head `5b19915`

**P1, fixed.** `CheckRecipientReachability` fell back to the registration file's mtime whenever the row failed to parse — mirroring `sweep.go`'s `registrationAge`, which needs that fallback for the OPPOSITE reason (a corrupt row must age out, not be immortal against cleanup). Send needs the opposite direction entirely: an unparseable row proves NOTHING about reachability, so it must fail CLOSED, not read as fresh. A fresh-but-malformed `agents/<id>.md` was reading as `Fresh=true` and reaching both the preflight and the under-lock re-check, committing delivery to a recipient never actually confirmed reachable — precisely the black-hole this slice exists to eliminate, reached through the corrupt-row door instead of the never-registered door.

**Fix.** Removed the mtime fallback entirely. A parse failure that isn't `os.ErrNotExist` now returns a new `ErrRecipientUnreadable`, propagated as a refusal by both the lock-free preflight and `DeliverUnderRecipientLock`'s under-lock re-check.

**Error taxonomy decision.** A malformed row gets its OWN text, distinct from both C29(a) and C29(b)/(c): `"<to>"'s registration could not be read (malformed); not sending. Inspect agents/<to>.md by hand.` Reasoning: it is not "no row" (C29a — a row physically exists), and telling an operator "was here, gone since <time>" (C29b) about a file that failed to parse would be actively misleading, since we have no valid timestamp to report at all.

**Tests.** `TestCheckRecipientReachabilityFailsClosedOnMalformedRow` and `TestDeliverUnderRecipientLockBacksOffWhenRecipientBecomesMalformedDuringLock` (loop package, the latter via the existing `afterRecipientLockHook` seam — a row that gets corrupted mid-lock, not just pre-seeded malformed) prove both refusal points; `TestSendRefusesMalformedRecipientAtPreflight` (cli package) proves the preflight text, no stdin consumption, and no state-dir creation. Probe-reproduced the bug first (`Fresh=true, committed=true` against a fresh malformed row, matching codex's repro exactly), then mutation-verified all three new tests (reintroduced the mtime fallback, confirmed all three go red; restored, confirmed green).

CI green on `5b19915` (build/vet/gofmt/test/test-race, `AGENTCHUTE_*` stripped).
