### PR TITLE
fix(shims): export dispatcher binary override

### DIFF
--- a/internal/cli/shims.go
+++ b/internal/cli/shims.go
@@ -170,6 +170,7 @@ func renderDispatcherScript(agentchuteBin, shimDir string) string {
 	return fmt.Sprintf(`#!/bin/sh
 # agentchute dispatcher v1
 AGENTCHUTE_BIN=${AGENTCHUTE_BIN:-%s}
+export AGENTCHUTE_BIN
 exec "$AGENTCHUTE_BIN" dispatch --shim-dir %s -- "$@"
 `, shellQuote(agentchuteBin), shellQuote(shimDir))
 }

--- a/internal/cli/shims_test.go
+++ b/internal/cli/shims_test.go
@@ -45,6 +45,9 @@ func TestShimsInstallWritesDispatcher(t *testing.T) {
 	if !strings.Contains(string(data), "AGENTCHUTE_BIN=") {
 		t.Fatalf("dispatcher missing AGENTCHUTE_BIN override:\n%s", data)
 	}
+	if !strings.Contains(string(data), "export AGENTCHUTE_BIN\n") {
+		t.Fatalf("dispatcher does not export AGENTCHUTE_BIN to wrapper children:\n%s", data)
+	}
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
- export the dispatcher-selected AGENTCHUTE_BIN before exec
- assert generated dispatchers propagate the override to wrapper children

## Verification
- tools/test.sh