### PR TITLE
fix(gate): mirror blocked verdicts to stderr for hook feedback channels

### DIFF
--- a/internal/cli/gate.go
+++ b/internal/cli/gate.go
@@ -113,6 +113,7 @@ func cmdGate(args []string) error {
 		emitGateText(status)
 	}
 
+	emitGateBlockedStderr(status)
 	if status.Blocked {
 		return errBlocked
 	}
@@ -365,6 +366,27 @@ func emitGateJSON(s gateStatus) error {
 	return enc.Encode(s)
 }
 
+// gateBlockedReasonLine is the one-line block verdict shared by every channel
+// that carries the reason to a model: the codex Stop envelope's "reason" field
+// and the stderr mirror below.
+func gateBlockedReasonLine(s gateStatus) string {
+	return fmt.Sprintf("agentchute gate --before %s: %s", s.Phase, strings.Join(s.Reasons, "; "))
+}
+
+// emitGateBlockedStderr mirrors a blocked verdict to stderr in the
+// non-envelope modes (text and --json). Claude Code's Stop hook surfaces only
+// stderr for an exit-2 hook — its stdout is reserved for that harness's own
+// decision-JSON schema, which the plain --json shape is not — so a
+// stdout-only block re-prompted the session with "No stderr output" and no
+// actionable content, an empty-feedback wake loop (aws-demo report,
+// 2026-08-11). Envelope modes (--codex-hook) keep their single channel.
+func emitGateBlockedStderr(s gateStatus) {
+	if !s.Blocked {
+		return
+	}
+	fmt.Fprintln(os.Stderr, gateBlockedReasonLine(s))
+}
+
 // emitGateCodexStop emits codex's Stop-hook shape. On block: `{"decision":
 // "block","reason":"..."}` to stdout, exit 0 (returned nil) — codex sees
 // the decision and continues the turn. On clear: no stdout (codex stops
@@ -374,10 +396,9 @@ func emitGateCodexStop(s gateStatus) error {
 	if !s.Blocked {
 		return nil
 	}
-	reason := fmt.Sprintf("agentchute gate --before %s: %s", s.Phase, strings.Join(s.Reasons, "; "))
 	out := map[string]any{
 		"decision": "block",
-		"reason":   reason,
+		"reason":   gateBlockedReasonLine(s),
 	}
 	enc := json.NewEncoder(os.Stdout)
 	return enc.Encode(out)

--- a/internal/cli/gate_test.go
+++ b/internal/cli/gate_test.go
@@ -91,6 +91,32 @@ func TestGateFinishBlocksOnUnreadMail(t *testing.T) {
 	})
 }
 
+// A blocked gate mirrors its reasons to stderr in the non-envelope modes
+// (same aws-demo Stop-hook contract as turn-end: stdout is not a feedback
+// channel when the caller is a hook that only surfaces stderr).
+func TestGateBlockedMirrorsReasonsToStderr(t *testing.T) {
+	root := setupBootFixture(t)
+	withCwd(t, root, func() {
+		t.Setenv("TMUX_PANE", "%1")
+		if _, err := captureStdout(t, func() error { return cmdBoot(bootArgs()) }); err != nil {
+			t.Fatal(err)
+		}
+		inboxDir := filepath.Join(root, ".agentchute", "loop", "inbox", "claude-code")
+		mustWriteSeqInbox(t, inboxDir, "codex", 1,
+			[]byte("---\nfrom: codex\nto: claude-code\ntask: x\n---\n\nb\n"))
+
+		_, errOut, err := captureStdoutStderr(t, func() error {
+			return cmdGate(gateArgs("finish"))
+		})
+		if !errors.Is(err, errBlocked) {
+			t.Fatalf("err = %v, want errBlocked", err)
+		}
+		if !strings.Contains(errOut, "unread") {
+			t.Errorf("stderr = %q, want the unread-mail reason mirrored there", errOut)
+		}
+	})
+}
+
 // gate --before consensus does NOT consult the stale-reg threshold. Stale
 // registration alone (with empty inbox + ledger) must pass consensus.
 func TestGateConsensusIgnoresStaleReg(t *testing.T) {

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -77,6 +77,14 @@ func clearGuardEnv(t *testing.T) {
 	t.Setenv("AGENTCHUTE_GUARD", "")
 }
 
+func captureStdoutStderr(t *testing.T, fn func() error) (stdout, stderr string, err error) {
+	t.Helper()
+	stderr = captureStderr(t, func() {
+		stdout, err = captureStdout(t, fn)
+	})
+	return stdout, stderr, err
+}
+
 // Pull-only (Gate 6c): setTmuxPaneLockObserver was removed with the tmux
 // pane-registration lock it observed. v2.5 plan B5: withFakeTmuxTargets (its
 // last caller, the presence scan's tmux enumeration) is gone too.

--- a/internal/cli/turn_end.go
+++ b/internal/cli/turn_end.go
@@ -185,6 +185,7 @@ func cmdTurnEnd(args []string) error {
 		emitTurnEndText(status, acked)
 	}
 
+	emitGateBlockedStderr(status)
 	if status.Blocked {
 		return errBlocked
 	}

--- a/internal/cli/turn_end_test.go
+++ b/internal/cli/turn_end_test.go
@@ -103,6 +103,82 @@ func TestTurnEndArchivesAndClearsLatchEvenWhenGateBlocked(t *testing.T) {
 	})
 }
 
