### PR TITLE
fix(doctor): enforce hook and binary parity

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"crypto/sha256"
+	"debug/buildinfo"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -131,9 +132,12 @@ func cmdDoctor(args []string) error {
 		return errBlocked
 	}
 
+	runningExecutable, _ := os.Executable()
 	opts := doctorOptions{
-		Now:     time.Now().UTC(),
-		PathEnv: os.Getenv("PATH"),
+		Now:               time.Now().UTC(),
+		PathEnv:           os.Getenv("PATH"),
+		RunningExecutable: runningExecutable,
+		RunningVersion:    version,
 	}
 	if gs, err := readSetupGlobalState(); err == nil {
 		opts.GlobalState = &gs
@@ -178,10 +182,13 @@ type doctorReport struct {
 }
 
 type doctorOptions struct {
-	Now         time.Time
-	PathEnv     string
-	GlobalState *setupGlobalState
-	PoolState   *setupPoolState
+	Now               time.Time
+	PathEnv           string
+	GlobalState       *setupGlobalState
+	PoolState         *setupPoolState
+	RunningExecutable string
+	RunningVersion    string
+	ReadBinaryVersion func(string) (string, error)
 }
 
 // runDoctorChecks executes the canonical check sequence and returns a
@@ -193,6 +200,7 @@ func runDoctorChecks(cfg *loop.Config, agentID string, opts doctorOptions) docto
 		checkProtocolVersions(cfg),
 		checkStaleTempFiles(cfg, opts.Now),
 		checkBinaryOnPath(),
+		checkBinaryIdentity(opts),
 		checkHookFilePresence(cfg, agentID),
 		checkHookContentSanity(cfg),
 		checkWrapperShadowing(cfg, agentID, opts),
@@ -474,6 +482,174 @@ func checkBinaryOnPath() doctorCheck {
 	}
 }
 
