### PR TITLE
refactor(loop): one frontmatter parser, grammar in the spec (v2.5 plan B8)

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -4,11 +4,12 @@
 
 > **Executable spec.** The normative invariants below are encoded as runnable,
 > language-neutral conformance vectors in [`conformance/`](conformance/) — seven
-> core invariants (`R1`/`D1`/`D2`/`O1`/`C1`/`E1`/`B1`) plus two crash-safety
-> vectors (`C2` universal, `Q1` inbox-profile), driven against two substrate
-> bindings (private inbox dir + shared log). Any substrate that passes its
-> applicable vectors is conformant. When prose and the suite disagree, the
-> suite wins.
+> core invariants (`R1`/`D1`/`D2`/`O1`/`C1`/`E1`/`B1`), the malformed-quarantine
+> vector (`Q1`, inbox-profile), the v2.5 wire-break vectors
+> (`TS1`/`TS2`/`TS3`/`DR1`, `DR1` inbox-profile), and the frontmatter-grammar
+> vectors (`FM1`/`FM2`), driven against two substrate bindings (private inbox
+> dir + shared log). Any substrate that passes its applicable vectors is
+> conformant. When prose and the suite disagree, the suite wins.
 
 ---
 
@@ -191,6 +192,28 @@ Encoded as optional YAML frontmatter. The **normative** envelope is small:
 - `in_reply_to` (optional): the canonical reference `to-<to>_from-<from>_seq-<020d>` of the message being answered. Consuming a reply whose `in_reply_to` matches one of the asker's outstanding `.owed` entries discharges that obligation.
 
 **Compatibility fields:** `message_id` is no longer emitted (removed in v0.9.0); the identity is `(to,from,seq)` and reply threading rides `in_reply_to` (the canonical `(to,from,seq)` ref). A `message_id` on an older in-flight message is still tolerated on read (ignored — never the identity). `to`, `task`, and `status` are no longer part of the envelope or the reference CLI at all (`to` is encoded by location; a message's subject, if any, is a body convention — the first Markdown line — not a typed field). They carry no special-case compat handling anymore; a stray `task:`/`status:`/`to:` line on an old in-flight message is simply an unrecognized field, ignored per §6.5 like any other.
+
+**Frontmatter grammar (v2.5 plan B8).** One parser (`parseFrontmatter`, the reference CLI's `internal/loop/registration.go`) implements this grammar for both message envelopes here and registration rows (§5.2) — one engine, not a per-context dialect, closing a historical validator/recorder skew where a message's envelope was gated by one parser and its fields read by another. It is a flat key:value format, not general YAML:
+
+```
+block       := "---" LF *line "---" LF
+line        := blank-line | kv-line
+kv-line     := key ":" [ SP value ] LF
+key         := 1*(ALPHA / DIGIT / "_")            ; non-empty, no leading space/tab
+value       := scalar | list-header
+list-header := LF *( SP SP "-" SP item LF )        ; only when the scalar is empty
+scalar      := 1*OCTET                            ; everything after the first ":"
+```
+
+Rules, precisely:
+- The opening and closing lines are the first line and the next line whose TRIMMED content is exactly `---`; whitespace around the delimiter itself is tolerated. A block with no closing `---` is a hard parse error for the whole message.
+- Blank lines between the delimiters are skipped.
+- Every other line MUST be a `key: value` pair with the key un-indented. An indented line, or any line without a `:` — including a `#`-prefixed comment, since this grammar has no comment syntax — is a hard parse error for the **whole block**, not a line skipped in isolation.
+- A key may appear at most once; a repeated key is a hard parse error for the whole block (no last-write-wins).
+- A `key:` with nothing after the colon on that line opens a LIST: each immediately following `  - <item>` line (after trimming) is consumed as an item; the first non-item, non-blank line ends the list and resumes normal key:value scanning. A key with no following items is an empty scalar.
+- Scalars are trimmed, then unwrapped: `strconv.Unquote` is tried first (interprets backslash escapes inside a double-quoted value); failing that, one layer of surrounding matched `"` or `'` is stripped; `null` and `~` collapse to the empty string.
+
+Unknown keys are always tolerated (§6.5) — the grammar's strictness is about **shape** (one key per line, no stray text, no indentation, no duplicates), never about which key names appear.
 
 ### 6.5 Forward compatibility
 Receivers MUST ignore unrecognized frontmatter fields. `from` is required information (§6.4). Conforming registrations emit the protocol major version in the `v:` field (emitted as `v: 2`; absent `v:` implies a silent legacy/unknown state with no warnings generated, as mixed fleets are normal). A genuine protocol-major version mismatch (where `v:` is present and does not equal 2) surfaces as a diagnostic warning (doctor/status) but is never a delivery blocker. Messages MUST be valid UTF-8. The reference CLI accepts up to 4 MiB per message.

--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -193,27 +193,20 @@ Encoded as optional YAML frontmatter. The **normative** envelope is small:
 
 **Compatibility fields:** `message_id` is no longer emitted (removed in v0.9.0); the identity is `(to,from,seq)` and reply threading rides `in_reply_to` (the canonical `(to,from,seq)` ref). A `message_id` on an older in-flight message is still tolerated on read (ignored — never the identity). `to`, `task`, and `status` are no longer part of the envelope or the reference CLI at all (`to` is encoded by location; a message's subject, if any, is a body convention — the first Markdown line — not a typed field). They carry no special-case compat handling anymore; a stray `task:`/`status:`/`to:` line on an old in-flight message is simply an unrecognized field, ignored per §6.5 like any other.
 
-**Frontmatter grammar (v2.5 plan B8).** One parser (`parseFrontmatter`, the reference CLI's `internal/loop/registration.go`) implements this grammar for both message envelopes here and registration rows (§5.2) — one engine, not a per-context dialect, closing a historical validator/recorder skew where a message's envelope was gated by one parser and its fields read by another. It is a flat key:value format, not general YAML:
+**Frontmatter grammar (v2.5 plan B8).** One parser (`parseFrontmatter`, the reference CLI's `internal/loop/registration.go`) implements this for both message envelopes here and registration rows (§5.2) — one engine, not a per-context dialect, closing a historical validator/recorder skew where a message's envelope was gated by one parser and its fields read by another. It is a flat key:value format, not general YAML. The steps below are exact — verified line-for-line against `parseFrontmatter` and against the independent conformance reimplementation (`conformance/fm.go`); the two agree with each other on every point:
 
-```
-block       := "---" LF *line "---" LF
-line        := blank-line | kv-line
-kv-line     := key ":" [ SP value ] LF
-key         := 1*(ALPHA / DIGIT / "_")            ; non-empty, no leading space/tab
-value       := scalar | list-header
-list-header := LF *( SP SP "-" SP item LF )        ; only when the scalar is empty
-scalar      := 1*OCTET                            ; everything after the first ":"
-```
+1. The opening line and the next line whose TRIMMED content is exactly `---` delimit the block; whitespace around the delimiter itself is tolerated. A block with no closing `---` is a hard parse error for the whole message.
+2. Scan the lines strictly between the delimiters, top to bottom:
+   - A blank line (after trimming) is skipped.
+   - A line starting with a literal space or tab is a hard parse error for the **whole block** — UNLESS it is a list item continuation (see below); a list is the only place indentation is expected or tolerated.
+   - Every other line MUST contain a `:`. The KEY is everything before the *first* `:`, trimmed; it may be **any non-empty text** — there is no charset restriction (hyphens, spaces, Unicode all pass) beyond "not empty after trimming." In practice every field name in this protocol is a bare identifier (`agent_id`/`from`/`reply_required`/…), but the parser itself does not enforce that shape. A line with no `:` at all — including a `#`-prefixed comment, since this grammar has no comment syntax — is a hard parse error for the whole block.
+   - A key may appear at most once; a repeated key is a hard parse error for the whole block (no last-write-wins).
+   - The VALUE is everything after that first `:`, trimmed (further `:` or `#` characters inside it are literal value content, not new fields or comments).
+   - A non-empty value makes the field a SCALAR: its text runs through the cleanup in step 3.
+   - An empty value (`key:` with nothing after it, or only whitespace) OPENS A LIST: each following line is inspected — a blank line is skipped and does **not** end the list; a line whose content, after trimming **any** amount of leading whitespace (zero, one, a tab, or more — there is no fixed indent width), starts with `- ` (dash, single space) is consumed as a list item, its text being everything after that `- ` prefix, run through the same cleanup as a scalar; the first line that is neither blank nor `- `-prefixed ends the list — that line is **not** consumed, and is re-scanned as an ordinary top-level line (subject to every rule above, including the indentation check) — and leaves the key with an empty scalar.
+3. Scalar/item cleanup: `strconv.Unquote` is tried first (interprets backslash escapes inside a double-quoted value, e.g. `"a\tb"` → `a`+TAB+`b`); failing that, one layer of surrounding matched `"` or `'` is stripped verbatim (no escape interpretation); the literal values `null` and `~` collapse to the empty string.
 
-Rules, precisely:
-- The opening and closing lines are the first line and the next line whose TRIMMED content is exactly `---`; whitespace around the delimiter itself is tolerated. A block with no closing `---` is a hard parse error for the whole message.
-- Blank lines between the delimiters are skipped.
-- Every other line MUST be a `key: value` pair with the key un-indented. An indented line, or any line without a `:` — including a `#`-prefixed comment, since this grammar has no comment syntax — is a hard parse error for the **whole block**, not a line skipped in isolation.
-- A key may appear at most once; a repeated key is a hard parse error for the whole block (no last-write-wins).
-- A `key:` with nothing after the colon on that line opens a LIST: each immediately following `  - <item>` line (after trimming) is consumed as an item; the first non-item, non-blank line ends the list and resumes normal key:value scanning. A key with no following items is an empty scalar.
-- Scalars are trimmed, then unwrapped: `strconv.Unquote` is tried first (interprets backslash escapes inside a double-quoted value); failing that, one layer of surrounding matched `"` or `'` is stripped; `null` and `~` collapse to the empty string.
-
-Unknown keys are always tolerated (§6.5) — the grammar's strictness is about **shape** (one key per line, no stray text, no indentation, no duplicates), never about which key names appear.
+Unknown keys are always tolerated (§6.5) — the grammar's strictness is about **shape** (a `:`-bearing key per line, no stray text, no indentation outside a list, no duplicate keys), never about which key names or how many list-item spaces appear.
 
 ### 6.5 Forward compatibility
 Receivers MUST ignore unrecognized frontmatter fields. `from` is required information (§6.4). Conforming registrations emit the protocol major version in the `v:` field (emitted as `v: 2`; absent `v:` implies a silent legacy/unknown state with no warnings generated, as mixed fleets are normal). A genuine protocol-major version mismatch (where `v:` is present and does not equal 2) surfaces as a diagnostic warning (doctor/status) but is never a delivery blocker. Messages MUST be valid UTF-8. The reference CLI accepts up to 4 MiB per message.

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -12,7 +12,7 @@ implementation.
 For a copy-pasteable filesystem walkthrough, see
 [`AGENTCHUTE.md` Appendix C](AGENTCHUTE.md#appendix-c-hand-protocol-walkthrough).
 
-The conformance vectors — seven core invariants (`R1`/`D1`/`D2`/`O1`/`C1`/`E1`/`B1`), the malformed-quarantine vector (`Q1`), and the v2.5 wire-break vectors (`TS1`/`TS2`/`TS3`/`DR1`) — *are* those semantics,
+The conformance vectors — seven core invariants (`R1`/`D1`/`D2`/`O1`/`C1`/`E1`/`B1`), the malformed-quarantine vector (`Q1`), the v2.5 wire-break vectors (`TS1`/`TS2`/`TS3`/`DR1`), and the frontmatter-grammar vectors (`FM1`/`FM2`) — *are* those semantics,
 and [`conformance/`](conformance/) is the executable spec — the invariants as a
 Go test suite driven against multiple substrate bindings. An implementation that
 passes the suite is conformant; when this prose and the suite disagree, the suite

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -104,12 +104,21 @@ just that Go code — against the same fixture set promoted from
 - **`TestFM1_Accept`** — every well-formed block is accepted and its fields
   extracted exactly as documented: quoting (double, single, escaped),
   whitespace around keys/values/delimiters, CRLF, blank lines inside the
-  block, a list header, an empty scalar, a value containing `:` or `#`, and
-  the body-only (no frontmatter at all) case.
+  block, a list header at zero/one/tab/two-space item indentation, an
+  empty scalar, a value containing `:` or `#`, a key containing characters
+  outside `[A-Za-z0-9_]` (there is no key charset restriction), the
+  `null`/`~` sentinel collapse, a double-quoted backslash escape actually
+  being interpreted (not just quote-stripped), and the body-only (no
+  frontmatter at all) case. The last three pin RESULT values, not merely
+  that the block parses — a standalone parser that skips escape
+  interpretation or sentinel collapse provably fails this vector.
 - **`TestFM2_Reject`** — every malformed block is rejected as a WHOLE (no
   partial field extraction survives): an indented continuation line, a
   duplicate key, any non-key:value line (including a `#` comment — this
-  grammar has no comment syntax), an empty key, and a missing closing `---`.
+  grammar has no comment syntax), an empty key, a missing closing `---`,
+  and a near-miss list item (`-nospace`, missing the required `- ` dash-space
+  prefix) — it is not silently swallowed; it falls out of the list and is
+  rejected as an ordinary invalid line.
 
 ## B1 is the §5 decision, as code
 

--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -92,6 +92,25 @@ unchanged; only the delivery-side guarantee changed.
   recognizes BOTH the old `(to,from,seq)` grammar and the new timestamp
   grammar, and classifies anything else as garbage.
 
+### v2.5 plan B8 — one frontmatter grammar
+
+What used to be three hand-written parsers (one already deleted in A6) is
+now one flat key:value grammar, shared by message envelopes (§6.4) and
+registration rows (§5.2). `fm.go` reimplements it independently of the
+reference CLI's `internal/loop/parseFrontmatter` — proving the grammar, not
+just that Go code — against the same fixture set promoted from
+`internal/loop/frontmatter_characterization_test.go`.
+
+- **`TestFM1_Accept`** — every well-formed block is accepted and its fields
+  extracted exactly as documented: quoting (double, single, escaped),
+  whitespace around keys/values/delimiters, CRLF, blank lines inside the
+  block, a list header, an empty scalar, a value containing `:` or `#`, and
+  the body-only (no frontmatter at all) case.
+- **`TestFM2_Reject`** — every malformed block is rejected as a WHOLE (no
+  partial field extraction survives): an indented continuation line, a
+  duplicate key, any non-key:value line (including a `#` comment — this
+  grammar has no comment syntax), an empty key, and a missing closing `---`.
+
 ## B1 is the §5 decision, as code
 
 `TestB1_PrivacyFork` runs the *same* assertion on both models and prints opposite

--- a/conformance/fm.go
+++ b/conformance/fm.go
@@ -1,0 +1,107 @@
+package conformance
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// fm.go — v2.5 plan B8: an independent reimplementation of the ONE flat
+// key:value frontmatter grammar (AGENTCHUTE.md §6.4/§5.2), mirroring but not
+// importing internal/loop's parseFrontmatter (tsid.go's own posture: prove
+// the WIRE GRAMMAR, not just the reference CLI's Go code). Any binding's
+// envelope parser must satisfy the FM1 (accept) / FM2 (reject) vectors this
+// file is exercised against.
+
+// ParseFrontmatterFields parses a message's leading frontmatter block into a
+// flat key/value map. A body-only input (no leading `---`) is not an error —
+// it returns an empty map, nil. A malformed block (an indented line, a
+// non-key:value line — including a `#` comment, since this grammar has no
+// comment syntax — a duplicate key, an empty key, or a missing closing
+// `---`) returns a non-nil error and a nil map; the whole block is rejected,
+// not just the offending line.
+func ParseFrontmatterFields(content string) (map[string]string, error) {
+	text := strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return map[string]string{}, nil
+	}
+
+	closing := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			closing = i
+			break
+		}
+	}
+	if closing == -1 {
+		return nil, fmt.Errorf("missing frontmatter closing ---")
+	}
+
+	fields := map[string]string{}
+	for i := 1; i < closing; i++ {
+		line := lines[i]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			return nil, fmt.Errorf("unexpected indented line %q", line)
+		}
+
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid frontmatter line %q", line)
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" {
+			return nil, fmt.Errorf("empty frontmatter key")
+		}
+		if _, exists := fields[key]; exists {
+			return nil, fmt.Errorf("duplicate frontmatter key %q", key)
+		}
+
+		if value != "" {
+			fields[key] = cleanFmScalar(value)
+			continue
+		}
+
+		// A bare "key:" opens a list: consume following "  - item" lines.
+		// List items are not surfaced in the flat scalar map (the header key
+		// gets an empty string) — matches ParseMessageFrontmatter's own
+		// scalar-only view; no current message field is list-valued.
+		for i+1 < closing {
+			trimmed := strings.TrimSpace(lines[i+1])
+			if trimmed == "" {
+				i++
+				continue
+			}
+			if strings.HasPrefix(trimmed, "- ") {
+				i++
+				continue
+			}
+			break
+		}
+		fields[key] = ""
+	}
+	return fields, nil
+}
+
+// cleanFmScalar mirrors internal/loop's cleanScalar: strconv.Unquote first
+// (interprets backslash escapes), falling back to a single paired-quote
+// strip; `null`/`~` collapse to empty string.
+func cleanFmScalar(value string) string {
+	if value == "null" || value == "~" {
+		return ""
+	}
+	if unquoted, err := strconv.Unquote(value); err == nil {
+		return unquoted
+	}
+	if len(value) >= 2 {
+		first, last := value[0], value[len(value)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
+}

--- a/conformance/fm_test.go
+++ b/conformance/fm_test.go
@@ -1,0 +1,41 @@
+package conformance
+
+import "testing"
+
+// fm_test.go — v2.5 plan B8 vectors: the one flat key:value frontmatter
+// grammar that message envelopes and registration rows now share.
+
+// FM1 — the grammar accepts every well-formed block and extracts exactly the
+// documented fields.
+func TestFM1_Accept(t *testing.T) {
+	v := vectorByID(t, "FM1", "frontmatter_accept")
+	for _, c := range v.AcceptCases {
+		got, err := ParseFrontmatterFields(c.Input)
+		if err != nil {
+			t.Errorf("%s: expected ACCEPT, got error: %v", c.Name, err)
+			continue
+		}
+		if len(got) != len(c.Fields) {
+			t.Errorf("%s: field count mismatch: got %v, want %v", c.Name, got, c.Fields)
+			continue
+		}
+		for k, want := range c.Fields {
+			if got[k] != want {
+				t.Errorf("%s: field %q: got %q, want %q (map=%v)", c.Name, k, got[k], want, got)
+			}
+		}
+	}
+}
+
+// FM2 — the same grammar hard-rejects every malformed block: indentation, a
+// duplicate key, a non-key:value line (including a `#` comment — this
+// grammar has no comment syntax), an empty key, and a missing closing
+// delimiter. Rejection is whole-block: no partial field extraction survives.
+func TestFM2_Reject(t *testing.T) {
+	v := vectorByID(t, "FM2", "frontmatter_reject")
+	for _, c := range v.RejectCases {
+		if _, err := ParseFrontmatterFields(c.Input); err == nil {
+			t.Errorf("%s: expected REJECT, got no error", c.Name)
+		}
+	}
+}

--- a/conformance/vectors/core.json
+++ b/conformance/vectors/core.json
@@ -265,6 +265,54 @@
             "from": "codex",
             "reply_required": "true"
           }
+        },
+        {
+          "name": "unusual-key-chars",
+          "input": "---\nweird key-name!: value\nfrom: codex\n---\n\nbody\n",
+          "fields": {
+            "weird key-name!": "value",
+            "from": "codex"
+          }
+        },
+        {
+          "name": "list-zero-indent",
+          "input": "---\nfrom: codex\nworking_repos:\n- /a\n- /b\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "working_repos": ""
+          }
+        },
+        {
+          "name": "list-tab-indent",
+          "input": "---\nfrom: codex\nworking_repos:\n\t- /a\n\t- /b\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "working_repos": ""
+          }
+        },
+        {
+          "name": "quoted-value-escaped",
+          "input": "---\nfrom: codex\ntask: \"a\\tb\"\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "task": "a\tb"
+          }
+        },
+        {
+          "name": "null-value",
+          "input": "---\nfrom: codex\ntask: null\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "task": ""
+          }
+        },
+        {
+          "name": "tilde-value",
+          "input": "---\nfrom: codex\ntask: ~\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "task": ""
+          }
         }
       ]
     },
