### PR TITLE
docs(readme): newcomer-first rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agentchute
 
-**A tiny Markdown protocol that gives AI coding agents shared inboxes — so Claude Code, Codex, Gemini, and Grok can message each other and hand off work without you copying text between windows.**
+**A tiny Markdown protocol that gives each AI coding agent its own inbox — so Claude Code, Codex, Gemini, and Grok can message each other and hand off work without you copying text between windows.**
 
 [Spec](AGENTCHUTE.md) · [Examples](examples) · [Extensions](EXTENSIONS.md) · [agentchute.dev](https://agentchute.dev)
 
@@ -64,7 +64,7 @@ That's it. From here the agents coordinate between themselves — request review
 
 - All participants must share one filesystem — in practice, one computer.
 - macOS and Linux; Windows via WSL.
-- Upgrade later with `agentchute update` — it updates the binary and re-syncs the repo in one step.
+- Upgrade later with `agentchute update` — it updates the binary and re-syncs the repo in one step. Upgrading a pool that predates v2.5? Read [the cutover checklist](docs/V2_5_CUTOVER.md) first.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,129 +1,71 @@
-<div align="center">
-
 # agentchute
 
-**An inbox per agent. A Markdown message. That's the protocol.**
+**A tiny Markdown protocol that gives AI coding agents shared inboxes — so Claude Code, Codex, Gemini, and Grok can message each other and hand off work without you copying text between windows.**
 
-**Protocol v2.5 · Reference CLI v1.5**
-
-A small Markdown protocol that lets AI agents hand off work, request review, and message each other — without a human relaying every step. No server, no broker, no SDK.
-
-[![Protocol v2.5](https://img.shields.io/badge/protocol-v2.5-1e6f57.svg)](AGENTCHUTE.md) [![CLI v1.5.3](https://img.shields.io/badge/CLI-v1.5.3-1e6f57.svg)](CHANGELOG.md) [![MIT](https://img.shields.io/badge/license-MIT-1e6f57.svg)](LICENSE) [![Conformance · 14 vectors](https://img.shields.io/badge/conformance-14%20vectors-1e6f57.svg)](conformance/)
-
-[Spec](AGENTCHUTE.md) · [Conformance](conformance/) · [Extensions](EXTENSIONS.md) · [Website](https://agentchute.dev) · [Why the wire moved →](https://agentchute.dev/blog/v2-5-the-wire-broke.html)
-
-<img src="docs/agentchute-hero.svg" alt="AI agents — e.g. claude, codex, gemini, grok, but any terminal-based agent works — each with its own inbox, passing Markdown messages peer to peer with no central broker." width="760">
-
-</div>
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/agentchute/agentchute/main/install.sh | sh
-```
-
-Already installed? Read the [v2.5 cutover checklist](docs/V2_5_CUTOVER.md) before `agentchute update`. This release changes the wire and must be upgraded pool-at-once; never use `--no-resync` for the first old→v2.5 update.
-
-That's the reference CLI. The protocol itself is just files — an implementation of your own interoperates with it directly, and the [conformance vectors](conformance/) tell you whether you got it right.
+[Spec](AGENTCHUTE.md) · [Examples](examples) · [Extensions](EXTENSIONS.md) · [agentchute.dev](https://agentchute.dev)
 
 ---
 
-## What 1.0 means here
+> **agentchute is the protocol, not the program.** The entire protocol is one file, [`AGENTCHUTE.md`](AGENTCHUTE.md): every agent owns an inbox — a folder of plain Markdown files inside your project — and agents communicate by writing message files into each other's inboxes. Any agent that can read and write files can participate. Everything else in this repo is the reference implementation, a Go CLI that was used agent-to-agent to build this very repository. The CLI is a convenience; the files are the contract.
 
-**Done, not big.** Most projects reach 1.0 by adding; agentchute got here by deleting. The pull-only redesign removed the watchdog, the wake adapters, and the reachability machinery; one release alone removed 8,262 lines; every release since is required to remove something. What's left is the stable core:
-
-- **Protocol v2 was declared stable.** *Stable* was meant SemVer-serious, not rhetorical: the covenants — the primitives (§1), the envelope (§6.4), the identity grammar (§6.1), the lifecycle guarantees — were to change only through the written deprecation process. The primitives, envelope, and lifecycle guarantees held. **The identity grammar didn't**: v2.5 replaces it (see [`AGENTCHUTE.md`](AGENTCHUTE.md)'s own top note and [the write-up](https://agentchute.dev/blog/v2-5-the-wire-broke.html)) — a real wire break, walked back openly rather than smuggled into a minor.
-- **CLI v1.5.x implements Protocol v2.5.** Registration rows carry integer `v: 3`; `status` and `doctor` render it as v2.5 and warn on mixed pools.
-- **Honesty clause:** the protocol had been stable since v0.10.0 through 1.0; v2.5 is the first time that changed, and this section says so rather than quietly updating the claim above it.
-
-## The idea
-
-Every agent has an inbox — a directory. A message is a Markdown file dropped in it. The recipient reads its own inbox, on its own schedule. Delivery is best-effort; the message just waits until it's read. That's the whole protocol, and it works with **any terminal-based agent** — Claude Code, Codex, Gemini CLI, Grok, or your own — because the protocol depends on no vendor behavior. (The reference runner installs a single `ac` dispatcher — launch any of those four with `ac serve <wrapper>`; any other terminal agent runs under the same runner or its own polling loop.)
-
-## What's in the protocol
-
-Five implementation-agnostic primitives. The inbox medium and transport are your choice — files, a queue, HTTP, or git all fit.
-
-- **Per-recipient inbox.** Each agent owns an ordered message stream; the recipient owns consumption.
-- **Identified messages.** Each message has a durable committed identity. A sender's messages stay in order, with no clock.
-- **No-overwrite delivery.** A sender never clobbers an existing message; a collision is refused and retried under a fresh identity — delivery is at-most-once, not deduped.
-- **Recipient reads its own inbox.** Pull, not push. Senders write and walk away.
-- **Self-registration + presence.** Each agent publishes a small record and a liveness heartbeat, read on demand.
-
-The guarantees are pinned by **language-neutral conformance vectors** — 14 vectors as JSON, run against both shipped bindings, plus a 251-line stdlib-Python proof that the vectors are implementable in any language. An implementation that passes the vectors is conformant, on any substrate.
-
-## A handoff
+## How it works
 
 ```
-   claude                                   codex
-  ┌────────┐                              ┌────────┐
-  │ inbox/ │                              │ inbox/ │
-  └────────┘                              └────────┘
-      │  1. write message to codex's inbox (no-overwrite)
-      ├─────────────────────────────────────────▶
-      │                                      2. codex reads its own
-      │                                         inbox on its cadence
-      │  3. reply lands in claude's inbox       │
-      │◀─────────────────────────────────────────
+ claude                              codex
+┌────────┐                         ┌────────┐
+│ inbox/ │                         │ inbox/ │
+└────────┘                         └────────┘
+    │  1. write a message file into codex's inbox
+    ├────────────────────────────────────▶
+    │                                    │ 2. codex reads its own
+    │                                    │    inbox, on its own schedule
+    │  3. reply lands in claude's inbox  │
+    │◀────────────────────────────────────
 ```
 
-No sender ever pokes a recipient, and there is no process in the middle. The message waits in the inbox until the recipient reads it.
+- **One inbox per agent.** Delivery is no-overwrite: a sender can never replace existing mail. A message is archived once it's handled. No server, no broker, no process in the middle.
+- **Reply obligations.** A message flagged with `--ask` records the obligation on the sender's side, so an unanswered request surfaces as an overdue item instead of silently hanging — and a finish gate keeps an agent from ending its turn with unread mail in its inbox.
+- **`ac serve` does the housekeeping.** The runner enrolls the agent, polls its inbox, and cues it when mail arrives; lifecycle hooks cover the rest. No manual bookkeeping.
+- **Projects are isolated.** Agents only see teammates in their own project. Connecting separate projects or Git worktrees is possible but explicit (`agentchute prepare-pool`).
 
-## Quickstart
+## Install the reference CLI
 
 ```sh
-# 1. install + wire your repo once
 curl -fsSL https://raw.githubusercontent.com/agentchute/agentchute/main/install.sh | sh
-agentchute setup --wake runner --wrappers all --yes
-
-# 2. start each agent in its own terminal, with a pinned id so peers can address it
-AGENTCHUTE_AGENT_ID=claude-code ac serve claude   # one terminal
-AGENTCHUTE_AGENT_ID=codex       ac serve codex    # another terminal
-agentchute doctor --as codex                      # sanity-check (any terminal)
 ```
 
-That's it — both agents are enrolled and polling their own inboxes. Coordination happens between them; you won't normally run these next commands yourself, but they're what the agents do:
+The installer also wires the current repo: lifecycle hooks plus a single `ac` dispatcher. Open a new shell so `ac` lands on your PATH, then verify:
 
 ```sh
-# claude-code asks codex for a review
-agentchute send --from claude-code --to codex --ask --body "review PR #42"
-
-# codex reads its own inbox, replies, then commits
-agentchute check --as codex     # CLAIM + display (does not archive yet)
-agentchute send --from codex --to claude-code --reply-to <ref> --body "looks good"
-agentchute ack --as codex       # COMMIT: archive the claimed message
+agentchute doctor
 ```
 
-`--ask` records the obligation on the **sender's** side, so an unanswered request surfaces as your own overdue item — never a silent hang.
+## Start your agents
+
+Launch each agent in its own terminal through `ac serve` — it enrolls the agent in the pool and keeps it polling its inbox. Anything after the wrapper name is passed through to the agent itself:
+
+```sh
+ac serve claude                                # Claude Code
+ac serve codex                                 # Codex, second terminal
+ac serve codex resume                          # pass-through args work
+ac --as sonnet-review serve claude --model sonnet   # pin a custom id peers can address
+```
+
+That's it. From here the agents coordinate between themselves — request reviews, reply, hand off — using their inboxes.
 
 ## What it isn't
 
-Not a multi-agent framework. No task graphs, no role election, no central broker, no SaaS tier.
+- **Not a multi-agent framework.** No task graphs, no roles, no orchestrator. Your agents stay what they are — this only gives them mail.
+- **Not a message broker.** Delivery is best-effort, no retries: a message just waits until it's read. Need guarantees? Use a queue.
+- **Not secure messaging.** Plain, unsigned text — only for agents you trust on your own machine.
+- **Not an audit log.** The mail folder is a transient local working trace, not a permanent record.
 
-- **Not a delivery broker.** Best-effort and at-most-once (consume is at-least-once via claim/ack; handler idempotency is the covenant); the recipient reads on its own cadence. Need retries and exactly-once? Use a queue.
-- **Not an auth system.** Messages are unsigned plain text. If you don't trust your peers, don't run them on your machine.
-- **Not a router.** Agents are peers; senders pick recipients explicitly. No wildcard, no broadcast.
-- **Not an audit log.** The loop is a transient, local operational trace, gitignored by default.
+## Good to know
 
-## Status: a protocol, not a product
-
-agentchute is an open protocol and a faithful reference implementation. It is **not a product**: there is no support tier, no SLA, no roadmap-by-request. The reference CLI is maintained for spec fidelity; alternate implementations are welcome and the [vectors](conformance/) are how you prove one. Every release must remove something or shorten the removable-later list — that policy is why 1.0 exists.
-
-What's next lives **around** the stable core, never inside the wire — self-serve conformance certification, a cleaner cue channel, git-backed pools for multi-host. [The roadmap around a stable core →](https://agentchute.dev/blog/after-done-roadmap.html)
-
-## Spec, hacking, license
-
-The protocol is [`AGENTCHUTE.md`](AGENTCHUTE.md); the binary is one reference implementation. Behavior changes start with the spec and the [conformance vectors](conformance/). Tested targets and operational assumptions are in [`AGENTCHUTE.md` §2](AGENTCHUTE.md#2-scope).
-
-```sh
-git clone https://github.com/agentchute/agentchute
-cd agentchute && test -z "$(gofmt -l .)" && go vet ./... && go test ./... && go build ./...
-```
-
-Go 1.21+. Core is stdlib; the agent supervisor uses `github.com/creack/pty`. See [`CONTRIBUTING.md`](CONTRIBUTING.md) · [`SECURITY.md`](SECURITY.md) · MIT — [`LICENSE`](LICENSE).
+- All participants must share one filesystem — in practice, one computer.
+- macOS and Linux; Windows via WSL.
+- Upgrade later with `agentchute update` — it updates the binary and re-syncs the repo in one step.
 
 ---
 
-<div align="center">
-
-*Built by [reHuman Labs](https://rehumanlabs.com). Let humans do human work, agents do agent work, and stop using humans as a message bus.*
-
-</div>
+MIT — see [LICENSE](LICENSE)


### PR DESCRIPTION
Replaces the release-history README with a short page written for someone who has never heard of agentchute — they have a few seconds to grasp what it is before moving on.

- One-line pitch up top, then how-it-works diagram, install, launch, what-it-isn't.
- Drops internal history (1.0 honesty clause, roadmap, badges, cutover warning) that means nothing to a first-time visitor.
- 40 lines in, 98 out.

Authored by Alex; on the bus for 4-way gate review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)