+type binaryIdentity struct {
+	label   string
+	path    string
+	version string
+}
+
+// checkBinaryIdentity verifies that the running binary, the generated ac
+// dispatcher's pinned binary, and bare agentchute on PATH report one version.
+// Missing/unreadable sources remain owned by the existing binary_on_path and
+// ac_dispatcher checks; a proven version mismatch is the only new blocker.
+func checkBinaryIdentity(opts doctorOptions) doctorCheck {
+	const name = "binary_identity"
+	if strings.TrimSpace(opts.RunningExecutable) == "" {
+		return doctorCheck{Name: name, Severity: severitySkip, Message: "running executable unavailable; skipping binary version parity"}
+	}
+
+	readVersion := opts.ReadBinaryVersion
+	if readVersion == nil {
+		readVersion = readAgentchuteBuildVersion
+	}
+	runningVersion := normalizeBinaryVersion(opts.RunningVersion)
+	if runningVersion == "" {
+		var err error
+		runningVersion, err = readVersion(opts.RunningExecutable)
+		if err != nil {
+			return doctorCheck{Name: name, Severity: severitySkip, Message: fmt.Sprintf("cannot read running binary version: %v", err)}
+		}
+		runningVersion = normalizeBinaryVersion(runningVersion)
+	}
+
+	identities := []binaryIdentity{{label: "running", path: opts.RunningExecutable, version: runningVersion}}
+	addIdentity := func(label, path string) {
+		if strings.TrimSpace(path) == "" || executableFileProblem(path) != "" {
+			return
+		}
+		candidateVersion := runningVersion
+		if !samePath(path, opts.RunningExecutable) {
+			var err error
+			candidateVersion, err = readVersion(path)
+			if err != nil {
+				return
+			}
+			candidateVersion = normalizeBinaryVersion(candidateVersion)
+		}
+		if candidateVersion != "" {
+			identities = append(identities, binaryIdentity{label: label, path: path, version: candidateVersion})
+		}
+	}
+
+	if target, err := dispatcherBinaryTarget(opts); err == nil {
+		addIdentity("dispatcher", target)
+	}
+	if pathBinary, err := resolveExecutableOnPath("agentchute", opts.PathEnv); err == nil {
+		addIdentity("PATH", pathBinary)
+	}
+
+	parts := make([]string, 0, len(identities))
+	mismatch := false
+	for _, identity := range identities {
+		parts = append(parts, fmt.Sprintf("%s=%s (%s)", identity.label, identity.version, identity.path))
+		if identity.version != runningVersion {
+			mismatch = true
+		}
+	}
+	if mismatch {
+		return doctorCheck{
+			Name:     name,
+			Severity: severityBlocker,
+			Message:  fmt.Sprintf("agentchute binary version mismatch: %s; rerun `agentchute setup` with the intended binary and fix PATH before launching wrappers", strings.Join(parts, ", ")),
+		}
+	}
+	if len(identities) < 2 {
+		return doctorCheck{Name: name, Severity: severitySkip, Message: "only the running agentchute binary version could be inspected; existing path/dispatcher checks own missing sources"}
+	}
+	return doctorCheck{Name: name, Severity: severityOK, Message: fmt.Sprintf("agentchute binary versions agree: %s", strings.Join(parts, ", "))}
+}
+
+func dispatcherBinaryTarget(opts doctorOptions) (string, error) {
+	if opts.GlobalState == nil || strings.TrimSpace(opts.GlobalState.ShimDir) == "" {
+		return "", errors.New("dispatcher shim directory unavailable")
+	}
+	data, err := os.ReadFile(filepath.Join(opts.GlobalState.ShimDir, "ac"))
+	if err != nil {
+		return "", err
+	}
+	const prefix = "AGENTCHUTE_BIN=${AGENTCHUTE_BIN:-"
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) || !strings.HasSuffix(line, "}") {
+			continue
+		}
+		return unquoteDispatcherValue(strings.TrimSuffix(strings.TrimPrefix(line, prefix), "}"))
+	}
+	return "", errors.New("dispatcher binary assignment not found")
+}
+
+func unquoteDispatcherValue(value string) (string, error) {
+	if len(value) < 2 || value[0] != '\'' || value[len(value)-1] != '\'' {
+		return "", fmt.Errorf("unsupported dispatcher binary quoting %q", value)
+	}
+	const escapedQuote = "'\\''"
+	inner := value[1 : len(value)-1]
+	marked := strings.ReplaceAll(inner, escapedQuote, "\x00")
+	if strings.Contains(marked, "'") {
+		return "", fmt.Errorf("unsupported dispatcher binary quoting %q", value)
+	}
+	return strings.ReplaceAll(marked, "\x00", "'"), nil
+}
+
+func resolveExecutableOnPath(name, pathEnv string) (string, error) {
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			dir = "."
+		}
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		candidate := filepath.Join(absDir, name)
+		if executableFileProblem(candidate) == "" {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("%s not found on PATH", name)
+}
+
+func readAgentchuteBuildVersion(path string) (string, error) {
+	info, err := buildinfo.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	for _, setting := range info.Settings {
+		if setting.Key != "-ldflags" {
+			continue
+		}
+		if value := mainVersionFromLDFlags(setting.Value); value != "" {
+			return value, nil
+		}
+	}
+	if info.Main.Version != "" && info.Main.Version != "(devel)" {
+		return info.Main.Version, nil
+	}
+	return "dev", nil
+}
+
+func mainVersionFromLDFlags(flags string) string {
+	fields := strings.Fields(strings.Trim(flags, "\""))
+	for i := 0; i < len(fields); i++ {
+		assignment := ""
+		switch {
+		case fields[i] == "-X" && i+1 < len(fields):
+			i++
+			assignment = fields[i]
+		case strings.HasPrefix(fields[i], "-X="):
+			assignment = strings.TrimPrefix(fields[i], "-X=")
+		}
+		assignment = strings.Trim(assignment, "\"'")
+		if strings.HasPrefix(assignment, "main.version=") {
+			return strings.TrimPrefix(assignment, "main.version=")
+		}
+	}
+	return ""
+}
+
+func normalizeBinaryVersion(value string) string {
+	return strings.TrimPrefix(strings.TrimSpace(value), "v")
+}
+
 // checkWrapperShadowing verifies the single `ac` dispatcher (v0.8.8) resolves
 // from the shim dir ahead of the system `ac` (/usr/sbin/ac, the accounting
 // command). It is OK when `ac` resolves from $shim_dir AND $shim_dir precedes any
