### PR TITLE
fix(send): remove the done-when warning instead of widening it

### DIFF
--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -165,12 +165,17 @@ func cmdSend(args []string) error {
 	// present. Pure body manipulation; the reply_required frontmatter
 	// is plumbed via ComposeMessage below.
 	if ask {
-		// Warn-only done-when check (AGENTS.md Communication Rules, rule 2):
-		// an --ask with no verifiable done-when forces the recipient to guess
-		// scope. Advisory only — never blocks the send.
-		if !strings.Contains(strings.ToLower(rawBody), "done-when") {
-			fmt.Fprintf(os.Stderr, "warning: --ask body has no 'done-when' line; the recipient will have to guess when this is done\n")
-		}
+		// The done-when warning (v2.5 plan B9) was removed here (post-1.5.x
+		// friction program, item 3): it grepped for the single literal
+		// spelling "done-when", but AGENTS.md's Communication Rules rule 2
+		// requires only a stated, verifiable completion condition in
+		// free-form style ("no required label order... style is free") —
+		// no spelling is mandated, so a one-spelling substring check
+		// false-positived on every legitimate variant, including the
+		// retired six-label envelope's ACCEPTANCE:. Widening the check to
+		// a second hardcoded label would only move the same false positive
+		// to the next spelling someone reasonably chooses; the rule itself
+		// stays a prose covenant, not a mechanically checkable one.
 		body = applyAskHeading(body)
 		// Self-send + --ask is a loop hazard per AGENTCHUTE.md §6.4: the
 		// sender immediately owes itself a reply. The combination is

--- a/internal/cli/send_done_when_test.go
+++ b/internal/cli/send_done_when_test.go
@@ -5,11 +5,54 @@ import (
 	"testing"
 )
 
-// send_done_when_test.go — the warn-only done-when check (v2.5 plan B9,
-// AGENTS.md Communication Rules rule 2): an --ask body with no verifiable
-// done-when line gets a stderr warning; never a blocked send.
+// send_done_when_test.go — the done-when warning (v2.5 plan B9) was REMOVED
+// (post-1.5.x friction program, item 3): it grepped for the single literal
+// spelling "done-when", but AGENTS.md's Communication Rules rule 2 requires
+// only a stated, verifiable completion condition in free-form style — no
+// spelling is mandated, so a one-spelling substring check false-positived
+// on every legitimate variant (the retired six-label envelope's ACCEPTANCE:,
+// which codex still sends). This file now proves the warning is gone for
+// every shape, not narrowed to recognize a second hardcoded label.
 
-func TestSendAskWithoutDoneWhenWarns(t *testing.T) {
+// item 3 of the post-1.5.x friction program: the warning fired on every
+// --ask sent with an ACCEPTANCE: line instead of DONE-WHEN: — including
+// the retired six-label envelope's own spelling, which codex still uses —
+// even though AGENTS.md's current Communication Rules (rule 2) require
+// only a stated, verifiable completion condition, in free-form style
+// ("no required label order... style is free", AGENTS.md:171). A
+// substring check for one literal spelling cannot honestly verify a
+// requirement the spec explicitly declines to pin to any spelling, so the
+// warning is removed rather than widened to a second hardcoded label
+// (widening just moves the same false-positive to the next spelling
+// someone reasonably chooses). This test proves an ACCEPTANCE:-shaped
+// envelope — the exact shape that misfired today — no longer warns, and
+// TestSendAskWithNoCompletionConditionNeverWarns proves the warning is
+// gone outright, not narrowed.
+func TestSendAskWithAcceptanceLineNeverWarns(t *testing.T) {
+	root, _ := setupSendFixture(t)
+	var stderr string
+	withCwd(t, root, func() {
+		stderr = captureStderr(t, func() {
+			if _, err := captureStdout(t, func() error {
+				return cmdSend([]string{
+					"--from", "claude-code", "--to", "codex",
+					"--ask", "--body", "please review this.\n\nACCEPTANCE: verdict issued for head abc1234",
+				})
+			}); err != nil {
+				t.Fatalf("send: %v", err)
+			}
+		})
+	})
+	if strings.Contains(stderr, "done-when") {
+		t.Fatalf("an ACCEPTANCE:-shaped envelope must not warn about a missing done-when line, got stderr=%q", stderr)
+	}
+}
+
+// The warning is removed outright (not narrowed to a wider label set): an
+// --ask with no stated completion condition at all no longer warns either.
+// AGENTS.md rule 2 is unchanged and still expects one — this only removes
+// the mechanical nag that could not check it honestly.
+func TestSendAskWithNoCompletionConditionNeverWarns(t *testing.T) {
 	root, _ := setupSendFixture(t)
 	var stderr string
 	withCwd(t, root, func() {
@@ -24,8 +67,8 @@ func TestSendAskWithoutDoneWhenWarns(t *testing.T) {
 			}
 		})
 	})
-	if !strings.Contains(stderr, "no 'done-when' line") {
-		t.Fatalf("expected a done-when warning, got stderr=%q", stderr)
+	if strings.Contains(stderr, "done-when") {
+		t.Fatalf("the done-when warning was removed; got stderr=%q", stderr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Item 3 of the post-1.5.x friction program: `--ask`'s completion-condition warning grepped for one literal spelling, `done-when`, so any envelope stating its completion condition a different legitimate way false-positived -- every ask sent today with the retired six-label envelope's `ACCEPTANCE:` line (which codex still sends) got warned at, despite plainly stating a verifiable completion condition.
- Read the current spec before deciding: AGENTS.md's Communication Rules rule 2 requires only a stated, verifiable completion condition, in free-form style -- "no required label order... style is free" (AGENTS.md:171). No spelling is mandated. A substring check for any fixed label set -- one spelling or a widened two -- cannot honestly verify a requirement the spec explicitly declines to pin to any spelling; widening would just relocate today's false positive to whichever spelling a lane reasonably chooses next.
- **Chose: delete the warning, not widen it.** Rule 2 itself is unchanged -- this only removes a mechanical nag that enforced something narrower than the spec actually requires.

## Review freeze (E3)
- Base: `5a94cea`
- Head: `ff5752b`
- Changed files: `internal/cli/send.go`, `internal/cli/send_done_when_test.go`

## Test plan
- [x] `TestSendAskWithAcceptanceLineNeverWarns` -- reproduces today's exact false positive (an `ACCEPTANCE:`-shaped ask), proves it no longer warns
- [x] `TestSendAskWithNoCompletionConditionNeverWarns` -- proves the warning is gone outright (not narrowed to a wider label set) even for a body with no completion condition at all
- [x] `TestSendAskWithDoneWhenIsSilent`, `TestSendNonAskNeverWarnsAboutDoneWhen` -- pre-existing, still pass
- [x] Full `TestSend*` suite green, `gofmt`/`go vet`/`go build`/`go test ./...` all clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>