+// TestTurnEndBlockedMirrorsReasonsToStderr is the aws-demo silent-wake-loop
+// regression (2026-08-11): Claude Code's Stop hook surfaces ONLY stderr for an
+// exit-2 hook, and turn-end's block verdict lived entirely on stdout — the
+// blocked session was re-prompted with "No stderr output" and no way to learn
+// why. A blocked turn-end must mirror the gate reasons to stderr in the
+// non-envelope modes, while stdout keeps its existing --json contract.
+func TestTurnEndBlockedMirrorsReasonsToStderr(t *testing.T) {
+	root := setupBootFixture(t)
+	withCwd(t, root, func() {
+		clearGuardEnv(t)
+		inboxDir := filepath.Join(root, ".agentchute", "loop", "inbox", "claude-code")
+		mustWriteSeqInbox(t, inboxDir, "codex", 1,
+			[]byte("---\nfrom: codex\nto: claude-code\ntask: x\n---\n\nb\n"))
+
+		out, errOut, err := captureStdoutStderr(t, func() error {
+			return cmdTurnEnd(turnEndArgs("--json"))
+		})
+		if !errors.Is(err, errBlocked) {
+			t.Fatalf("err = %v, want errBlocked", err)
+		}
+		var status gateStatus
+		if jerr := json.Unmarshal([]byte(out), &status); jerr != nil {
+			t.Fatalf("stdout is no longer parseable --json: %v\n%s", jerr, out)
+		}
+		if !status.Blocked {
+			t.Fatalf("status = %+v, want Blocked=true", status)
+		}
+		if !strings.Contains(errOut, "unread") {
+			t.Errorf("stderr = %q, want the unread-mail reason mirrored there (Claude Stop-hook feedback channel)", errOut)
+		}
+	})
+}
+
+// A clear turn-end must keep stderr empty: non-blocking hook stderr would be
+// pure noise on every successful stop.
+func TestTurnEndClearKeepsStderrSilent(t *testing.T) {
+	root := setupBootFixture(t)
+	withCwd(t, root, func() {
+		clearGuardEnv(t)
+		_, errOut, err := captureStdoutStderr(t, func() error {
+			return cmdTurnEnd(turnEndArgs("--json"))
+		})
+		if err != nil {
+			t.Fatalf("turn-end: %v", err)
+		}
+		if errOut != "" {
+			t.Errorf("stderr = %q, want empty on a clear gate", errOut)
+		}
+	})
+}
+
+// The codex Stop envelope carries the reason inside its stdout JSON; stderr
+// stays untouched there so codex never sees the message twice.
+func TestTurnEndCodexHookStopKeepsStderrSilentOnBlock(t *testing.T) {
+	root := setupBootFixture(t)
+	withCwd(t, root, func() {
+		clearGuardEnv(t)
+		inboxDir := filepath.Join(root, ".agentchute", "loop", "inbox", "claude-code")
+		mustWriteSeqInbox(t, inboxDir, "codex", 1,
+			[]byte("---\nfrom: codex\nto: claude-code\ntask: x\n---\n\nb\n"))
+
+		out, errOut, err := captureStdoutStderr(t, func() error {
+			return cmdTurnEnd(turnEndArgs("--codex-hook", "Stop"))
+		})
+		if err != nil {
+			t.Fatalf("turn-end --codex-hook Stop: %v", err)
+		}
+		if !strings.Contains(out, `"decision"`) {
+			t.Fatalf("stdout = %q, want codex block JSON", out)
+		}
+		if errOut != "" {
+			t.Errorf("stderr = %q, want empty in envelope mode", errOut)
+		}
+	})
+}
+
 // TestTurnEndDoesNotArchiveForeignLatchResidue is the gemini crash case
 // (grok P1): claimed residue exists from a DIFFERENT (dead/foreign) session
 // than the one now running turn-end. That residue must NOT be archived —


