### PR TITLE
docs(cutover): status header says executed, not pending authorization

### DIFF
--- a/docs/V2_5_CUTOVER.md
+++ b/docs/V2_5_CUTOVER.md
@@ -1,6 +1,6 @@
 # Protocol v2.5 live-pool cutover
 
-Status: **prepared, not executed**. Do not run this checklist until Alex explicitly authorizes the live-pool cutover. Do not tag or publish as part of the cutover.
+Status: **executed 2026-07-31** on this repository's own pool; shipped as v1.5.0 (the same steps are recorded as history in CHANGELOG.md's v1.5.0 entry). Retained as the reference procedure for any pool upgrading from a pre-v2.5 install — follow the numbered steps against your own pool.
 
 Preconditions: all Group B slices merged to the release branch; Group A already live on the pool (it is wire-compatible and de-risks the break).
 


### PR DESCRIPTION
Follow-up to #121, raised by sonnet on the bus: the README now points pre-v2.5 upgraders at docs/V2_5_CUTOVER.md, whose status header still said "prepared, not executed — do not run until Alex explicitly authorizes". That cutover executed 2026-07-31 (shipped as v1.5.0), so an external reader was being told to wait on an internal gate that already fired.

One line changed: the status header now records the cutover as executed and frames the checklist as the reference procedure for pools upgrading their own pre-v2.5 install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)