@@ -551,11 +727,32 @@ func shimNamesForAgent(agentID string) []string {
 func checkHookFilePresence(cfg *loop.Config, agentID string) doctorCheck {
 	present := []string{}
 	presentSet := map[string]bool{}
+	drifted := []string{}
 	for _, h := range hookWrappers {
 		full := filepath.Join(cfg.ControlRepo, filepath.FromSlash(h.Dest))
-		if _, err := os.Stat(full); err == nil {
-			present = append(present, h.Name)
-			presentSet[h.Name] = true
+		installed, err := os.ReadFile(full)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return doctorCheck{
+				Name:     "hook_file_presence",
+				Severity: severityBlocker,
+				Message:  fmt.Sprintf("installed hook for %s is unreadable at %s: %v", h.Name, full, err),
+			}
+		}
+		present = append(present, h.Name)
+		presentSet[h.Name] = true
+		canonical, err := fs.ReadFile(hooksFS, h.Src)
+		if err != nil {
+			return doctorCheck{
+				Name:     "hook_file_presence",
+				Severity: severityBlocker,
+				Message:  fmt.Sprintf("canonical hook template for %s is unreadable: %v", h.Name, err),
+			}
+		}
+		if !bytes.Equal(installed, canonical) {
+			drifted = append(drifted, h.Name)
 		}
 	}
 	if wrapper, ok := hookWrapperForAgent(agentID); ok {
@@ -566,12 +763,12 @@ func checkHookFilePresence(cfg *loop.Config, agentID string) doctorCheck {
 				Message:  fmt.Sprintf("acting wrapper hook for %s is missing; run `agentchute hooks install --wrapper %s`", agentID, wrapper),
 			}
 		}
-		if drift := actingHookDrift(cfg, wrapper); drift != "" {
-			return doctorCheck{
-				Name:     "hook_file_presence",
-				Severity: severityBlocker,
-				Message:  drift,
-			}
+	}
+	if len(drifted) > 0 {
+		return doctorCheck{
+			Name:     "hook_file_presence",
+			Severity: severityBlocker,
+			Message:  fmt.Sprintf("installed hook template(s) differ from the canonical embed: %s; run `agentchute hooks install --wrapper all --scope repo --force`", strings.Join(drifted, ", ")),
 		}
 	}
 	if len(present) == 0 {
@@ -586,27 +783,6 @@ func checkHookFilePresence(cfg *loop.Config, agentID string) doctorCheck {
 		Severity: severityOK,
 		Message:  fmt.Sprintf("hook templates installed for: %s", strings.Join(present, ", ")),
 	}
-}
-
-func actingHookDrift(cfg *loop.Config, wrapper string) string {
-	for _, h := range hookWrappers {
-		if h.Name != wrapper {
-			continue
-		}
-		full := filepath.Join(cfg.ControlRepo, h.Dest)
-		installed, err := os.ReadFile(full)
-		if err != nil {
-			return fmt.Sprintf("acting wrapper hook for %s is unreadable at %s: %v", wrapper, full, err)
-		}
-		canonical, err := fs.ReadFile(hooksFS, h.Src)
-		if err != nil {
-			return fmt.Sprintf("canonical hook template for %s is unreadable: %v", wrapper, err)
-		}
-		if !bytes.Equal(installed, canonical) {
-			return fmt.Sprintf("acting wrapper hook for %s differs from the canonical template; run `agentchute hooks install --wrapper %s --force`", wrapper, wrapper)
-		}
-	}
-	return ""
 }
 
 // hookWrapperForAgent resolves an agent id to its canonical hookable wrapper.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -278,13 +278,9 @@ func TestDoctorPermissionsAllowNamingCheckDoesNotBlock(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(hookContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	r := runDoctorChecks(cfg, "", doctorOptions{Now: time.Now().UTC()})
-	got := findCheck(t, r, "hook_content_sanity")
+	got := checkHookContentSanity(cfg)
 	if got.Severity != severityOK {
 		t.Errorf("hook_content_sanity severity = %q, want OK (permissions.allow naming `agentchute check` is not a hook invoking it); msg=%q", got.Severity, got.Message)
-	}
-	if r.Blockers != 0 {
-		t.Errorf("Blockers = %d, want 0", r.Blockers)
 	}
 }
 
@@ -311,13 +307,9 @@ func TestDoctorMalformedHookJSONWithPermissionsSubstringDoesNotBlock(t *testing.
 	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(malformed), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	r := runDoctorChecks(cfg, "", doctorOptions{Now: time.Now().UTC()})
-	got := findCheck(t, r, "hook_content_sanity")
+	got := checkHookContentSanity(cfg)
 	if got.Severity != severityWarn {
 		t.Errorf("hook_content_sanity severity = %q, want WARN (invalid JSON, not a BLOCKER, and must not scan raw body); msg=%q", got.Severity, got.Message)
-	}
-	if r.Blockers != 0 {
-		t.Errorf("Blockers = %d, want 0 (malformed file must never trip the permissions-substring false positive)", r.Blockers)
 	}
 }
 
@@ -451,13 +443,9 @@ func TestDoctorUnknownSubcmdInPermissionsOnlyPasses(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(hookContent), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	r := runDoctorChecks(cfg, "", doctorOptions{Now: time.Now().UTC()})
-	got := findCheck(t, r, "hook_content_sanity")
+	got := checkHookContentSanity(cfg)
 	if got.Severity != severityOK {
 		t.Fatalf("hook_content_sanity severity = %q, want OK (permissions-only mention of an unknown subcommand); msg=%q", got.Severity, got.Message)
-	}
-	if r.Blockers != 0 {
-		t.Errorf("Blockers = %d, want 0", r.Blockers)
 	}
 }
 
@@ -678,6 +666,29 @@ func TestDoctorAsBlocksWhenActingWrapperHookDiverged(t *testing.T) {
 	}
 }
 
