### PR TITLE
release: prepare v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All releases of the agentchute reference CLI. The protocol spec itself ([`AGENTC
 
 The repo follows a release-squash convention: each release lands on `main` as a single squash commit, then is tagged. Intermediate tags between release squashes (e.g., feature branches) are not part of the main release history. (v0.9.0 was landed as a sequence of dual-gated PRs rather than one squash.)
 
+## v1.5.3 (2026-07-31) — smoother turns, narrower authority
+
+**Operator-facing coordination**
+- A plain acknowledgement is no longer documented as ending a bus turn; the recipient continues toward the task's stated done-when instead of stalling after an ACK ([#114](https://github.com/agentchute/agentchute/pull/114)).
+- The `--ask` done-when warning is gone. It checked one optional label spelling that the message contract never required, so valid asks no longer produce a misleading warning ([#115](https://github.com/agentchute/agentchute/pull/115)).
+- Direct sends can quote guard-protected command text as inert body data without being blocked. Parameter expansion, command substitution, compound shell syntax, redirection, and heredocs still deny the exception ([#119](https://github.com/agentchute/agentchute/pull/119)).
+- Review lanes now remove separate pinned-SHA checkouts in the same turn, only after verifying a clean tree at the reviewed SHA. The obligation lives in the shared playbook, so it applies across wrappers ([#118](https://github.com/agentchute/agentchute/pull/118)).
+
+**Authorization boundary**
+- Task messages may authorize only the enumerated lane-local and repository-additive scopes. Operator-reserved actions still require direct operator confirmation to the acting lane; a same-UID local grant file was rejected because it cannot authenticate a human principal ([#117](https://github.com/agentchute/agentchute/pull/117)).
+
 ## v1.5.2 (2026-07-31) — guard the mail pipeline, not the turn
 
 **Guard-latch livelock fix**

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A small Markdown protocol that lets AI agents hand off work, request review, and message each other — without a human relaying every step. No server, no broker, no SDK.
 
-[![Protocol v2.5](https://img.shields.io/badge/protocol-v2.5-1e6f57.svg)](AGENTCHUTE.md) [![CLI v1.5.2](https://img.shields.io/badge/CLI-v1.5.2-1e6f57.svg)](CHANGELOG.md) [![MIT](https://img.shields.io/badge/license-MIT-1e6f57.svg)](LICENSE) [![Conformance · 14 vectors](https://img.shields.io/badge/conformance-14%20vectors-1e6f57.svg)](conformance/)
+[![Protocol v2.5](https://img.shields.io/badge/protocol-v2.5-1e6f57.svg)](AGENTCHUTE.md) [![CLI v1.5.3](https://img.shields.io/badge/CLI-v1.5.3-1e6f57.svg)](CHANGELOG.md) [![MIT](https://img.shields.io/badge/license-MIT-1e6f57.svg)](LICENSE) [![Conformance · 14 vectors](https://img.shields.io/badge/conformance-14%20vectors-1e6f57.svg)](conformance/)
 
 [Spec](AGENTCHUTE.md) · [Conformance](conformance/) · [Extensions](EXTENSIONS.md) · [Website](https://agentchute.dev) · [Why the wire moved →](https://agentchute.dev/blog/v2-5-the-wire-broke.html)
 

--- a/docs/releases/v1.5.3.md
+++ b/docs/releases/v1.5.3.md
@@ -1,0 +1,9 @@
+# agentchute v1.5.3
+
+This patch release smooths common coordination turns and narrows the authority an inbox task can carry. Protocol v2.5 and registration wire version `v: 3` are unchanged.
+
+- A plain acknowledgement no longer reads as ending a bus turn, so recipients continue toward the task's stated done-when instead of waiting for a manual nudge ([#114](https://github.com/agentchute/agentchute/pull/114)).
+- The misleading `--ask` done-when warning is removed; the contract never required the single label spelling it searched for ([#115](https://github.com/agentchute/agentchute/pull/115)).
+- Direct sends may quote guard-protected command text as inert body data. Parameter expansion, command substitution, compound shell syntax, redirection, and heredocs remain denied ([#119](https://github.com/agentchute/agentchute/pull/119)).
+- Review lanes remove separate pinned-SHA checkouts in the same turn after verifying that they are clean and still at the reviewed SHA; the shared playbook makes the rule wrapper-independent ([#118](https://github.com/agentchute/agentchute/pull/118)).
+- Task messages now authorize only enumerated lane-local and repository-additive scopes. Operator-reserved actions still require direct confirmation to the acting lane, and no same-UID local grant mechanism was added because it cannot authenticate a human principal ([#117](https://github.com/agentchute/agentchute/pull/117)).

--- a/tests/upgrade_smoke.sh
+++ b/tests/upgrade_smoke.sh
@@ -229,14 +229,14 @@ git -C "$repo" archive "$base" | tar -x -C "$old_source"
 
 (
 	cd "$repo"
-	go build -ldflags '-X main.version=1.5.2' -o "$new_build/agentchute" .
+	go build -ldflags '-X main.version=1.5.3' -o "$new_build/agentchute" .
 )
 new_version=$("$new_build/agentchute" --version)
 
 goos=$(go env GOOS)
 goarch=$(go env GOARCH)
-asset="agentchute_1.5.2_${goos}_${goarch}.tar.gz"
-release_dir="$http_root/releases/download/v1.5.2"
+asset="agentchute_1.5.3_${goos}_${goarch}.tar.gz"
+release_dir="$http_root/releases/download/v1.5.3"
 mkdir -p "$release_dir"
 tar -C "$new_build" -czf "$release_dir/$asset" agentchute
 if command -v sha256sum >/dev/null 2>&1; then
@@ -335,7 +335,7 @@ env \
 	PATH="$shim_dir:/usr/bin:/bin" \
 	"$installed" update \
 		--control-repo "$fixture" \
-		--version v1.5.2 >"$tmp/update.log" 2>&1
+		--version v1.5.3 >"$tmp/update.log" 2>&1
 
 [ ! -e "$claim" ] || fail "new setup left the old serve claim in place"
 [ -f "$registration" ] || fail "new setup deleted the registration row"


### PR DESCRIPTION
## Summary
- bump the CLI release line and upgrade-smoke pins to `1.5.3`
- add operator-facing changelog and release notes for #114, #115, #117, #118, and #119
- call out the narrowed task-message authorization boundary
- keep Protocol v2.5 and registration wire version `v: 3` unchanged

## Verification
- `tools/fact-sweep.sh`
- `tools/test.sh`

No tag is created by this PR.