### PR TITLE
ci: stub a codex wrapper in the release smoke so setup installs hooks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,6 +139,13 @@ jobs:
           printf '%s\n' "$metadata"
           grep -F 'vcs.modified=false' <<<"$metadata"
 
+          # setup installs hooks only for wrappers it detects on PATH; the
+          # runner has no real vendor CLIs, so stub codex the way an operator
+          # machine would have it. This also makes the smoke exercise the
+          # hook-install path that doctor then verifies.
+          printf '#!/bin/sh\nexit 0\n' >"$install_dir/codex"
+          chmod +x "$install_dir/codex"
+
           git init -q "$fixture"
           fixture_path="$install_dir:$smoke_home/.agentchute/bin:$PATH"
           (

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The repo follows a release-squash convention: each release lands on `main` as a 
 - The guard latch is best-effort defense-in-depth, never a security boundary. Coverage is stated per vendor and launch mode, including Codex hosted-tool gaps, Gemini's start-of-next-turn handler, Grok's lack of hooks, and unsupervised sessions.
 
 **Measured release delta**
-- Canonical tag-range measurement: `git diff --numstat v1.0.0..v1.5.0` = `+14,643 / -8,618` lines, net `+6,025`, across the complete unreleased range. The deletion count is measured from Git rather than copied from the implementation plan.
+- Canonical tag-range measurement: `git diff --numstat v1.0.0..v1.5.0` = `+14,650 / -8,618` lines, net `+6,032`, across the complete unreleased range. The deletion count is measured from Git rather than copied from the implementation plan.
 
 **Migration and live-pool cutover**
 


### PR DESCRIPTION
The v1.5.0 release run failed at the smoke step, before publishing: the runner has no vendor CLIs, so `setup --wrappers all` detected nothing and installed no hooks, and `doctor --as codex` correctly blocked on the missing hook (its behavior is right; the smoke's environment was unrealistic).

Fix: drop a stub `codex` executable into `$install_dir` (already first on the fixture PATH) before setup. Setup then detects it and installs hooks, as on a real operator machine — so the smoke now also exercises the hook-install path. Reproduced the failure and verified the fix locally with the workflow's exact env shape (env -i, same PATH order): doctor exits 0, blockers 0, warnings 0.

Includes the CHANGELOG delta re-measure (+14,650 / -8,618, net +6,032) since the workflow edit itself moves the number; re-verified the changelog edit doesn't move it further.

Note for merge: the release workflow runs from the tag's commit, so after merge the v1.5.0 tag (never published — the failed run stopped before `gh release create`) moves to the new merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)