### PR TITLE
fix(doctor/update): detect stale hook templates, warn on skipped refresh (v1.5.0 cutover incident)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,7 @@
       "Bash(agentchute send:*)",
       "Bash(agentchute ack:*)",
       "Bash(agentchute gate:*)",
+      "Bash(agentchute turn-end:*)",
       "Bash(agentchute boot:*)",
       "Bash(agentchute doctor:*)",
       "Bash(agentchute status:*)",
@@ -57,20 +58,23 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${AGENTCHUTE_BIN:-agentchute} guard --pre-tool-use"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} self-check --quiet"
-          },
-          {
-            "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} ack --quiet"
-          },
-          {
-            "type": "command",
-            "command": "${AGENTCHUTE_BIN:-agentchute} gate --before finish --json"
+            "command": "${AGENTCHUTE_BIN:-agentchute} turn-end --json"
           }
         ]
       }

--- a/docs/decisions/agentchute-v150-cutover-incident-and-fix.md
+++ b/docs/decisions/agentchute-v150-cutover-incident-and-fix.md
@@ -1,0 +1,54 @@
+# v1.5.0 cutover incident: stale hook templates, and the fix
+
+Status: ACCEPTED (codex decision B, ref `20260731T175038205661Z_from-codex`, 2026-07-31) — implemented in the PR that carries this document.
+Authorization: Alex ("brief the team and fix everything with a full review"); merge to main in scope, tag/release out of scope.
+
+## Incident
+
+On 2026-07-31 the fleet updated from a Protocol v2 CLI to 1.5.0 via `agentchute update`. Immediately after, every Claude Code prompt was blocked by its UserPromptSubmit hook:
+
+```
+[${AGENTCHUTE_BIN:-agentchute} poller ensure --vendor anthropic --quiet]: agentchute: unknown command "poller"
+```
+
+The installed hook templates in the control repo (`.claude/settings.json`, `.codex/hooks.json`, `.gemini/settings.json`) still invoked `poller ensure`, a subcommand the update removed. The outage lasted ~4 minutes until an operator-side `agentchute hooks install --wrapper all --scope repo --force` rewrote all three files from the 1.5.0 embedded templates.
+
+Timeline (UTC, from file mtimes, registration rows, and `setup.json`):
+
+- ~17:25 — old updater swaps the binary, re-execs the new binary's `setup`.
+- 17:27:55 — replayed setup writes `setup.json`; hook refresh skipped (below). Serve leases invalidated (designed); lanes relaunch on 1.5.0.
+- ~17:30 — stale `poller` hooks × new binary → prompts blocked fleet-wide.
+- 17:31:17 — manual `hooks install --force` rewrites all three hook files (`.bak` backups). Outage over.
+
+## Root cause
+
+Three layers, ordered cause → missing detection → compounding drift:
+
+1. **The setup replay had no wrappers to replay.** The pre-v2.5 pool state never recorded a wrapper list, so `readSetupPoolState` returned `wrappers: null`, and `cmdUpdate` maps an empty list to `--wrappers none` (`internal/cli/update.go:120-124` — deliberate: empty is the valid "none" mode, indistinguishable from missing). The replayed `setup --wrappers none` therefore installed no hook templates, while the binary moved past the installed ones. The replay also re-records `wrappers` as empty, so the state **self-perpetuates**: every future `update` of this pool would skip hook refresh the same way.
+2. **doctor could not see the breakage.** `hook_content_sanity` validates the forbidden `check` subcommand and that the binary reference resolves — it never validates referenced subcommands against the command registry (`commandHandlers`, `internal/cli/dispatch.go` — "the single source of truth for agentchute's subcommands"). A hook invoking a removed subcommand passes doctor cleanly.
+3. **The control-repo checkout compounded the confusion.** The live checkout sat ~40 commits behind main, and main's own tracked `.claude/settings.json` was a pre-1.5 hook shape (no PreToolUse guard, Stop still running `ack` + `gate`) — so both the working tree and a fresh clone disagreed with the binary's embedded templates.
+
+## Decision (option B)
+
+Detection belongs in doctor; update warns but does not hard-fail; the state repair is deferred to the operator.
+
+1. **doctor: unknown-subcommand validation (BLOCKER).** Extend `hook_content_sanity`: extract every `<binary-ref> <subcommand>` token from installed hook commands (parsed via the existing `hookCommandBody`, so `permissions.allow` entries stay out of scope) and require the token to be a registered command. Message names the wrapper file and the unknown token, and gives the fix (`agentchute hooks install --wrapper all --scope repo --force`). This turns the incident's silent failure mode into a named blocker.
+2. **update: loud warning when hook refresh is skipped.** When the replayed wrapper list resolves to `none` while wrapper hook files exist on disk, `update` prints a warning naming the affected wrappers, the refresh command above, and `agentchute setup --wrappers ...` to re-record the pool. No behavior change to the replay itself — a hard-fail branch inside update was considered and rejected (option C) as heavier than the incident justifies.
+3. **Delete the duplicate hook-path table.** `doctor.go` kept its own `hookFiles` list of the three wrapper paths, parallel to `hookWrappers` in `hooks.go`. Two hand-maintained copies of the same table are a drift hazard; doctor now derives paths from `hookWrappers`.
+4. **Refresh the tracked `.claude/settings.json`.** This repo is its own control repo; its committed hook file must match the embedded template. It now does (guard + turn-end shape, `turn-end` permission included).
+5. **This document** is the incident record.
+
+Out of scope: auto-repairing `setup.json` (rerunning `setup` re-fences all live supervisors; Alex re-records wrappers at the next planned restart — **operator rule until then: do not run `agentchute update` on this pool**); any change to the replay's `none` semantics; protocol or wire changes.
+
+## Test plan
+
+- Fixture hook file invoking `poller ensure` → `hook_content_sanity` BLOCKER naming `poller`, plus the fix hint.
+- Hyphenated subcommands (`self-check`, `turn-end`, `boot --context-only` flags) pass the token extraction.
+- `permissions.allow` entry naming an unknown subcommand, hooks clean → OK (regression guard for the PR #74 false-positive class).
+- Canonical installed templates still pass end-to-end (existing `TestDoctorCanonicalInstalledTemplatesPassHookContentSanity` now also exercises the new rule).
+- The update warning decision is a pure helper unit-tested without network; skip/fire cases for: no hook files, hook files + `none`, hook files + recorded wrappers.
+- Existing presence/drift tests hold after the table dedup.
+
+## Rollout
+
+PR to main; review by codex + sonnet + grok (pinned SHAs); merge after verdicts and green CI. Live-checkout switch to main and the fleet-side verification are operational steps tracked in the recovery brief (`.agentchute/loop/scratch-brief-2026-07-31-v150-recovery.md`), not in this PR.

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -12,28 +12,37 @@ import (
 // commandHandlers is the single source of truth for agentchute's subcommands.
 // main()'s top-level switch and the `ac` dispatcher both resolve commands here,
 // so "is this a known command?" can never drift from "what runs it".
-var commandHandlers = map[string]func([]string) error{
-	"init":         cmdInit,
-	"prepare-pool": cmdPreparePool,
-	"register":     cmdRegister,
-	"boot":         cmdBoot,
-	"gate":         cmdGate,
-	"send":         cmdSend,
-	"check":        cmdCheck,
-	"ack":          cmdAck,
-	"pending":      cmdPending,
-	"serve":        cmdServe,
-	"setup":        cmdSetup,
-	"update":       cmdUpdate,
-	"self-check":   cmdSelfCheck,
-	"identity":     cmdIdentity,
-	"shims":        cmdShims,
-	"status":       cmdStatus,
-	"doctor":       cmdDoctor,
-	"hooks":        cmdHooks,
-	"clean":        cmdClean,
-	"guard":        cmdGuard,
-	"turn-end":     cmdTurnEnd,
+//
+// Populated in init() rather than a var initializer: doctor's
+// hook_content_sanity validates hook subcommand tokens against this map, so a
+// static initializer would form an initialization cycle (commandHandlers →
+// cmdDoctor → checkHookContentSanity → commandHandlers).
+var commandHandlers map[string]func([]string) error
+
+func init() {
+	commandHandlers = map[string]func([]string) error{
+		"init":         cmdInit,
+		"prepare-pool": cmdPreparePool,
+		"register":     cmdRegister,
+		"boot":         cmdBoot,
+		"gate":         cmdGate,
+		"send":         cmdSend,
+		"check":        cmdCheck,
+		"ack":          cmdAck,
+		"pending":      cmdPending,
+		"serve":        cmdServe,
+		"setup":        cmdSetup,
+		"update":       cmdUpdate,
+		"self-check":   cmdSelfCheck,
+		"identity":     cmdIdentity,
+		"shims":        cmdShims,
+		"status":       cmdStatus,
+		"doctor":       cmdDoctor,
+		"hooks":        cmdHooks,
+		"clean":        cmdClean,
+		"guard":        cmdGuard,
+		"turn-end":     cmdTurnEnd,
+	}
 }
 
 // globalValueFlags are the leading flags the `ac` dispatcher accepts BEFORE the

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -542,26 +542,20 @@ func shimNamesForAgent(agentID string) []string {
 	return names
 }
 
-// hookFile maps a wrapper to the conventional template location relative
-// to the control repo. checkHookFilePresence walks this list to surface
-// which wrappers are wired up vs. relying on plain-text fallback.
-var hookFiles = []struct {
-	wrapper string
-	path    []string // relative to control repo
-}{
-	{"claude-code", []string{".claude", "settings.json"}},
-	{"codex", []string{".codex", "hooks.json"}},
-	{"gemini-cli", []string{".gemini", "settings.json"}},
-}
+// Wrapper hook locations come from hookWrappers (hooks.go) — the same
+// table `hooks install` writes from — so doctor can never check a
+// different path than install wrote (two hand-maintained copies of the
+// three paths drifted into being during v2; deleted with the v1.5.0
+// cutover fix).
 
 func checkHookFilePresence(cfg *loop.Config, agentID string) doctorCheck {
 	present := []string{}
 	presentSet := map[string]bool{}
-	for _, h := range hookFiles {
-		full := filepath.Join(append([]string{cfg.ControlRepo}, h.path...)...)
+	for _, h := range hookWrappers {
+		full := filepath.Join(cfg.ControlRepo, filepath.FromSlash(h.Dest))
 		if _, err := os.Stat(full); err == nil {
-			present = append(present, h.wrapper)
-			presentSet[h.wrapper] = true
+			present = append(present, h.Name)
+			presentSet[h.Name] = true
 		}
 	}
 	if wrapper, ok := hookWrapperForAgent(agentID); ok {
@@ -692,8 +686,8 @@ func checkHookContentSanity(cfg *loop.Config) doctorCheck {
 	var invalidJSONFiles []string
 	seenUnknown := map[string]bool{}
 
-	for _, h := range hookFiles {
-		full := filepath.Join(append([]string{cfg.ControlRepo}, h.path...)...)
+	for _, h := range hookWrappers {
+		full := filepath.Join(cfg.ControlRepo, filepath.FromSlash(h.Dest))
 		data, err := os.ReadFile(full)
 		if err != nil {
 			continue // absence is handled by checkHookFilePresence
@@ -706,12 +700,12 @@ func checkHookContentSanity(cfg *loop.Config) doctorCheck {
 			// subcommand would read as a hook invoking it). Surface the
 			// parse failure as its own signal instead; a malformed hook
 			// file won't fire correctly anyway, which is worth flagging.
-			invalidJSONFiles = append(invalidJSONFiles, h.wrapper)
+			invalidJSONFiles = append(invalidJSONFiles, h.Name)
 			continue
 		}
 
 		if hookCheckSubcmdRE.MatchString(body) {
-			checkOffenders = append(checkOffenders, h.wrapper)
+			checkOffenders = append(checkOffenders, h.Name)
 		}
 
 		// A subcommand the running binary doesn't know is a stale template
@@ -721,7 +715,7 @@ func checkHookContentSanity(cfg *loop.Config) doctorCheck {
 		// UserPromptSubmit hook blocks the prompt entirely.
 		for _, m := range hookSubcmdTokenRE.FindAllStringSubmatch(body, -1) {
 			if _, known := commandHandlers[m[1]]; !known {
-				offender := h.wrapper + " (`" + m[1] + "`)"
+				offender := h.Name + " (`" + m[1] + "`)"
 				if !seenUnknown[offender] {
 					seenUnknown[offender] = true
 					unknownOffenders = append(unknownOffenders, offender)
@@ -738,11 +732,11 @@ func checkHookContentSanity(cfg *loop.Config) doctorCheck {
 		// either form can't resolve in this environment.
 		switch {
 		case hasBare && !binOnPath:
-			resolutionOffenders = append(resolutionOffenders, h.wrapper+" (bare `agentchute` needs PATH)")
+			resolutionOffenders = append(resolutionOffenders, h.Name+" (bare `agentchute` needs PATH)")
 		case hasTemplated && !envBinValid && !binOnPath:
-			resolutionOffenders = append(resolutionOffenders, h.wrapper+" (templated `${AGENTCHUTE_BIN:-agentchute}` needs AGENTCHUTE_BIN or PATH)")
+			resolutionOffenders = append(resolutionOffenders, h.Name+" (templated `${AGENTCHUTE_BIN:-agentchute}` needs AGENTCHUTE_BIN or PATH)")
 		case hasEnvOnly && !envBinValid:
-			resolutionOffenders = append(resolutionOffenders, h.wrapper+" (`$AGENTCHUTE_BIN` reference needs AGENTCHUTE_BIN set)")
+			resolutionOffenders = append(resolutionOffenders, h.Name+" (`$AGENTCHUTE_BIN` reference needs AGENTCHUTE_BIN set)")
 		}
 	}
 	if len(checkOffenders) > 0 {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -47,6 +47,12 @@ var (
 	// Env-only form. Distinct from templated because absent
 	// AGENTCHUTE_BIN there is no fallback.
 	hookEnvOnlyRE = regexp.MustCompile(`\$AGENTCHUTE_BIN[ \t]+[a-z]`)
+
+	// Any invocation form followed by its subcommand token (capture 1).
+	// Flags (leading `-`) never match the token class; (?m) so a bare
+	// invocation at the start of a joined-body line still anchors. The
+	// bare-form guard mirrors hookBareAgentchuteRE.
+	hookSubcmdTokenRE = regexp.MustCompile(`(?m)(?:\$\{AGENTCHUTE_BIN:-agentchute\}|\$AGENTCHUTE_BIN|(?:^|[^A-Za-z0-9_/\-{])agentchute)[ \t]+([a-z][a-z0-9-]*)`)
 )
 
 const (
@@ -681,8 +687,10 @@ func checkHookContentSanity(cfg *loop.Config) doctorCheck {
 	envBinValid := isAgentchuteBinValid()
 
 	var checkOffenders []string
+	var unknownOffenders []string
 	var resolutionOffenders []string
 	var invalidJSONFiles []string
+	seenUnknown := map[string]bool{}
 
 	for _, h := range hookFiles {
 		full := filepath.Join(append([]string{cfg.ControlRepo}, h.path...)...)
@@ -706,6 +714,21 @@ func checkHookContentSanity(cfg *loop.Config) doctorCheck {
 			checkOffenders = append(checkOffenders, h.wrapper)
 		}
 
+		// A subcommand the running binary doesn't know is a stale template
+		// from another binary version — the v1.5.0 cutover outage class
+		// (docs/decisions/agentchute-v150-cutover-incident-and-fix.md):
+		// every such hook dies with `unknown command`, and a failing
+		// UserPromptSubmit hook blocks the prompt entirely.
+		for _, m := range hookSubcmdTokenRE.FindAllStringSubmatch(body, -1) {
+			if _, known := commandHandlers[m[1]]; !known {
+				offender := h.wrapper + " (`" + m[1] + "`)"
+				if !seenUnknown[offender] {
+					seenUnknown[offender] = true
+					unknownOffenders = append(unknownOffenders, offender)
+				}
+			}
+		}
+
 		hasBare := hookBareAgentchuteRE.MatchString(body)
 		hasTemplated := hookTemplatedRE.MatchString(body)
 		hasEnvOnly := hookEnvOnlyRE.MatchString(body)
@@ -727,6 +750,13 @@ func checkHookContentSanity(cfg *loop.Config) doctorCheck {
 			Name:     "hook_content_sanity",
 			Severity: severityBlocker,
 			Message:  fmt.Sprintf("hook file(s) invoke `agentchute check` (silent-drain risk; check archives and quarantines): %s — replace with `pending` or `boot --context-only`", strings.Join(checkOffenders, ", ")),
+		}
+	}
+	if len(unknownOffenders) > 0 {
+		return doctorCheck{
+			Name:     "hook_content_sanity",
+			Severity: severityBlocker,
+			Message:  fmt.Sprintf("hook file(s) invoke unknown agentchute subcommand(s) — stale templates from another binary version: %s — run `agentchute hooks install --wrapper all --scope repo --force`", strings.Join(unknownOffenders, ", ")),
 		}
 	}
 	if len(resolutionOffenders) > 0 {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -367,6 +367,100 @@ func TestDoctorCanonicalInstalledTemplatesPassHookContentSanity(t *testing.T) {
 	}
 }
 
+// The v1.5.0 cutover outage class (docs/decisions/
+// agentchute-v150-cutover-incident-and-fix.md): a hook template written by an
+// older binary invokes a subcommand the current binary removed (`poller
+// ensure`), every hook invocation dies with `unknown command`, and
+// UserPromptSubmit failures block prompts fleet-wide. doctor must name the
+// stale token instead of reporting the hooks clean.
+func TestDoctorUnknownHookSubcmdBlocks(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	claudeDir := filepath.Join(cfg.ControlRepo, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// AGENTCHUTE_BIN stub so the resolution check can't be the blocker that
+	// trips — this test must prove the unknown-subcommand branch fires.
+	stub := filepath.Join(cfg.ControlRepo, "stub-agentchute")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGENTCHUTE_BIN", stub)
+	hookContent := `{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"${AGENTCHUTE_BIN:-agentchute} poller ensure --vendor anthropic --quiet"}]}]}}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(hookContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := runDoctorChecks(cfg, "", doctorOptions{Now: time.Now().UTC()})
+	got := findCheck(t, r, "hook_content_sanity")
+	if got.Severity != severityBlocker {
+		t.Fatalf("hook_content_sanity severity = %q, want BLOCKER (hook invokes removed subcommand `poller`); msg=%q", got.Severity, got.Message)
+	}
+	for _, want := range []string{"poller", "hooks install --wrapper all --scope repo --force"} {
+		if !strings.Contains(got.Message, want) {
+			t.Errorf("message %q missing %q", got.Message, want)
+		}
+	}
+	if r.Blockers == 0 {
+		t.Errorf("Blockers = 0; want >0 (unknown hook subcommand)")
+	}
+}
+
+// Hyphenated registered subcommands (`turn-end`, `self-check`) must pass the
+// token extraction — a token regex that stops at `-` would misread
+// `turn-end` as unknown token `turn`.
+func TestDoctorHyphenatedKnownSubcmdsPass(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	claudeDir := filepath.Join(cfg.ControlRepo, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stub := filepath.Join(cfg.ControlRepo, "stub-agentchute")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGENTCHUTE_BIN", stub)
+	hookContent := `{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"${AGENTCHUTE_BIN:-agentchute} turn-end --json"},{"type":"command","command":"${AGENTCHUTE_BIN:-agentchute} self-check --quiet"}]}]}}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(hookContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := runDoctorChecks(cfg, "", doctorOptions{Now: time.Now().UTC()})
+	got := findCheck(t, r, "hook_content_sanity")
+	if got.Severity != severityOK {
+		t.Fatalf("hook_content_sanity severity = %q, want OK for hyphenated registered subcommands; msg=%q", got.Severity, got.Message)
+	}
+}
+
+// Same guard the `check` rule needed on #74: a permissions.allow entry that
+// merely names an unknown subcommand is not a hook invoking it. The
+// unknown-subcommand scan must consume hookCommandBody output only.
+func TestDoctorUnknownSubcmdInPermissionsOnlyPasses(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	claudeDir := filepath.Join(cfg.ControlRepo, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stub := filepath.Join(cfg.ControlRepo, "stub-agentchute")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AGENTCHUTE_BIN", stub)
+	hookContent := `{
+		"permissions": {"allow": ["Bash(agentchute poller:*)"]},
+		"hooks": {"SessionStart":[{"hooks":[{"type":"command","command":"${AGENTCHUTE_BIN:-agentchute} boot --context-only"}]}]}
+	}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(hookContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := runDoctorChecks(cfg, "", doctorOptions{Now: time.Now().UTC()})
+	got := findCheck(t, r, "hook_content_sanity")
+	if got.Severity != severityOK {
+		t.Fatalf("hook_content_sanity severity = %q, want OK (permissions-only mention of an unknown subcommand); msg=%q", got.Severity, got.Message)
+	}
+	if r.Blockers != 0 {
+		t.Errorf("Blockers = %d, want 0", r.Blockers)
+	}
+}
+
 // Codex review on bff226c: --json discovery failure must still exit
 // errBlocked. Previously emitDoctorJSON returned nil before the
 // errBlocked guard ran.

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -141,6 +141,9 @@ func cmdUpdate(args []string) error {
 		} else if p := strings.TrimSpace(global.Profile); p != "" {
 			setupArgs = append(setupArgs, "--profile", p)
 		}
+		if w := hookRefreshSkipWarning(cfg.ControlRepo, wrappersArg); w != "" {
+			fmt.Fprintln(os.Stderr, w)
+		}
 	}
 
 	// 2. Resolve the real binary we will replace — refuse a shim BEFORE any
@@ -254,6 +257,31 @@ var updateRunResync = func(target string, setupArgs []string, controlRepo string
 	setup.Stdin = os.Stdin
 	setup.Dir = controlRepo
 	return setup.Run()
+}
+
+// hookRefreshSkipWarning reports the warning to print when a resync will
+// replay `setup --wrappers none` while wrapper hook templates exist on disk:
+// the replay will NOT refresh those templates — the exact state that
+// stranded pre-1.5 hooks against the 1.5.0 binary
+// (docs/decisions/agentchute-v150-cutover-incident-and-fix.md). Empty means
+// nothing to warn about. The replay itself is deliberately untouched: an
+// empty recorded wrapper list is the valid `--wrappers none` mode and update
+// cannot distinguish "chose none" from "state predates wrapper recording".
+func hookRefreshSkipWarning(controlRepo, wrappersArg string) string {
+	if wrappersArg != "none" {
+		return ""
+	}
+	var present []string
+	for _, h := range hookWrappers {
+		if _, err := os.Stat(filepath.Join(controlRepo, filepath.FromSlash(h.Dest))); err == nil {
+			present = append(present, h.Name)
+		}
+	}
+	if len(present) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("WARNING: saved setup state records no wrappers; this update will NOT refresh the installed hook templates for: %s\n  after the update, run `agentchute hooks install --wrapper all --scope repo --force`, then re-record the pool with `agentchute setup --wrappers <list>`.",
+		strings.Join(present, ", "))
 }
 
 // resolveUpdateTargetForTest, when non-empty, overrides the running-binary

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -527,3 +527,30 @@ func TestFetchChecksumRejectsNonHex(t *testing.T) {
 		t.Fatalf("non-hex checksum must be rejected; got %v", err)
 	}
 }
+
+// The v1.5.0 cutover gap (docs/decisions/
+// agentchute-v150-cutover-incident-and-fix.md): a pool whose saved state
+// records no wrappers replays `setup --wrappers none`, which skips the hook
+// template refresh while hook files sit on disk — stranding stale templates
+// against the new binary. The replay stays untouched (decision B rejects a
+// hard-fail); update just has to say it loudly.
+func TestHookRefreshSkipWarning(t *testing.T) {
+	repo := t.TempDir()
+	if got := hookRefreshSkipWarning(repo, "none"); got != "" {
+		t.Fatalf("no hook files installed: want empty warning, got %q", got)
+	}
+	mustWriteCanonicalHook(t, repo, "claude-code")
+	mustWriteCanonicalHook(t, repo, "codex")
+	got := hookRefreshSkipWarning(repo, "none")
+	for _, want := range []string{"claude-code", "codex", "hooks install --wrapper all --scope repo --force", "setup --wrappers"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("warning %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "gemini-cli") {
+		t.Fatalf("warning names a wrapper with no installed hook file: %q", got)
+	}
+	if got := hookRefreshSkipWarning(repo, "claude-code,codex"); got != "" {
+		t.Fatalf("recorded wrappers: want empty warning, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes out the v1.5.0 cutover incident (fleet-wide prompt block from stale hook templates invoking the removed `poller` subcommand). Design + incident record: `docs/decisions/agentchute-v150-cutover-incident-and-fix.md` (decision B, codex-approved on the bus, ref `20260731T175038205661Z_from-codex`).

Root cause in one line: the update's setup replay had `wrappers: null` recorded (pre-v2.5 state), replayed `setup --wrappers none`, and skipped the hook refresh while the binary moved past the installed templates — and doctor had no check that could see it.

## Changes

- **doctor / `hook_content_sanity`**: every `agentchute <subcommand>` token in installed hook commands must be a registered command (validated against `commandHandlers`); unknown tokens are a named BLOCKER with the refresh command. Would have caught `poller` immediately. `commandHandlers` moves to `init()` (contents unchanged) to break the resulting initialization cycle.
- **doctor**: the duplicate `hookFiles` path table is gone; presence + content checks walk `hookWrappers` — the same table `hooks install` writes from.
- **update**: when a resync will replay `setup --wrappers none` while wrapper hook files exist on disk, print a WARNING naming the affected wrappers plus the refresh and re-record commands. Replay behavior unchanged (decision B explicitly rejects a hard-fail).
- **repo**: tracked `.claude/settings.json` refreshed to the embedded 1.5 template (was pre-1.5 shape: no guard, Stop still ran `ack`+`gate`); byte-identity verified via doctor's drift check.
- **docs**: incident + decision record.

## Testing

- New: `TestDoctorUnknownHookSubcmdBlocks` (the outage fixture, verbatim `poller ensure` command), `TestDoctorHyphenatedKnownSubcmdsPass`, `TestDoctorUnknownSubcmdInPermissionsOnlyPasses` (#74 false-positive class), `TestHookRefreshSkipWarning` (skip/fire/wrapper-scoping cases).
- `gofmt` clean, `go vet ./...` clean, `go build ./...` clean, full `go test ./...` green (AGENTCHUTE_* env stripped).
- `TestDoctorCanonicalInstalledTemplatesPassHookContentSanity` now exercises the new validation against the real embedded templates end-to-end.

## Review

Review freeze: base `571e8bc`, head `d0a0287`; changed files: `docs/decisions/agentchute-v150-cutover-incident-and-fix.md`, `internal/cli/doctor.go`, `internal/cli/doctor_test.go`, `internal/cli/dispatch.go`, `internal/cli/update.go`, `internal/cli/update_test.go`, `.claude/settings.json`. Reviewers: codex (deep backstop, closes last), sonnet, grok (review-only). Verdicts via PR comments.

Out of scope (deferred, recorded in the design doc): repairing the live pool's `setup.json` `wrappers: null` — Alex re-records at the next planned restart; operator rule until then: no `agentchute update` on this pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
