### PR TITLE
release: prepare v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All releases of the agentchute reference CLI. The protocol spec itself ([`AGENTC
 
 The repo follows a release-squash convention: each release lands on `main` as a single squash commit, then is tagged. Intermediate tags between release squashes (e.g., feature branches) are not part of the main release history. (v0.9.0 was landed as a sequence of dual-gated PRs rather than one squash.)
 
+## v1.5.1 (2026-07-31) — updates verify their hooks
+
+**Update safety**
+- `agentchute update` now refreshes every installed hook template from the new binary, even when recorded wrapper membership is empty or stale, so an update no longer leaves old hook commands behind ([#110](https://github.com/agentchute/agentchute/pull/110)).
+- Before reporting success, the resync verifies installed hook commands against the new binary. A broken hook now makes the update fail loudly with a non-zero exit and an actionable repair command instead of silently completing; `doctor` also blocks on unknown hook subcommands ([#109](https://github.com/agentchute/agentchute/pull/109), [#110](https://github.com/agentchute/agentchute/pull/110)).
+- Design and incident rationale: [`docs/decisions/agentchute-update-fix-v2.md`](docs/decisions/agentchute-update-fix-v2.md).
+
 ## v1.5.0 (2026-07-31) — the wire moved
 
 **Protocol v2.5 is a deliberate wire break.** Protocol v2's pull-only primitives, small envelope, and two-phase recipient lifecycle remain. The filename/identity grammar changes, so registration rows now carry integer `v: 3`, rendered by the CLI as `v2.5`; `doctor` and `status` warn on explicit mixed-version rows and direct operators to update and restart every lane.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A small Markdown protocol that lets AI agents hand off work, request review, and message each other — without a human relaying every step. No server, no broker, no SDK.
 
-[![Protocol v2.5](https://img.shields.io/badge/protocol-v2.5-1e6f57.svg)](AGENTCHUTE.md) [![CLI v1.5.0](https://img.shields.io/badge/CLI-v1.5.0-1e6f57.svg)](CHANGELOG.md) [![MIT](https://img.shields.io/badge/license-MIT-1e6f57.svg)](LICENSE) [![Conformance · 14 vectors](https://img.shields.io/badge/conformance-14%20vectors-1e6f57.svg)](conformance/)
+[![Protocol v2.5](https://img.shields.io/badge/protocol-v2.5-1e6f57.svg)](AGENTCHUTE.md) [![CLI v1.5.1](https://img.shields.io/badge/CLI-v1.5.1-1e6f57.svg)](CHANGELOG.md) [![MIT](https://img.shields.io/badge/license-MIT-1e6f57.svg)](LICENSE) [![Conformance · 14 vectors](https://img.shields.io/badge/conformance-14%20vectors-1e6f57.svg)](conformance/)
 
 [Spec](AGENTCHUTE.md) · [Conformance](conformance/) · [Extensions](EXTENSIONS.md) · [Website](https://agentchute.dev) · [Why the wire moved →](https://agentchute.dev/blog/v2-5-the-wire-broke.html)
 

--- a/docs/releases/v1.5.1.md
+++ b/docs/releases/v1.5.1.md
@@ -1,0 +1,8 @@
+# agentchute v1.5.1
+
+This patch release makes the existing update path enforce hook compatibility before it reports success. Protocol v2.5 and registration wire version `v: 3` are unchanged.
+
+- Updating refreshes every installed hook template from the new binary, even when recorded wrapper membership is empty or stale, so old hook commands are not left behind ([#110](https://github.com/agentchute/agentchute/pull/110)).
+- The resync verifies installed hook commands against the new binary. If a hook is still broken, the update exits non-zero with an actionable repair command instead of silently completing ([#109](https://github.com/agentchute/agentchute/pull/109), [#110](https://github.com/agentchute/agentchute/pull/110)).
+
+Design and incident rationale: [`docs/decisions/agentchute-update-fix-v2.md`](../decisions/agentchute-update-fix-v2.md).

--- a/tests/upgrade_smoke.sh
+++ b/tests/upgrade_smoke.sh
@@ -229,14 +229,14 @@ git -C "$repo" archive "$base" | tar -x -C "$old_source"
 
 (
 	cd "$repo"
-	go build -ldflags '-X main.version=1.5.0' -o "$new_build/agentchute" .
+	go build -ldflags '-X main.version=1.5.1' -o "$new_build/agentchute" .
 )
 new_version=$("$new_build/agentchute" --version)
 
 goos=$(go env GOOS)
 goarch=$(go env GOARCH)
-asset="agentchute_1.5.0_${goos}_${goarch}.tar.gz"
-release_dir="$http_root/releases/download/v1.5.0"
+asset="agentchute_1.5.1_${goos}_${goarch}.tar.gz"
+release_dir="$http_root/releases/download/v1.5.1"
 mkdir -p "$release_dir"
 tar -C "$new_build" -czf "$release_dir/$asset" agentchute
 if command -v sha256sum >/dev/null 2>&1; then
@@ -335,7 +335,7 @@ env \
 	PATH="$shim_dir:/usr/bin:/bin" \
 	"$installed" update \
 		--control-repo "$fixture" \
-		--version v1.5.0 >"$tmp/update.log" 2>&1
+		--version v1.5.1 >"$tmp/update.log" 2>&1
 
 [ ! -e "$claim" ] || fail "new setup left the old serve claim in place"
 [ -f "$registration" ] || fail "new setup deleted the registration row"


### PR DESCRIPTION
## Summary

- Prepare CLI v1.5.1 while keeping Protocol v2.5 and registration wire version v: 3 unchanged.
- Document the operator-visible update safety fixes from PRs #109 and #110 and docs/decisions/agentchute-update-fix-v2.md.
- Update the synthetic release version used by the upgrade smoke.
- Add docs/releases/v1.5.1.md because the release workflow requires a nonempty tag-matched notes file.

## Pinned review

- Base: 9a851ffae9f0cefed7c315564f348402dc1b6d16
- Head: 6f036ddf80f34b680851ffca0faa2b49f3ba0e85
- Changed files:
  - CHANGELOG.md
  - README.md
  - docs/releases/v1.5.1.md
  - tests/upgrade_smoke.sh

## Verification

- gofmt -w .
- go vet ./...
- go test ./...
- go build ./...
- sh -n tests/upgrade_smoke.sh
- shellcheck tests/upgrade_smoke.sh (when available)
- isolated sh tests/upgrade_smoke.sh: PASS (artifact fetch/checksum, old-supervisor fencing, explicit relaunch)
- git diff --check 9a851ff..6f036dd

No tag was created.