### PR DESCRIPTION
## What

When `turn-end` or `gate` blocks in a non-envelope mode (text or `--json`), the one-line block verdict is now also written to **stderr**. stdout contracts are unchanged; clear gates and `--codex-hook Stop` still write nothing to stderr.

## Why

Field report from the aws-demo team (relayed by Alex, reproduced by hand there and re-verified here): the shipped Claude Stop hook runs `agentchute turn-end --json`. On block it wrote `{"blocked": true, "reasons": [...]}` to stdout and exited 2 with **empty stderr**. Claude Code surfaces only stderr for an exit-2 Stop hook (its stdout is reserved for the harness's own decision-JSON schema, which our `--json` shape is not), so the blocked session saw `turn-end: No stderr output` and was re-prompted with zero actionable content — a silent wake loop that burned dozens of content-free re-prompts. The protocol verdict itself was correct; only the feedback channel was wrong. The codex lane was unaffected because its envelope (`--codex-hook Stop`) carries the reason inside the JSON codex actually reads.

## How

- `gateBlockedReasonLine` factors the existing codex-envelope reason string (`agentchute gate --before <phase>: <reasons>`) so every model-facing channel emits the identical line.
- `emitGateBlockedStderr` writes that line to stderr on block; called from the non-envelope emit paths of `cmdGate` and `cmdTurnEnd`.
- No hook template changes — installed fleets get the fix with a binary update alone; already-deployed `.claude/settings.json` files keep working as-is.
- The gate's reason strings already embed their own repair hints (e.g. ``run `agentchute check --as <id>` to quarantine``), so the mirror stays a verbatim reflection — no separate hint layer.

## Considered and declined: rate-limiting repeated identical blocks

The report's second item asked whether repeated identical blocks should back off. Declined: the token burn was amplified by the *empty* feedback — the model had nothing to act on, so it immediately re-stopped, forever. With the reason on stderr the loop resolves in one cycle (session runs `check`, next turn-end commits and clears). A gate that stops blocking on repetition would defeat the finish-gate invariant, and a counter that keeps blocking with the same message saves nothing. If a pathological loop ever reappears *with* actionable feedback, that's a new bug to diagnose, not a backoff to tune.

## Verification

- TDD: 4 new tests (`TestTurnEndBlockedMirrorsReasonsToStderr`, `TestGateBlockedMirrorsReasonsToStderr`, `TestTurnEndClearKeepsStderrSilent`, `TestTurnEndCodexHookStopKeepsStderrSilentOnBlock`) — the two mirror tests were watched failing with `stderr = ""` before the fix.
- Full suite green locally (`go test ./...` with `AGENTCHUTE_*` stripped), `gofmt`/`go vet` clean.
- Process-boundary probe of the built binary against a scratch pool: blocked finish gate → exit 2, unchanged stdout JSON, verdict line on stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