+func TestDoctorAsBlocksWhenNonActingInstalledHookDiverged(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	mustWriteCanonicalHook(t, cfg.ControlRepo, "codex")
+	mustWriteCanonicalHook(t, cfg.ControlRepo, "claude-code")
+
+	path := filepath.Join(cfg.ControlRepo, ".claude", "settings.json")
+	canonical := string(mustRead(t, path))
+	diverged := strings.Replace(canonical, "turn-end --json", "gate --before finish --json", 1)
+	if diverged == canonical {
+		t.Fatal("canonical claude-code hook did not contain the expected turn-end command")
+	}
+	mustWrite(t, path, []byte(diverged))
+
+	r := runDoctorChecks(cfg, "codex", doctorOptions{Now: time.Now().UTC()})
+	got := findCheck(t, r, "hook_file_presence")
+	if got.Severity != severityBlocker {
+		t.Fatalf("hook_file_presence severity = %q, want BLOCKER for non-acting claude-code drift; msg=%q", got.Severity, got.Message)
+	}
+	if !strings.Contains(got.Message, "claude-code") || !strings.Contains(got.Message, "--force") {
+		t.Fatalf("message should name claude-code and the forced repair: %q", got.Message)
+	}
+}
+
 // A tmux/herdr-only wake set — including the combined "tmux,herdr" — installs
 // only hookless shims, so a hookable wrapper (codex) relies on its lifecycle
 // hook and shadowing is not applicable. Regression for the pre-fix `wake ==