@@ -296,6 +344,10 @@
         {
           "name": "empty-key",
           "input": "---\n: value\n---\n\nbody\n"
+        },
+        {
+          "name": "list-item-missing-gap",
+          "input": "---\nfrom: codex\nworking_repos:\n-nospace\n---\n\nbody\n"
         }
       ]
     }

--- a/conformance/vectors/core.json
+++ b/conformance/vectors/core.json
@@ -13,7 +13,10 @@
       "kind": "atomic_visibility",
       "name": "staged delivery is invisible until committed",
       "recipient": "bob",
-      "message": {"from": "alice", "body": "hello"}
+      "message": {
+        "from": "alice",
+        "body": "hello"
+      }
     },
     {
       "id": "D2",
@@ -31,22 +34,44 @@
       "name": "one sender's order is preserved",
       "recipient": "bob",
       "sender": "alice",
-      "bodies": ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"]
+      "bodies": [
+        "a0",
+        "a1",
+        "a2",
+        "a3",
+        "a4",
+        "a5",
+        "a6",
+        "a7",
+        "a8",
+        "a9"
+      ]
     },
     {
       "id": "C1",
       "kind": "consume_redelivery",
       "name": "crash after act redelivers (consume is at-least-once)",
       "recipient": "bob",
-      "message": {"from": "alice", "body": "do-it"}
+      "message": {
+        "from": "alice",
+        "body": "do-it"
+      }
     },
     {
       "id": "E1",
       "kind": "envelope",
       "name": "unknown fields are ignored and from is required",
       "recipient": "bob",
-      "message": {"from": "alice", "body": "hi", "extra": {"future_field": "v"}},
-      "invalid_message": {"body": "no from"}
+      "message": {
+        "from": "alice",
+        "body": "hi",
+        "extra": {
+          "future_field": "v"
+        }
+      },
+      "invalid_message": {
+        "body": "no from"
+      }
     },
     {
       "id": "B1",
@@ -54,17 +79,28 @@
       "name": "binding declares whether peer reads are possible",
       "recipient": "bob",
       "reader": "carol",
-      "message": {"from": "alice", "body": "secret for bob"}
+      "message": {
+        "from": "alice",
+        "body": "secret for bob"
+      }
     },
     {
       "id": "Q1",
       "kind": "malformed_quarantine",
       "name": "malformed items are quarantined without blocking valid inbox mail",
-      "applies_to": ["inbox"],
+      "applies_to": [
+        "inbox"
+      ],
       "recipient": "bob",
       "sender": "alice",
-      "bodies": ["first", "second"],
-      "malformed_items": ["not-a-valid-message-name.md", "also-bad.md"]
+      "bodies": [
+        "first",
+        "second"
+      ],
+      "malformed_items": [
+        "not-a-valid-message-name.md",
+        "also-bad.md"
+      ]
     },
     {
       "id": "TS1",
@@ -95,16 +131,173 @@
       "name": "a delivery collision is refused, never a silent dedup no-op, and a fresh-id retry lands (C4)",
       "recipient": "bob",
       "sender": "alice",
-      "message": {"from": "alice", "body": "m1"}
+      "message": {
+        "from": "alice",
+        "body": "m1"
+      }
     },
     {
       "id": "DR1",
       "kind": "dual_read_listing",
       "name": "old-grammar, new-grammar, and garbage names all classify correctly during the migration window",
-      "applies_to": ["inbox"],
-      "old_names": ["from-codex-agentchute_seq-00000000000000000001.md"],
-      "new_names": ["20260730T182415123456Z_from-codex-agentchute_r9f2c04aa71de4b02b6d1c33f08e95a17.md"],
-      "garbage_names": ["not-a-message.md", "README.md", "2026-05-09T16-32-00-123456Z_from-alice_msg-ab12.md"]
+      "applies_to": [
+        "inbox"
+      ],
+      "old_names": [
+        "from-codex-agentchute_seq-00000000000000000001.md"
+      ],
+      "new_names": [
+        "20260730T182415123456Z_from-codex-agentchute_r9f2c04aa71de4b02b6d1c33f08e95a17.md"
+      ],
+      "garbage_names": [
+        "not-a-message.md",
+        "README.md",
+        "2026-05-09T16-32-00-123456Z_from-alice_msg-ab12.md"
+      ]
+    },
+    {
+      "id": "FM1",
+      "kind": "frontmatter_accept",
+      "name": "the flat key:value frontmatter grammar accepts every well-formed block and extracts exactly the documented fields",
+      "accept_cases": [
+        {
+          "name": "quoted-value",
+          "input": "---\nfrom: \"codex\"\ntask: \"do the thing\"\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "task": "do the thing"
+          }
+        },
+        {
+          "name": "single-quoted-value",
+          "input": "---\nfrom: 'codex'\n---\n\nbody\n",
+          "fields": {
+            "from": "codex"
+          }
+        },
+        {
+          "name": "unquoted-value",
+          "input": "---\nfrom: codex\ntask: do-thing\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "task": "do-thing"
+          }
+        },
+        {
+          "name": "leading-ws-in-value",
+          "input": "---\nfrom:    codex\n---\n\nbody\n",
+          "fields": {
+            "from": "codex"
+          }
+        },
+        {
+          "name": "trailing-ws-in-value",
+          "input": "---\nfrom: codex   \n---\n\nbody\n",
+          "fields": {
+            "from": "codex"
+          }
+        },
+        {
+          "name": "blank-line-in-block",
+          "input": "---\nfrom: codex\n\ntask: after-blank\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "task": "after-blank"
+          }
+        },
+        {
+          "name": "crlf",
+          "input": "---\r\nfrom: codex\r\ntask: t\r\n---\r\n\r\nbody\r\n",
+          "fields": {
+            "from": "codex",
+            "task": "t"
+          }
+        },
+        {
+          "name": "list-value",
+          "input": "---\nfrom: codex\nworking_repos:\n  - /a\n  - /b\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "working_repos": ""
+          }
+        },
+        {
+          "name": "empty-value",
+          "input": "---\nfrom: codex\ntask:\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "task": ""
+          }
+        },
+        {
+          "name": "value-with-colon",
+          "input": "---\nfrom: codex\ntask: a: b: c\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "task": "a: b: c"
+          }
+        },
+        {
+          "name": "value-with-hash",
+          "input": "---\nfrom: codex\ntask: trailing # not-a-comment\n---\n\nbody\n",
+          "fields": {
+            "from": "codex",
+            "task": "trailing # not-a-comment"
+          }
+        },
+        {
+          "name": "ws-around-delim",
+          "input": "---\nfrom: codex\n  ---  \n\nbody\n",
+          "fields": {
+            "from": "codex"
+          }
+        },
+        {
+          "name": "body-only",
+          "input": "no frontmatter, just body\n",
+          "fields": {}
+        },
+        {
+          "name": "reply-required-true",
+          "input": "---\nmessage_id: m1\nfrom: codex\nreply_required: true\n---\n\nbody\n",
+          "fields": {
+            "message_id": "m1",
+            "from": "codex",
+            "reply_required": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "FM2",
+      "kind": "frontmatter_reject",
+      "name": "the same grammar hard-rejects every malformed block: indentation, duplicate keys, non-key:value lines (including comments), an empty key, and a missing close",
+      "reject_cases": [
+        {
+          "name": "indented-line",
+          "input": "---\nfrom: codex\n  task: indented\n---\n\nbody\n"
+        },
+        {
+          "name": "comment-line",
+          "input": "---\n# a comment\nfrom: codex\n---\n\nbody\n"
+        },
+        {
+          "name": "missing-close",
+          "input": "---\nfrom: codex\ntask: t\n\nbody without close\n"
+        },
+        {
+          "name": "dup-key",
+          "input": "---\nfrom: codex\nfrom: gemini-cli\n---\n\nbody\n"
+        },
+        {
+          "name": "non-keyvalue-line",
+          "input": "---\nfrom: codex\nthis is just prose\n---\n\nbody\n"
+        },
+        {
+          "name": "empty-key",
+          "input": "---\n: value\n---\n\nbody\n"
+        }
+      ]
     }
   ]
 }

