### PR TITLE
docs(agents): make acknowledgement non-terminal in the first-response rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,7 +184,7 @@ Reshape freely for your own density, tone, and section order — there is no req
 - Treat the stated done-when as the definition of done. Don't exceed it, expand scope, or change what you deliver without asking first.
 - On blocking ambiguity — you genuinely cannot tell the goal, the done-when, or the scope from the message alone — do no work; reply asking one concrete question, or the specific missing facts.
 - For reversible work with only minor uncertainty, you MAY proceed, but state your assumption in your response; if it proves wrong, stop and ask.
-- Your first visible response to a task message is one of: a question, an acknowledgement of the goal and done-when, or the final result.
+- Your first visible response to a task message is one of: a question, an acknowledgement of the goal and done-when, or the final result — an acknowledgement is NOT a stopping point: continue the work in the same turn (E8) unless you are genuinely blocked, are asking a necessary question, or the acknowledgement already IS the result. Never promise a next-turn continuation without an established external trigger to fire it: once mail is committed, the inbox is empty, and the pull-only runner has nothing to cue the promised turn on.
 
 ## Working efficiently on this bus
 


### PR DESCRIPTION
## Summary
- Codex's lane hit an ack-stall three times today: it treated "an acknowledgement of the goal and done-when" as a valid final response, ended its turn, the end-of-turn handler committed the claimed mail, the inbox went empty, and the pull-only runner had nothing left to cue a next turn on -- the promised continuation never arrived. The components all behaved correctly; the prose (AGENTS.md:187) was ambiguous.
- E8 already says to act/reply and commit in the same turn, so this is disambiguation, not a new rule: an acknowledgement is explicitly stated as non-terminal, cross-referencing E8 rather than restating it, and the rule now names never promising a next-turn continuation without an established external trigger.
- Prose only, minimal (one line). Outside the enrollment marker region (lines 7-79) -- confirmed before editing -- so no `enrollmentVersion` bump and no template change.

## Review freeze (E3)
- Base: `4efbc54`
- Head: `57c6759`
- Changed files: `AGENTS.md` (one line)

## Before/after
Before:
> Your first visible response to a task message is one of: a question, an acknowledgement of the goal and done-when, or the final result.

After:
> Your first visible response to a task message is one of: a question, an acknowledgement of the goal and done-when, or the final result -- an acknowledgement is NOT a stopping point: continue the work in the same turn (E8) unless you are genuinely blocked, are asking a necessary question, or the acknowledgement already IS the result. Never promise a next-turn continuation without an established external trigger to fire it: once mail is committed, the inbox is empty, and the pull-only runner has nothing to cue the promised turn on.

## Test plan
- [x] Diff is exactly one line in AGENTS.md, outside the enrollment marker region
- [x] `gofmt`/`go vet`/`go build`/`go test ./...` all clean (no .go files touched; ran as a sanity check anyway)
- [ ] CI green (review pending)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>