@@ -726,6 +737,106 @@ func TestDoctorAcDispatcherResolution(t *testing.T) {
 	got = checkWrapperShadowing(cfg, "codex", mkOpts(sysDir))
 	if got.Severity != severityWarn || !strings.Contains(got.Message, "not on PATH") {
 		t.Fatalf("not-on-path case: sev=%q msg=%q, want WARN not-on-PATH", got.Severity, got.Message)
+	}
+}
+
+func TestDoctorBlocksOnBinaryVersionMismatch(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	root := t.TempDir()
+	shimDir := filepath.Join(root, "shim")
+	pathDir := filepath.Join(root, "path")
+	runningBin := filepath.Join(root, "running-agentchute")
+	dispatcherBin := filepath.Join(root, "dispatcher-agentchute")
+	pathBin := filepath.Join(pathDir, "agentchute")
+
+	for _, path := range []string{runningBin, dispatcherBin, pathBin} {
+		mustWrite(t, path, []byte("binary fixture"))
+		if err := os.Chmod(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(t, filepath.Join(shimDir, "ac"), []byte(renderDispatcherScript(dispatcherBin, shimDir)))
+
+	readVersion := func(path string) (string, error) {
+		switch {
+		case samePath(path, runningBin), samePath(path, dispatcherBin):
+			return "1.5.3", nil
+		case samePath(path, pathBin):
+			return "1.0.0", nil
+		default:
+			return "", os.ErrNotExist
+		}
+	}
+	r := runDoctorChecks(cfg, "", doctorOptions{
+		Now:               time.Now().UTC(),
+		PathEnv:           pathDir,
+		GlobalState:       &setupGlobalState{Wake: "runner", ShimDir: shimDir},
+		PoolState:         &setupPoolState{Wake: "runner"},
+		RunningExecutable: runningBin,
+		RunningVersion:    "1.5.3",
+		ReadBinaryVersion: readVersion,
+	})
+	got := findCheck(t, r, "binary_identity")
+	if got.Severity != severityBlocker {
+		t.Fatalf("binary_identity severity = %q, want BLOCKER; msg=%q", got.Severity, got.Message)
+	}
+	for _, want := range []string{"running=1.5.3", "dispatcher=1.5.3", "PATH=1.0.0"} {
+		if !strings.Contains(got.Message, want) {
+			t.Fatalf("binary_identity message missing %q: %q", want, got.Message)
+		}
+	}
+}
+
+func TestDoctorBinaryVersionsAgree(t *testing.T) {
+	root := t.TempDir()
+	shimDir := filepath.Join(root, "shim")
+	runningBin := filepath.Join(root, "agentchute")
+	mustWrite(t, runningBin, []byte("binary fixture"))
+	if err := os.Chmod(runningBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(shimDir, "ac"), []byte(renderDispatcherScript(runningBin, shimDir)))
+
+	got := checkBinaryIdentity(doctorOptions{
+		PathEnv:           root,
+		GlobalState:       &setupGlobalState{Wake: "runner", ShimDir: shimDir},
+		RunningExecutable: runningBin,
+		RunningVersion:    "1.5.3",
+		ReadBinaryVersion: func(string) (string, error) { return "", errors.New("same binary should reuse the running version") },
+	})
+	if got.Severity != severityOK {
+		t.Fatalf("binary_identity severity = %q, want OK; msg=%q", got.Severity, got.Message)
+	}
+	for _, want := range []string{"running=1.5.3", "dispatcher=1.5.3", "PATH=1.5.3"} {
+		if !strings.Contains(got.Message, want) {
+			t.Fatalf("binary_identity message missing %q: %q", want, got.Message)
+		}
+	}
+}
+
+func TestDispatcherBinaryTargetParsesGeneratedQuoting(t *testing.T) {
+	shimDir := t.TempDir()
+	want := filepath.Join(t.TempDir(), "agentchute's binary")
+	mustWrite(t, filepath.Join(shimDir, "ac"), []byte(renderDispatcherScript(want, shimDir)))
+
+	got, err := dispatcherBinaryTarget(doctorOptions{GlobalState: &setupGlobalState{ShimDir: shimDir}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("dispatcher target = %q, want %q", got, want)
+	}
+}
+
+func TestMainVersionFromLDFlags(t *testing.T) {
+	for flags, want := range map[string]string{
+		`-s -w -X main.version=1.5.3`:  "1.5.3",
+		`-s -X=main.version=v1.5.4`:    "v1.5.4",
+		`-s -X other.value=irrelevant`: "",
+	} {
+		if got := mainVersionFromLDFlags(flags); got != want {
+			t.Errorf("mainVersionFromLDFlags(%q) = %q, want %q", flags, got, want)
+		}
 	}
 }
 
@@ -870,6 +981,8 @@ func TestDoctorAGENTCHUTE_BINAcceptsExecutableFile(t *testing.T) {
 
 func TestCmdDoctorJSONShape(t *testing.T) {
 	cfg := newDoctorCfg(t)
+	t.Setenv("AGENTCHUTE_BIN", "")
+	t.Setenv("PATH", t.TempDir())
 	// cmdDoctor calls loop.Discover, which needs AGENTCHUTE.md at the
 	// control repo root. newDoctorCfg only sets up the loop dir; add the
 	// spec file so discovery succeeds.


### PR DESCRIPTION
## Summary
- byte-compare every installed known hook against the canonical embed
- compare running, dispatcher-pinned, and PATH agentchute versions using read-only Go build metadata
- block proven version mismatches without changing existing warning severities

## Verification
- tools/test.sh