--- a/conformance/vectors_test.go
+++ b/conformance/vectors_test.go
@@ -43,6 +43,20 @@ type testVector struct {
 	OldNames     []string `json:"old_names,omitempty"`
 	NewNames     []string `json:"new_names,omitempty"`
 	GarbageNames []string `json:"garbage_names,omitempty"`
+
+	// FM1/FM2 (frontmatter_accept/frontmatter_reject): the one flat
+	// key:value envelope grammar's accept and reject tables (v2.5 plan B8),
+	// promoted from internal/loop/frontmatter_characterization_test.go.
+	AcceptCases []fmCase `json:"accept_cases,omitempty"`
+	RejectCases []fmCase `json:"reject_cases,omitempty"`
+}
+
+// fmCase is one FM1/FM2 row: a named input and, for FM1, the exact flat
+// field map ParseFrontmatterFields must return for it.
+type fmCase struct {
+	Name   string            `json:"name"`
+	Input  string            `json:"input"`
+	Fields map[string]string `json:"fields,omitempty"`
 }
 
 type vectorMsg struct {
@@ -87,7 +101,7 @@ func loadVectors(t *testing.T) map[string]testVector {
 		}
 		out[v.ID] = v
 	}
-	for _, id := range []string{"R1", "D1", "D2", "O1", "C1", "E1", "B1", "Q1", "TS1", "TS2", "TS3", "DR1"} {
+	for _, id := range []string{"R1", "D1", "D2", "O1", "C1", "E1", "B1", "Q1", "TS1", "TS2", "TS3", "DR1", "FM1", "FM2"} {
 		if _, ok := out[id]; !ok {
 			t.Fatalf("missing vector %s", id)
 		}

--- a/internal/loop/frontmatter_characterization_test.go
+++ b/internal/loop/frontmatter_characterization_test.go
@@ -1,74 +1,41 @@
 package loop
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
-// This file CHARACTERIZES the current behavior of the frontmatter parsers
-// that historically caused validator/recorder skew (WI-10). It is a
-// behavior snapshot, NOT an aspiration: every assertion below documents what
-// the code does TODAY. If a future change alters these outputs, that is a
-// real behavior change and must be justified, not silently re-baselined.
+// This file CHARACTERIZES the behavior of the single frontmatter parser
+// (parseFrontmatter, registration.go) as seen through the two message-level
+// entry points that wrap it: ValidateMessageFrontmatter (the §11.1 malformed
+// gate) and ParseMessageFrontmatter (the field extractor). It is a behavior
+// snapshot, NOT an aspiration: every assertion below documents what the code
+// does TODAY. If a future change alters these outputs, that is a real
+// behavior change and must be justified, not silently re-baselined.
 //
-// Originally characterized THREE parsers; parser A (InferSenderFromFrontmatter)
-// was deleted in v2.5 plan A6 along with its sole production caller (the
-// §11.1 corrective-notify path) — this file dropped its A-specific
-// assertions accordingly. Full consolidation to ONE parser (dropping the B
-// vs C distinction below too) is v2.5 plan B8's job, not this one.
+// History: originally characterized THREE parsers. Parser A
+// (InferSenderFromFrontmatter) was deleted in v2.5 plan A6 along with its
+// sole production caller. Parser C (ParseMessageFrontmatter's own ad-hoc
+// lenient scanner) was deleted in v2.5 plan B8 — it now routes through
+// parseFrontmatter (parser B) like everything else in this package, closing
+// the validator/recorder skew WI-10 named (a message could be GATED one way
+// by B and have its fields EXTRACTED a different way by C). There is now
+// exactly one grammar; the fixtures below are its accept/reject vectors,
+// promoted to conformance/vectors/core.json as FM1/FM2.
 //
-// The two parsers still under characterization:
-//
-//	B. parseFrontmatter (registration.go) — STRICT key:value parser. Returns
-//	   (fields, body, error). Rejects indentation, non-key:value lines, dup
-//	   keys, missing close. Also reached via ValidateMessageFrontmatter, which
-//	   runs it as a pure validity GATE over message content.
-//	C. ParseMessageFrontmatter (message.go) — LENIENT key:value parser. Returns
-//	   map[string]string. Skips comments/blank lines, ignores non-key:value
-//	   lines, last-write-wins on dup keys, strips surrounding quotes.
-//
-// The skew that motivated WI-10: a message is GATED by B (via
-// ValidateMessageFrontmatter) but its fields are EXTRACTED by C. If an input
-// passes B but C reads it differently (or vice-versa), the recorder and the
-// validator disagree.
-
-// fmProbe runs both remaining parsers over one input and returns a comparable
-// snapshot. We feed C the raw content; B gets the CRLF-normalized text
-// exactly as ValidateMessageFrontmatter does.
-type fmProbe struct {
-	// B: parseFrontmatter (strict). bErr is the error string ("" if nil).
-	bErr    string
-	bFields map[string]string // scalar values only, for comparison
-	bBody   string
-	// C: ParseMessageFrontmatter (lenient)
-	cMap map[string]string
-}
-
-func probeFrontmatter(t *testing.T, content string) fmProbe {
-	t.Helper()
-	p := fmProbe{}
-
-	// B (strict).
-	fields, body, err := parseFrontmatter(content)
-	if err != nil {
-		p.bErr = err.Error()
-	} else {
-		p.bFields = map[string]string{}
-		for k, v := range fields {
-			p.bFields[k] = v.scalar
-		}
-		p.bBody = body
-	}
-
-	// C (lenient).
-	p.cMap = ParseMessageFrontmatter([]byte(content))
-
-	return p
-}
+// B8 REAL BEHAVIOR CHANGES for message frontmatter (not just the
+// plan-sanctioned dup-key/indentation tightening) — see the PR body for the
+// full list:
+//   - `#` comment lines and other non-key:value prose lines now reject the
+//     WHOLE block (previously silently skipped by parser C).
+//   - An empty-key line (`: value`) now rejects the whole block (previously
+//     recorded under an empty-string key).
+//   - Quoted values with backslash escapes are now unquoted via
+//     strconv.Unquote (previously a blunt strings.Trim left escapes literal).
+//   - `null`/`~` values now collapse to empty string (previously kept as
+//     literal text).
 
 // frontmatterFixtures is the shared fixture set covering the dimensions the
-// task calls out: quoting, whitespace, indentation, comments, blank lines,
-// CRLF, missing close, dup keys, lists, empty values, and `:`/`#` in values.
+// grammar cares about: quoting, whitespace, indentation, comments, blank
+// lines, CRLF, missing close, dup keys, lists, empty values, and `:`/`#` in
+// values. This is the FM1/FM2 vector source (conformance/vectors/core.json).
 func frontmatterFixtures() map[string]string {
 	return map[string]string{
 		"quoted-value": "---\n" +
@@ -99,259 +66,275 @@ func frontmatterFixtures() map[string]string {
 	}
 }
 
-// TestFrontmatterCharacterization_Snapshot drives both remaining parsers over
-// the shared fixtures and emits a comparison table (visible with -v). It does
-// not assert; the targeted tests below pin the load-bearing comparisons. Run
-// with `go test -run Characterization -v ./internal/loop` to see the table.
-func TestFrontmatterCharacterization_Snapshot(t *testing.T) {
+// frontmatterAcceptCases is FM1: fixture name -> the exact flat field map
+// ParseMessageFrontmatter must return once ValidateMessageFrontmatter has
+// confirmed the block is well-formed. "body-only" has no frontmatter block
+// at all, which is valid-but-empty per §6.4, not a rejection.
+func frontmatterAcceptCases() map[string]map[string]string {
+	return map[string]map[string]string{
+		"quoted-value":         {"from": "codex", "task": "do the thing"},
+		"single-quoted-value":  {"from": "codex"},
+		"unquoted-value":       {"from": "codex", "task": "do-thing"},
+		"leading-ws-in-value":  {"from": "codex"},
+		"trailing-ws-in-value": {"from": "codex"},
+		"blank-line-in-block":  {"from": "codex", "task": "after-blank"},
+		"crlf":                 {"from": "codex", "task": "t"},
+		"list-value":           {"from": "codex", "working_repos": ""},
+		"empty-value":          {"from": "codex", "task": ""},
+		"value-with-colon":     {"from": "codex", "task": "a: b: c"},
+		"value-with-hash":      {"from": "codex", "task": "trailing # not-a-comment"},
+		"ws-around-delim":      {"from": "codex"},
+		"body-only":            {},
+		"reply-required-true":  {"message_id": "m1", "from": "codex", "reply_required": "true"},
+	}
+}
+
+// frontmatterRejectCases is FM2: fixture names whose block
+// ValidateMessageFrontmatter must error on, and whose ParseMessageFrontmatter
+// must therefore return an empty map.
+func frontmatterRejectCases() []string {
+	return []string{
+		"indented-line",
+		"comment-line",
+		"missing-close",
+		"dup-key",
+		"non-keyvalue-line",
+		"empty-key",
+	}
+}
+
+// TestFrontmatterFixtures_AllClassified guards against a fixture being added
+// without an FM1/FM2 classification (or a classification without a fixture).
+func TestFrontmatterFixtures_AllClassified(t *testing.T) {
 	fx := frontmatterFixtures()
-	names := make([]string, 0, len(fx))
-	for n := range fx {
-		names = append(names, n)
+	classified := map[string]bool{}
+	for name := range frontmatterAcceptCases() {
+		classified[name] = true
 	}
-	// deterministic order
-	for i := 0; i < len(names); i++ {
-		for j := i + 1; j < len(names); j++ {
-			if names[j] < names[i] {
-				names[i], names[j] = names[j], names[i]
+	for _, name := range frontmatterRejectCases() {
+		classified[name] = true
+	}
+	for name := range fx {
+		if !classified[name] {
+			t.Errorf("fixture %q has no FM1/FM2 classification", name)
+		}
+	}
+	for name := range classified {
+		if _, ok := fx[name]; !ok {
+			t.Errorf("classified case %q has no fixture", name)
+		}
+	}
+}
+
+// TestFrontmatterAccept_FM1 drives the accept table: ValidateMessageFrontmatter
+// must not error, and ParseMessageFrontmatter must return exactly the
+// documented field map.
+func TestFrontmatterAccept_FM1(t *testing.T) {
+	fx := frontmatterFixtures()
+	for name, want := range frontmatterAcceptCases() {
+		in, ok := fx[name]
+		if !ok {
+			t.Fatalf("fixture %q not found", name)
+		}
+		if err := ValidateMessageFrontmatter([]byte(in)); err != nil {
+			t.Fatalf("%s: expected ACCEPT, got error: %v", name, err)
+		}
+		got := ParseMessageFrontmatter([]byte(in))
+		if len(got) != len(want) {
+			t.Fatalf("%s: field count mismatch: got %v, want %v", name, got, want)
+		}
+		for k, v := range want {
+			if got[k] != v {
+				t.Fatalf("%s: field %q: got %q, want %q (map=%v)", name, k, got[k], v, got)
 			}
 		}
 	}
-	for _, n := range names {
-		p := probeFrontmatter(t, fx[n])
-		bSummary := "ok " + mapStr(p.bFields)
-		if p.bErr != "" {
-			bSummary = "ERR(" + p.bErr + ")"
+}
+
+// TestFrontmatterReject_FM2 drives the reject table: ValidateMessageFrontmatter
+// must error, and ParseMessageFrontmatter must return an empty map (the two
+// entry points can no longer disagree — this is the WI-10 fix).
+func TestFrontmatterReject_FM2(t *testing.T) {
+	fx := frontmatterFixtures()
+	for _, name := range frontmatterRejectCases() {
+		in, ok := fx[name]
+		if !ok {
+			t.Fatalf("fixture %q not found", name)
 		}
-		t.Logf("%-22s | B=%s | C=%s",
-			n, bSummary, mapStr(p.cMap))
+		if err := ValidateMessageFrontmatter([]byte(in)); err == nil {
+			t.Fatalf("%s: expected REJECT, got no error", name)
+		}
+		if got := ParseMessageFrontmatter([]byte(in)); len(got) != 0 {
+			t.Fatalf("%s: rejected block must extract as empty map, got %v", name, got)
+		}
 	}
 }
 
-func mapStr(m map[string]string) string {
-	if m == nil {
-		return "<nil>"
-	}
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	for i := 0; i < len(keys); i++ {
-		for j := i + 1; j < len(keys); j++ {
-			if keys[j] < keys[i] {
-				keys[i], keys[j] = keys[j], keys[i]
-			}
-		}
-	}
-	var b strings.Builder
-	b.WriteByte('{')
-	for i, k := range keys {
-		if i > 0 {
-			b.WriteString(", ")
-		}
-		b.WriteString(k)
-		b.WriteByte('=')
-		b.WriteString(m[k])
-	}
-	b.WriteByte('}')
-	return b.String()
-}
+// --- Focused characterization tests (named, for revert-verification) ---
 
-// --- Targeted characterization assertions (pin current behavior) ---
-
-// strictGate reports whether parseFrontmatter (parser B, the validity gate used
-// by ValidateMessageFrontmatter) ACCEPTS the input.
-func strictGate(content string) bool {
-	_, _, err := parseFrontmatter(content)
-	return err == nil
-}
-
-// TestChar_StrictRejectsIndentation pins that the strict parser (B) rejects an
-// indented line, while the lenient parser (C) silently absorbs it.
-func TestChar_StrictRejectsIndentation(t *testing.T) {
+// TestChar_IndentedLineRejected pins the plan-sanctioned tightening: an
+// indented continuation line now rejects the whole block. Before B8,
+// ParseMessageFrontmatter silently absorbed it as its own key.
+func TestChar_IndentedLineRejected(t *testing.T) {
 	in := "---\nfrom: codex\n  task: indented\n---\n\nbody\n"
-	if strictGate(in) {
-		t.Fatal("B: expected strict parser to REJECT indented line")
+	if err := ValidateMessageFrontmatter([]byte(in)); err == nil {
+		t.Fatal("expected indented continuation line to be REJECTED")
 	}
-	c := ParseMessageFrontmatter([]byte(in))
-	// C trims each line, so "  task: indented" becomes "task: indented".
-	if c["task"] != "indented" {
-		t.Fatalf("C: want task=indented, got %q (map=%v)", c["task"], c)
-	}
-	// from is still readable by C and A.
-	if c["from"] != "codex" {
-		t.Fatalf("C: want from=codex, got %q", c["from"])
+	if got := ParseMessageFrontmatter([]byte(in)); len(got) != 0 {
+		t.Fatalf("rejected block must extract as empty map, got %v", got)
 	}
 }
 
-// TestChar_StrictRejectsNonKeyValueLine pins that a prose line inside the block
-// is rejected by B but ignored by C.
-func TestChar_StrictRejectsNonKeyValueLine(t *testing.T) {
+// TestChar_NonKeyValueLineRejected pins that a prose line inside the block
+// (no colon) rejects the whole block. Before B8, ParseMessageFrontmatter
+// silently skipped it.
+func TestChar_NonKeyValueLineRejected(t *testing.T) {
 	in := "---\nfrom: codex\nthis is just prose\n---\n\nbody\n"
-	if strictGate(in) {
-		t.Fatal("B: expected strict parser to REJECT non-key:value line")
+	if err := ValidateMessageFrontmatter([]byte(in)); err == nil {
+		t.Fatal("expected non-key:value line to be REJECTED")
 	}
-	c := ParseMessageFrontmatter([]byte(in))
-	if c["from"] != "codex" {
-		t.Fatalf("C: want from=codex, got %q (map=%v)", c["from"], c)
+	if got := ParseMessageFrontmatter([]byte(in)); len(got) != 0 {
+		t.Fatalf("rejected block must extract as empty map, got %v", got)
 	}
 }
 
-// TestChar_StrictRejectsDupKey pins B rejecting a duplicate key; C is
+// TestChar_DupKeyRejected pins the plan-sanctioned tightening: a duplicate
+// key now rejects the whole block. Before B8, ParseMessageFrontmatter was
 // last-write-wins.
-func TestChar_StrictRejectsDupKey(t *testing.T) {
+func TestChar_DupKeyRejected(t *testing.T) {
 	in := "---\nfrom: codex\nfrom: gemini-cli\n---\n\nbody\n"
-	if strictGate(in) {
-		t.Fatal("B: expected strict parser to REJECT duplicate key")
+	if err := ValidateMessageFrontmatter([]byte(in)); err == nil {
+		t.Fatal("expected duplicate key to be REJECTED")
 	}
-	c := ParseMessageFrontmatter([]byte(in))
-	if c["from"] != "gemini-cli" {
-		t.Fatalf("C: dup key last-write-wins; want gemini-cli, got %q", c["from"])
+	if got := ParseMessageFrontmatter([]byte(in)); len(got) != 0 {
+		t.Fatalf("rejected block must extract as empty map, got %v", got)
 	}
 }
 
-// TestChar_CommentLine pins that B rejects a `#` comment line (it is not
-// key:value) while C explicitly skips it.
-func TestChar_CommentLine(t *testing.T) {
+// TestChar_CommentLineRejected pins a REAL (not plan-named) B8 behavior
+// change: a `#` comment line now makes the whole block unparseable, since
+// parseFrontmatter has no comment syntax and message frontmatter is no
+// longer more lenient about this than registration frontmatter. Before B8,
+// ParseMessageFrontmatter silently skipped the comment and still recorded
+// `from`.
+func TestChar_CommentLineRejected(t *testing.T) {
 	in := "---\n# a comment\nfrom: codex\n---\n\nbody\n"
-	if strictGate(in) {
-		t.Fatal("B: expected strict parser to REJECT comment line (not key:value)")
+	if err := ValidateMessageFrontmatter([]byte(in)); err == nil {
+		t.Fatal("expected comment line to be REJECTED (no comment syntax in the single engine)")
 	}
-	c := ParseMessageFrontmatter([]byte(in))
-	if _, ok := c["#"]; ok {
-		t.Fatalf("C: comment must be skipped, got map=%v", c)
-	}
-	if c["from"] != "codex" {
-		t.Fatalf("C: want from=codex, got %q", c)
+	if got := ParseMessageFrontmatter([]byte(in)); len(got) != 0 {
+		t.Fatalf("rejected block must extract as empty map (from is NO LONGER recovered), got %v", got)
 	}
 }
 
-// TestChar_ValueWithColon pins that both B and C keep everything after the
-// FIRST colon as the value (strings.Cut / IndexByte on first ':').
+// TestChar_EmptyKeyRejected pins another REAL B8 behavior change: a line
+// with nothing before the colon now rejects the whole block. Before B8,
+// ParseMessageFrontmatter recorded a spurious empty-string-keyed entry.
+func TestChar_EmptyKeyRejected(t *testing.T) {
+	in := "---\n: value\n---\n\nbody\n"
+	if err := ValidateMessageFrontmatter([]byte(in)); err == nil {
+		t.Fatal("expected empty key to be REJECTED")
+	}
+	if got := ParseMessageFrontmatter([]byte(in)); len(got) != 0 {
+		t.Fatalf("rejected block must extract as empty map, got %v", got)
+	}
+}
+
+// TestChar_ValueWithColon pins that everything after the FIRST colon is kept
+// as the value (strings.Cut on first ':').
 func TestChar_ValueWithColon(t *testing.T) {
 	in := "---\nfrom: codex\ntask: a: b: c\n---\n\nbody\n"
-	if !strictGate(in) {
-		t.Fatal("B: expected strict parser to ACCEPT value-with-colon")
+	if err := ValidateMessageFrontmatter([]byte(in)); err != nil {
+		t.Fatalf("expected ACCEPT, got %v", err)
 	}
-	fields, _, _ := parseFrontmatter(in)
-	if got := fields.scalar("task"); got != "a: b: c" {
-		t.Fatalf("B: want task=%q, got %q", "a: b: c", got)
-	}
-	c := ParseMessageFrontmatter([]byte(in))
-	if c["task"] != "a: b: c" {
-		t.Fatalf("C: want task=%q, got %q", "a: b: c", c["task"])
+	if got := ParseMessageFrontmatter([]byte(in))["task"]; got != "a: b: c" {
+		t.Fatalf("want task=%q, got %q", "a: b: c", got)
 	}
 }
 
-// TestChar_QuoteStripping pins the divergence in HOW B and C strip quotes.
-// B (cleanScalar) uses strconv.Unquote first (interprets escapes) then a
-// simple paired-quote strip. C (strings.Trim) strips ANY leading/trailing
-// run of quote characters.
+// TestChar_QuoteStripping pins a REAL B8 behavior change: quoted values now
+// run through cleanScalar (strconv.Unquote first, falling back to a
+// paired-quote strip), so backslash escapes are INTERPRETED. Before B8,
+// ParseMessageFrontmatter did a blunt strings.Trim(val, `"'`) and left
+// escapes literal.
 func TestChar_QuoteStripping(t *testing.T) {
-	// Simple paired double-quote: both agree.
 	in := "---\nfrom: codex\ntask: \"hello\"\n---\n\nbody\n"
-	fields, _, _ := parseFrontmatter(in)
-	c := ParseMessageFrontmatter([]byte(in))
-	if fields.scalar("task") != "hello" {
-		t.Fatalf("B: want hello, got %q", fields.scalar("task"))
-	}
-	if c["task"] != "hello" {
-		t.Fatalf("C: want hello, got %q", c["task"])
+	if got := ParseMessageFrontmatter([]byte(in))["task"]; got != "hello" {
+		t.Fatalf("want hello, got %q", got)
 	}
 
-	// A value that is a quote-balanced string with embedded escape: B unquotes
-	// (interprets \t), C strips outer quotes only.
 	in2 := "---\nfrom: codex\ntask: \"a\\tb\"\n---\n\nbody\n"
-	fields2, _, _ := parseFrontmatter(in2)
-	c2 := ParseMessageFrontmatter([]byte(in2))
-	if fields2.scalar("task") != "a\tb" {
-		t.Fatalf("B: strconv.Unquote interprets escape; want a<TAB>b, got %q", fields2.scalar("task"))
-	}
-	if c2["task"] != "a\\tb" {
-		t.Fatalf("C: literal quote-strip keeps backslash; want a\\tb, got %q", c2["task"])
+	if got := ParseMessageFrontmatter([]byte(in2))["task"]; got != "a\tb" {
+		t.Fatalf("strconv.Unquote interprets escape; want a<TAB>b, got %q", got)
 	}
 }
 
-// TestChar_NullSentinel pins that B maps `null`/`~` to empty string
-// (cleanScalar) while C keeps the literal text.
+// TestChar_NullSentinel pins a REAL B8 behavior change: `null`/`~` now map to
+// empty string in message frontmatter too (cleanScalar, shared with
+// registration). Before B8, ParseMessageFrontmatter kept the literal text.
 func TestChar_NullSentinel(t *testing.T) {
 	in := "---\nfrom: codex\ntask: null\n---\n\nbody\n"
-	fields, _, _ := parseFrontmatter(in)
-	c := ParseMessageFrontmatter([]byte(in))
-	if fields.scalar("task") != "" {
-		t.Fatalf("B: null sentinel -> empty; got %q", fields.scalar("task"))
-	}
-	if c["task"] != "null" {
-		t.Fatalf("C: literal; want null, got %q", c["task"])
+	if got := ParseMessageFrontmatter([]byte(in))["task"]; got != "" {
+		t.Fatalf("null sentinel -> empty string; got %q", got)
 	}
 }
 
-// TestChar_WhitespaceAroundDelimiter pins that BOTH B and C treat a
-// whitespace-padded `---` line as a delimiter (TrimSpace before compare). This
-// is the codex-flagged consistency that was already fixed.
+// TestChar_WhitespaceAroundDelimiter pins that a whitespace-padded `---` line
+// still closes the block (TrimSpace before compare).
 func TestChar_WhitespaceAroundDelimiter(t *testing.T) {
 	in := "---\nfrom: codex\ntask: t\n  ---  \n\nbody\n"
-	if !strictGate(in) {
-		t.Fatal("B: padded --- must close the block")
+	if err := ValidateMessageFrontmatter([]byte(in)); err != nil {
+		t.Fatalf("padded --- must close the block: %v", err)
 	}
-	c := ParseMessageFrontmatter([]byte(in))
-	if c["task"] != "t" || c["from"] != "codex" {
-		t.Fatalf("C: padded --- must close block; got map=%v", c)
+	got := ParseMessageFrontmatter([]byte(in))
+	if got["task"] != "t" || got["from"] != "codex" {
+		t.Fatalf("padded --- must close block; got map=%v", got)
 	}
 }
 
-// TestChar_MissingClose pins that B ERRORS on a missing closing `---`, while C
-// returns an EMPTY map (firstFrontmatterBlock returns ok=false).
-// ValidateMessageFrontmatter surfaces B's error.
+// TestChar_MissingClose pins that a missing closing `---` errors, and
+// ParseMessageFrontmatter returns an empty map for it.
 func TestChar_MissingClose(t *testing.T) {
 	in := "---\nfrom: codex\ntask: t\n\nbody without close\n"
-	if strictGate(in) {
-		t.Fatal("B: missing close must error")
+	if err := ValidateMessageFrontmatter([]byte(in)); err == nil {
+		t.Fatal("missing close must error")
 	}
-	c := ParseMessageFrontmatter([]byte(in))
-	if len(c) != 0 {
-		t.Fatalf("C: missing close -> empty map; got %v", c)
+	if got := ParseMessageFrontmatter([]byte(in)); len(got) != 0 {
+		t.Fatalf("missing close -> empty map; got %v", got)
 	}
 }
 
-// TestChar_EmptyValueListVsScalar pins the empty-value divergence. B treats a
-// bare `task:` as a potential LIST header (scalar empty, list possibly empty);
-// C records an empty-string scalar.
-func TestChar_EmptyValueListVsScalar(t *testing.T) {
+// TestChar_EmptyValueScalar pins that a bare `task:` (no list items follow)
+// records an empty-string scalar.
+func TestChar_EmptyValueScalar(t *testing.T) {
 	in := "---\nfrom: codex\ntask:\n---\n\nbody\n"
-	fields, _, err := parseFrontmatter(in)
-	if err != nil {
-		t.Fatalf("B: unexpected error %v", err)
+	if err := ValidateMessageFrontmatter([]byte(in)); err != nil {
+		t.Fatalf("unexpected error %v", err)
 	}
-	if fields.scalar("task") != "" {
-		t.Fatalf("B: empty value scalar should be empty, got %q", fields.scalar("task"))
-	}
-	c := ParseMessageFrontmatter([]byte(in))
-	if v, ok := c["task"]; !ok || v != "" {
-		t.Fatalf("C: empty value -> empty-string scalar present; got map=%v", c)
+	got := ParseMessageFrontmatter([]byte(in))
+	if v, ok := got["task"]; !ok || v != "" {
+		t.Fatalf("empty value -> empty-string scalar present; got map=%v", got)
 	}
 }
 
-// TestChar_ListValue pins that B parses `- ` list items into a list field
-// (scalar empty), while C records only the HEADER key with an empty value and
-// silently treats the `- /a` lines as their own (malformed) keys are NOT —
-// actually `- /a` has no colon so C SKIPS them. Document that.
+// TestChar_ListValue pins that `- ` list items parse into a list field
+// (parseFrontmatter's own fields.list), while ParseMessageFrontmatter's flat
+// map surfaces only the header key with an empty scalar — no current message
+// field is list-valued, so this is documentation, not a load-bearing path.
 func TestChar_ListValue(t *testing.T) {
 	in := "---\nfrom: codex\nworking_repos:\n  - /a\n  - /b\n---\n\nbody\n"
 	fields, _, err := parseFrontmatter(in)
 	if err != nil {
-		t.Fatalf("B: list parse unexpected error %v", err)
+		t.Fatalf("list parse unexpected error %v", err)
 	}
 	if got := fields.list("working_repos"); len(got) != 2 || got[0] != "/a" || got[1] != "/b" {
-		t.Fatalf("B: want [/a /b], got %v", got)
+		t.Fatalf("want [/a /b], got %v", got)
 	}
-	c := ParseMessageFrontmatter([]byte(in))
-	// C: header has empty value; `- /a` lines contain a... no colon? "- /a"
-	// has no ':' so IndexByte returns -1 and the line is skipped.
-	if v, ok := c["working_repos"]; !ok || v != "" {
-		t.Fatalf("C: want working_repos= (empty), got %v (map=%v)", v, c)
+	got := ParseMessageFrontmatter([]byte(in))
+	if v, ok := got["working_repos"]; !ok || v != "" {
+		t.Fatalf("want working_repos= (empty), got %v (map=%v)", v, got)
 	}
-	if len(c) != 2 { // from + working_repos
-		t.Fatalf("C: list item lines must be skipped (no colon); got map=%v", c)
+	if len(got) != 2 {
+		t.Fatalf("want exactly 2 keys (from + working_repos); got map=%v", got)
 	}
 }

--- a/internal/loop/frontmatter_characterization_test.go
+++ b/internal/loop/frontmatter_characterization_test.go
@@ -63,6 +63,19 @@ func frontmatterFixtures() map[string]string {
 		"empty-key":            "---\n: value\n---\n\nbody\n",
 		"body-only":            "no frontmatter, just body\n",
 		"reply-required-true":  "---\nmessage_id: m1\nfrom: codex\nreply_required: true\n---\n\nbody\n",
+
+		// Added after codex's second-round finding on PR #100: the §6.4
+		// grammar block claimed a key charset (ALPHA/DIGIT/_) and a fixed
+		// 2-space list indent that NEITHER implementation actually enforces,
+		// and FM1 never pinned the escaped-quote / null-sentinel RESULT
+		// values (only that the block parsed). These fixtures close both gaps.
+		"unusual-key-chars":     "---\nweird key-name!: value\nfrom: codex\n---\n\nbody\n",
+		"list-zero-indent":      "---\nfrom: codex\nworking_repos:\n- /a\n- /b\n---\n\nbody\n",
+		"list-tab-indent":       "---\nfrom: codex\nworking_repos:\n\t- /a\n\t- /b\n---\n\nbody\n",
+		"quoted-value-escaped":  "---\nfrom: codex\ntask: \"a\\tb\"\n---\n\nbody\n",
+		"null-value":            "---\nfrom: codex\ntask: null\n---\n\nbody\n",
+		"tilde-value":           "---\nfrom: codex\ntask: ~\n---\n\nbody\n",
+		"list-item-missing-gap": "---\nfrom: codex\nworking_repos:\n-nospace\n---\n\nbody\n",
 	}
 }
 
@@ -86,6 +99,13 @@ func frontmatterAcceptCases() map[string]map[string]string {
 		"ws-around-delim":      {"from": "codex"},
 		"body-only":            {},
 		"reply-required-true":  {"message_id": "m1", "from": "codex", "reply_required": "true"},
+
+		"unusual-key-chars":    {"weird key-name!": "value", "from": "codex"},
+		"list-zero-indent":     {"from": "codex", "working_repos": ""},
+		"list-tab-indent":      {"from": "codex", "working_repos": ""},
+		"quoted-value-escaped": {"from": "codex", "task": "a\tb"},
+		"null-value":           {"from": "codex", "task": ""},
+		"tilde-value":          {"from": "codex", "task": ""},
 	}
 }
 
@@ -100,6 +120,7 @@ func frontmatterRejectCases() []string {
 		"dup-key",
 		"non-keyvalue-line",
 		"empty-key",
+		"list-item-missing-gap",
 	}
 }
 

--- a/internal/loop/inbox.go
+++ b/internal/loop/inbox.go
@@ -51,23 +51,6 @@ func InferSenderFromFilename(filename string) (string, bool) {
 	return "", false
 }
 
-// firstFrontmatterBlock returns the content between the file's leading `---`
-// line and the next `---` line, exclusive of the delimiters. Returns ok=false
-// if the file does not start with `---` or no closing delimiter is found.
-func firstFrontmatterBlock(content []byte) (string, bool) {
-	text := strings.ReplaceAll(string(content), "\r\n", "\n")
-	lines := strings.Split(text, "\n")
-	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
-		return "", false
-	}
-	for i := 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) == "---" {
-			return strings.Join(lines[1:i], "\n"), true
-		}
-	}
-	return "", false
-}
-
 // QuarantineInboxFile moves srcPath into malformedDir per AGENTCHUTE.md §11.1,
 // with a collision-resistant name `<quarantine-ts>_to-<recipient>_<original>`.
 // The destination is created atomically; an existing quarantined file with

--- a/internal/loop/message.go
+++ b/internal/loop/message.go
@@ -113,9 +113,10 @@ func ValidateMessageFrontmatter(content []byte) error {
 }
 
 // ExtractMessageBody returns the body portion of a message (everything
-// after the closing frontmatter `---` line). Honors the same lenient
-// delimiter semantics as ParseMessageFrontmatter (trimmed `---` opens
-// and closes the block — surrounding whitespace tolerated per §6.4).
+// after the closing frontmatter `---` line). Body-splitting only depends on
+// where the delimiters are, never on whether the key:value content between
+// them parses, so this shares frontmatterClosingLine (registration.go) with
+// parseFrontmatter rather than validating the block itself (v2.5 plan B8).
 // Returns the full content unchanged when there's no frontmatter block
 // (body-only is valid per §6.4) or when the open delimiter has no
 // matching close.
@@ -125,49 +126,40 @@ func ExtractMessageBody(content []byte) string {
 	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
 		return text
 	}
-	for i := 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) == "---" {
-			// Body starts on the line after the closing delimiter; a
-			// blank line immediately following is conventional but not
-			// required, so don't trim it.
-			return strings.Join(lines[i+1:], "\n")
-		}
+	closing := frontmatterClosingLine(lines)
+	if closing == -1 {
+		return text
 	}
-	return text
+	// Body starts on the line after the closing delimiter; a blank line
+	// immediately following is conventional but not required, so don't trim it.
+	return strings.Join(lines[closing+1:], "\n")
 }
 
 // ParseMessageFrontmatter extracts the leading frontmatter block from a
-// message's bytes into a flat key/value map, honoring the same lenient
-// delimiter semantics as ValidateMessageFrontmatter (a trimmed `---` line
-// opens the block, a later trimmed `---` line closes it — surrounding
-// whitespace tolerated per §6.4). Body-only messages return an empty
-// map. Malformed blocks (opening `---` with no close) also return an empty
-// map; callers that need malformed-vs-absent distinction should call
-// ValidateMessageFrontmatter first.
-//
-// Mirrors the in-package parser used by `pending` / `check` so the
-// hot-path peek (pending.readFrontmatter) and the consume path
-// (check.displayConsumed) cannot disagree on what counts as a
-// well-formed frontmatter block.
+// message's bytes into a flat key/value map, using the SAME strict engine
+// (parseFrontmatter, registration.go) as ValidateMessageFrontmatter — the two
+// can no longer disagree on what counts as a well-formed block (v2.5 plan
+// B8; this closes the validator/recorder skew WI-10 named). Body-only
+// messages return an empty map. Malformed blocks (opening `---` with no
+// close, an indented line, a non-key:value line, a duplicate key, an empty
+// key) also return an empty map; callers that need malformed-vs-absent
+// distinction should call ValidateMessageFrontmatter first. List-shaped
+// fields (e.g. working_repos) surface with an empty string, matching
+// parseFrontmatter's own scalar/list split — no current message field is
+// list-valued.
 func ParseMessageFrontmatter(content []byte) map[string]string {
 	out := map[string]string{}
-	block, ok := firstFrontmatterBlock(content)
-	if !ok {
+	text := strings.ReplaceAll(string(content), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
 		return out
 	}
-	for _, line := range strings.Split(block, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		colon := strings.IndexByte(line, ':')
-		if colon < 0 {
-			continue
-		}
-		key := strings.TrimSpace(line[:colon])
-		val := strings.TrimSpace(line[colon+1:])
-		val = strings.Trim(val, `"'`)
-		out[key] = val
+	fields, _, err := parseFrontmatter(text)
+	if err != nil {
+		return out
+	}
+	for key := range fields {
+		out[key] = fields.scalar(key)
 	}
 	return out
 }

--- a/internal/loop/registration.go
+++ b/internal/loop/registration.go
@@ -260,6 +260,26 @@ func (f frontmatterFields) list(key string) []string {
 	return append([]string(nil), values...)
 }
 
+// frontmatterClosingLine returns the index (>=1) of the first line that is a
+// trimmed `---`, or -1 if none is found. Finding the close is a purely
+// structural question, independent of whether the key:value content between
+// the delimiters is valid, so it is factored out here and shared by
+// parseFrontmatter and ExtractMessageBody (message.go) rather than each
+// re-implementing the same scan (v2.5 plan B8 — one engine).
+func frontmatterClosingLine(lines []string) int {
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			return i
+		}
+	}
+	return -1
+}
+
+// parseFrontmatter always computes body from the closing delimiter before
+// validating the key:value lines between them, and returns it even when a
+// per-line error is returned (every current caller ignores body when err !=
+// nil, and ExtractMessageBody needs it precisely in that case — a malformed
+// block still has a body worth displaying).
 func parseFrontmatter(data string) (frontmatterFields, string, error) {
 	text := strings.ReplaceAll(data, "\r\n", "\n")
 	lines := strings.Split(text, "\n")
@@ -267,16 +287,11 @@ func parseFrontmatter(data string) (frontmatterFields, string, error) {
 		return nil, "", fmt.Errorf("missing frontmatter opening ---")
 	}
 
-	closing := -1
-	for i := 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) == "---" {
-			closing = i
-			break
-		}
-	}
+	closing := frontmatterClosingLine(lines)
 	if closing == -1 {
 		return nil, "", fmt.Errorf("missing frontmatter closing ---")
 	}
+	body := strings.TrimPrefix(strings.Join(lines[closing+1:], "\n"), "\n")
 
 	fields := make(frontmatterFields)
 	for i := 1; i < closing; i++ {
@@ -285,20 +300,20 @@ func parseFrontmatter(data string) (frontmatterFields, string, error) {
 			continue
 		}
 		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
-			return nil, "", fmt.Errorf("unexpected indented line %q", line)
+			return nil, body, fmt.Errorf("unexpected indented line %q", line)
 		}
 
 		key, value, ok := strings.Cut(line, ":")
 		if !ok {
-			return nil, "", fmt.Errorf("invalid frontmatter line %q", line)
+			return nil, body, fmt.Errorf("invalid frontmatter line %q", line)
 		}
 		key = strings.TrimSpace(key)
 		value = strings.TrimSpace(value)
 		if key == "" {
-			return nil, "", fmt.Errorf("empty frontmatter key")
+			return nil, body, fmt.Errorf("empty frontmatter key")
 		}
 		if _, exists := fields[key]; exists {
-			return nil, "", fmt.Errorf("duplicate frontmatter key %q", key)
+			return nil, body, fmt.Errorf("duplicate frontmatter key %q", key)
 		}
 
 		if value != "" {
@@ -324,8 +339,6 @@ func parseFrontmatter(data string) (frontmatterFields, string, error) {
 		fields[key] = fieldValue{list: items}
 	}
 
-	body := strings.Join(lines[closing+1:], "\n")
-	body = strings.TrimPrefix(body, "\n")
 	return fields, body, nil
 }
 


### PR DESCRIPTION
## Summary

Consolidates the three historical frontmatter parsers (parser A, `InferSenderFromFrontmatter`, already deleted in A6) down to **one**: `ParseMessageFrontmatter` and `ExtractMessageBody` (message.go) now route through the strict `parseFrontmatter` engine (registration.go) instead of message.go's own ad-hoc lenient scanner. `ValidateMessageFrontmatter` already used the strict engine — so the §11.1 malformed gate and the field extractor can no longer disagree on what counts as well-formed (the WI-10 skew the plan names).

- `parseFrontmatter` now computes the block's body *before* validating the key:value lines, and returns it even when a per-line error is returned — every existing caller already discarded body on error, and this lets `ExtractMessageBody` share the same closing-delimiter scan (factored into `frontmatterClosingLine`) instead of independently re-implementing it.
- `firstFrontmatterBlock` (inbox.go) deleted — its only caller is gone. (`frontmatterFromRE`, which the plan's B8 section also names, was already deleted in A6; confirmed via `git log --all -p`.)
- Re-verified every caller per the ASK: `check.go`'s two `ParseMessageFrontmatter` call sites plus its `ValidateMessageFrontmatter` gate, `pending.go`'s `readFrontmatter` (used by both `pending` and `boot`). None of them distinguish "malformed" from "no fields extracted" beyond what `ValidateMessageFrontmatter` already gates separately, and none read list-shaped fields — the tightening is safe for all three.
- `internal/loop/frontmatter_characterization_test.go` collapsed from a B-vs-C two-parser comparison into single-parser assertions, plus new `TestFrontmatterAccept_FM1` / `TestFrontmatterReject_FM2` table tests over the same fixture set (a completeness cross-check that every fixture has a classification, and vice versa).

## Behavior changes (real, not just the plan's two named ones)

**Plan-sanctioned** (explicit "Behavioral rule" in the ASK):
- Duplicate keys now reject the whole block (was last-write-wins).
- Indented continuation lines now reject the whole block (was silently absorbed as an extra key).

**Additional, my own finding — natural consequences of routing through the same engine `parseFrontmatter` already uses for registrations, not separately pre-authorized by the plan's behavioral-rule sentence:**
- `#` comment lines now reject the whole block — `parseFrontmatter` has no comment syntax, so message frontmatter is no longer more lenient here than registration frontmatter. (Was: silently skipped, `from` still recovered.)
- Any other non-key:value prose line now rejects the whole block. (Was: silently skipped.)
- An empty-key line (`: value`) now rejects the whole block. (Was: recorded under a spurious `""` key.)
- Quoted values now interpret backslash escapes via `strconv.Unquote` (was: a blunt `strings.Trim(val, `"'`)` that left escapes literal).
- `null`/`~` values now collapse to empty string (was: kept as literal text).

All of these are *tightenings* — less silently accepted, never more. I checked what each of the three real callers does with an empty map versus a partially-populated one: none of them behave unsafely — `check.go`'s `ValidateMessageFrontmatter` gate already rejected all of the above and quarantines the file before extraction is ever reached on that path; `pending`/`boot`'s hot-path peek (`readFrontmatter`) does NOT run the gate first, so before this change it could still read a stray `reply_required`/`from` out of a block `check` would go on to quarantine — after this change both paths agree, which is the whole point of B8.

## Spec + conformance

- `AGENTCHUTE.md` §6.4 gets the actual flat key:value grammar block (not an aspirational YAML reference), explicitly noting the same engine (`parseFrontmatter`) also parses registration rows (§5.2). No broader §-level rewrite — that's B9's, per the ASK's own constraint.
- `conformance/fm.go`: an independent reimplementation of the grammar (mirrors, does not import, `internal/loop`) — matches `tsid.go`'s "prove the wire spec, not the reference code" posture from B7.
- `conformance/vectors/core.json`: new `FM1` (`frontmatter_accept`) and `FM2` (`frontmatter_reject`) vectors, promoted byte-for-byte from `frontmatter_characterization_test.go`'s fixture set. Added to the required-vector-ID list in `vectors_test.go`. New `TestFM1_Accept` / `TestFM2_Reject` in `conformance/fm_test.go`.
- `conformance/CONFORMANCE.md` and `EXTENSIONS.md` updated with a description / vector-ID list entry for FM1/FM2.

## Incidental fix (found while editing AGENTCHUTE.md's top blockquote for FM1/FM2)

The spec's own opening "Executable spec" blockquote still listed the deleted `C2` vector and omitted `TS1`/`TS2`/`TS3`/`DR1` entirely — B7-era staleness that predates this slice. Fixed it alongside the FM1/FM2 addition since I was already touching that exact paragraph; flagging explicitly since it's outside B8's own diff surface but was clearly wrong.

## Verification

Both modules: `gofmt -l .` clean, `go vet ./...` clean, `go build ./...`, `go test ./...` and `go test -race ./...` all green. `git grep frontmatterFromRE` and `git grep firstFrontmatterBlock` both empty. `conformance/cmd/acdemo` still runs.

**Revert-verified**: temporarily reintroduced a lenient-fallback shim inside `ParseMessageFrontmatter` (simulating the pre-B8 scanner) and confirmed `TestChar_DupKeyRejected`, `TestChar_IndentedLineRejected`, `TestChar_CommentLineRejected`, `TestChar_NonKeyValueLineRejected`, `TestChar_EmptyKeyRejected`, and `TestFrontmatterReject_FM2` all correctly fail against it — proving the tests catch the regression, not just passing vacuously — then removed the shim and reconfirmed green.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean (root module)
- [x] `go test ./...` and `go test -race ./...` green (root module)
- [x] Same four checks green in `conformance/`
- [x] `git grep frontmatterFromRE` / `firstFrontmatterBlock` empty
- [x] FM1/FM2 vectors agree byte-for-byte with the Go-side fixture set (both sourced from the same fixture map)
- [x] Revert-verified duplicate-key and indented-continuation rejections (plus the three additional tightenings)
- [x] Demo binary (`conformance/cmd/acdemo`) runs

Do NOT merge — reviewers: claude-code + codex.