### PR TITLE
release: prepare v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All releases of the agentchute reference CLI. The protocol spec itself ([`AGENTC
 
 The repo follows a release-squash convention: each release lands on `main` as a single squash commit, then is tagged. Intermediate tags between release squashes (e.g., feature branches) are not part of the main release history. (v0.9.0 was landed as a sequence of dual-gated PRs rather than one squash.)
 
+## v1.5.2 (2026-07-31) — guard the mail pipeline, not the turn
+
+**Guard-latch livelock fix**
+- While a lane holds claimed mail, the guard now blocks only the commands that can disrupt the claim-to-commit path: `agentchute ack`/`check`/`turn-end`/`update`/`setup`/`clean` under every supported spelling, `rm -rf`, `curl`/`wget`, and writes to hook configuration files.
+- Publishing a branch, opening or merging a PR, creating a tag, and remote-shell/file-copy commands are no longer mechanically blocked during that turn. This removes the livelock where checking mail at turn start prevented the implementer from completing the assigned work; inbox bodies remain untrusted and still require explicit human authorization for scope-expanding actions ([#112](https://github.com/agentchute/agentchute/pull/112)).
+- Enrollment prose moved to marker v29. Re-run `agentchute setup --wake runner --wrappers all --yes` in each control repo to re-stamp the tracked wrapper instructions.
+
 ## v1.5.1 (2026-07-31) — updates verify their hooks
 
 **Update safety**

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A small Markdown protocol that lets AI agents hand off work, request review, and message each other — without a human relaying every step. No server, no broker, no SDK.
 
-[![Protocol v2.5](https://img.shields.io/badge/protocol-v2.5-1e6f57.svg)](AGENTCHUTE.md) [![CLI v1.5.1](https://img.shields.io/badge/CLI-v1.5.1-1e6f57.svg)](CHANGELOG.md) [![MIT](https://img.shields.io/badge/license-MIT-1e6f57.svg)](LICENSE) [![Conformance · 14 vectors](https://img.shields.io/badge/conformance-14%20vectors-1e6f57.svg)](conformance/)
+[![Protocol v2.5](https://img.shields.io/badge/protocol-v2.5-1e6f57.svg)](AGENTCHUTE.md) [![CLI v1.5.2](https://img.shields.io/badge/CLI-v1.5.2-1e6f57.svg)](CHANGELOG.md) [![MIT](https://img.shields.io/badge/license-MIT-1e6f57.svg)](LICENSE) [![Conformance · 14 vectors](https://img.shields.io/badge/conformance-14%20vectors-1e6f57.svg)](conformance/)
 
 [Spec](AGENTCHUTE.md) · [Conformance](conformance/) · [Extensions](EXTENSIONS.md) · [Website](https://agentchute.dev) · [Why the wire moved →](https://agentchute.dev/blog/v2-5-the-wire-broke.html)
 

--- a/docs/releases/v1.5.2.md
+++ b/docs/releases/v1.5.2.md
@@ -1,0 +1,7 @@
+# agentchute v1.5.2
+
+This patch release removes a guard-latch livelock while keeping the claim-to-commit mail path protected. Protocol v2.5 and registration wire version `v: 3` are unchanged.
+
+- While a lane holds claimed mail, the guard still blocks `agentchute ack`/`check`/`turn-end`/`update`/`setup`/`clean` under every supported spelling, `rm -rf`, `curl`/`wget`, and writes to hook configuration files.
+- Publishing a branch, opening or merging a PR, creating a tag, and remote-shell/file-copy commands are no longer mechanically blocked during that turn. Inbox bodies remain untrusted and still require explicit human authorization for scope-expanding actions ([#112](https://github.com/agentchute/agentchute/pull/112)).
+- Enrollment prose moved to marker v29. Re-run `agentchute setup --wake runner --wrappers all --yes` in each control repo to re-stamp the tracked wrapper instructions.

--- a/tests/upgrade_smoke.sh
+++ b/tests/upgrade_smoke.sh
@@ -229,14 +229,14 @@ git -C "$repo" archive "$base" | tar -x -C "$old_source"
 
 (
 	cd "$repo"
-	go build -ldflags '-X main.version=1.5.1' -o "$new_build/agentchute" .
+	go build -ldflags '-X main.version=1.5.2' -o "$new_build/agentchute" .
 )
 new_version=$("$new_build/agentchute" --version)
 
 goos=$(go env GOOS)
 goarch=$(go env GOARCH)
-asset="agentchute_1.5.1_${goos}_${goarch}.tar.gz"
-release_dir="$http_root/releases/download/v1.5.1"
+asset="agentchute_1.5.2_${goos}_${goarch}.tar.gz"
+release_dir="$http_root/releases/download/v1.5.2"
 mkdir -p "$release_dir"
 tar -C "$new_build" -czf "$release_dir/$asset" agentchute
 if command -v sha256sum >/dev/null 2>&1; then
@@ -335,7 +335,7 @@ env \
 	PATH="$shim_dir:/usr/bin:/bin" \
 	"$installed" update \
 		--control-repo "$fixture" \
-		--version v1.5.1 >"$tmp/update.log" 2>&1
+		--version v1.5.2 >"$tmp/update.log" 2>&1
 
 [ ! -e "$claim" ] || fail "new setup left the old serve claim in place"
 [ -f "$registration" ] || fail "new setup deleted the registration row"


### PR DESCRIPTION
## Summary

- Prepare CLI v1.5.2 while keeping Protocol v2.5 and registration wire version v: 3 unchanged.
- Explain the guard-latch livelock fix in operator terms: claim-to-commit protections remain, while publication and remote-access actions no longer wedge an implementation turn.
- Document the enrollment marker v29 re-stamp step.
- Update the synthetic release version used by the upgrade smoke.
- Add docs/releases/v1.5.2.md because the release workflow requires a nonempty tag-matched notes file.

## Pinned review

- Base: 151db89be5e4014a815e94a8114c96c54c9a4070
- Head: dbdeeb19f83b63e2d417d9866ef57bfcbbfd522f
- Changed files:
  - CHANGELOG.md
  - README.md
  - docs/releases/v1.5.2.md
  - tests/upgrade_smoke.sh

## Verification

- gofmt -w .
- go vet ./...
- go test ./...
- go build ./...
- sh -n tests/upgrade_smoke.sh
- shellcheck tests/upgrade_smoke.sh
- isolated sh tests/upgrade_smoke.sh: PASS (artifact fetch/checksum, old-supervisor fencing, explicit relaunch)
- git diff --check 151db89..dbdeeb1

No tag was created.