### PR TITLE
fix(install): refuse silent binary-only upgrades; warn on PATH shadowing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -291,6 +291,25 @@ path_expr_for_profile() {
 	esac
 }
 
+# warn_path_shadow reports (non-fatal) when the agentchute this process's OWN
+# PATH resolves to is not the binary just installed at target — e.g. an older
+# copy from a different install method (a package manager, an earlier --to)
+# sits before it on PATH. install.sh always writes to a fixed target with no
+# awareness of any other agentchute already on PATH; unlike `agentchute
+# update`, which self-corrects because it replaces whatever binary is
+# actually running, install.sh has no such feedback loop. Hooks and doctor
+# both invoke the bare `agentchute` (via ${AGENTCHUTE_BIN:-agentchute}), so a
+# shadowed old binary keeps running silently until PATH order changes (2026-
+# 08-11 hook-refresh-reliability investigation, finding 6).
+warn_path_shadow() {
+	target="$1"
+	resolved=$(command -v agentchute 2>/dev/null || true)
+	if [ -n "$resolved" ] && [ "$resolved" != "$target" ]; then
+		warn "agentchute on PATH resolves to $resolved, not the just-installed $target"
+		warn "  hooks and doctor use whichever copy PATH resolves; remove or reorder the other install so they see the new version"
+	fi
+}
+
 # warn_path_missing prints a friendly add-to-PATH hint if install_dir isn't on
 # $PATH. No mutation.
 warn_path_missing() {
@@ -488,6 +507,21 @@ EOF
 		fi
 	fi
 
+	# Resolve do_setup from auto NOW, before any download or mutation, using
+	# the have_tty probe already taken above. do_setup_was_auto distinguishes
+	# "environment decided" from an explicit --setup/--no-setup /
+	# AGENTCHUTE_SETUP, which the upgrade-in-place gate below must never
+	# second-guess.
+	do_setup_was_auto=0
+	if [ "$do_setup" = "auto" ]; then
+		do_setup_was_auto=1
+		if [ "$have_tty" = "1" ]; then
+			do_setup=1
+		else
+			do_setup=0
+		fi
+	fi
+
 	probe_deps
 	sha_cmd=$(pick_sha256)
 
@@ -520,6 +554,27 @@ EOF
 	# unwritable existing dir). Mutation (mkdir) happens later.
 	validate_install_dir "$install_dir" "$is_custom"
 
+	# An existing binary at the target IS the "upgrade-in-place" signal: a
+	# fresh install has nothing to leave stale. When the environment (not the
+	# operator) decided to skip setup, refuse BEFORE downloading or swapping
+	# anything rather than silently binary-only-upgrading and printing a hint
+	# nothing captures stderr for. An explicit --setup/--no-setup/
+	# AGENTCHUTE_SETUP is untouched: that is deliberate operator intent, not
+	# an environmental accident (2026-08-11 hook-refresh-reliability
+	# investigation, finding 1 — install.sh's do_setup=auto silently resolving
+	# to skip in any non-interactive context, e.g. CI, cron, or an agent's own
+	# shell tool, left hooks/enrollment/AGENTCHUTE.md on the old version with
+	# only a stderr hint as the signal).
+	upgrade_in_place=0
+	[ -x "$install_dir/agentchute" ] && upgrade_in_place=1
+	if [ "$do_setup_was_auto" = "1" ] && [ "$do_setup" = "0" ] && [ "$upgrade_in_place" = "1" ] && [ "$dry_run" != "1" ]; then
+		err "refusing to upgrade $install_dir/agentchute non-interactively: no controlling terminal, so setup would not run and hooks, enrollment blocks, and AGENTCHUTE.md would stay at the OLD version after the binary swap.
+  re-run with one of:
+    sh install.sh --setup     # force setup to run now
+    sh install.sh --no-setup  # explicitly accept binary-only; refresh later with: agentchute setup
+    sh install.sh              # from an interactive terminal"
+	fi
+
 	# Show the plan in a tab-aligned summary (gemini's "indifferent-but-informative" voice).
 	cat <<EOF
 agentchute install
@@ -547,6 +602,11 @@ EOF
 			info "--fresh would, after installing the new binary, run (DESTRUCTIVE):"
 			info "  agentchute setup --reset --wipe-state --shim-dir ${shim_dir:-${HOME:-}/.agentchute/bin} --wrappers $setup_wrappers --wake $setup_wake$fresh_yes"
 			info "  (wipes loop runtime state after stopping local processes; refuses a live bus)"
+		fi
+		if [ "$do_setup_was_auto" = "1" ] && [ "$do_setup" = "0" ] && [ "$upgrade_in_place" = "1" ]; then
+			info ""
+			info "note: this looks like a non-interactive upgrade over an existing install ($install_dir/agentchute exists, no controlling terminal)."
+			info "a real run would refuse here unless --setup or --no-setup is passed explicitly."
 		fi
 		return 0
 	fi
@@ -592,20 +652,13 @@ EOF
 	info "Security: this verified release checksums; piping the installer still trusts this GitHub repository."
 
 	ensure_path_available "$install_dir" "binary"
+	warn_path_shadow "$install_dir/agentchute"
 
 	if [ -z "$shim_dir" ]; then
 		[ -n "${HOME:-}" ] || err "HOME unset; set AGENTCHUTE_SHIM_DIR explicitly for the ac dispatcher"
 		shim_dir="${HOME}/.agentchute/bin"
 	fi
 	is_valid_install_dir "$shim_dir" || err "invalid shim dir: $shim_dir (must not contain quotes, dollar signs, backticks, or backslashes)"
-
-	if [ "$do_setup" = "auto" ]; then
-		if ( : </dev/tty ) 2>/dev/null; then
-			do_setup=1
-		else
-			do_setup=0
-		fi
-	fi
 
 	if [ "$do_setup" = "1" ]; then
 		if [ "$fresh" = "1" ]; then

--- a/tests/install_test.sh
+++ b/tests/install_test.sh
@@ -171,6 +171,164 @@ assert_eq "checksum line: missing → empty" "" "$out"
 rm -f "$tmp"
 
 # -----------------------------------------------------------------------
+# true main-flow: real install.sh, real network stack against a local
+# release fixture (no actual network egress). Covers the upgrade-in-place
+# setup-disposition gate and the PATH-shadow warning (2026-08-11 hook-
+# refresh-reliability investigation, findings 1 and 6).
+# -----------------------------------------------------------------------
+
+# These scenarios depend on the ambient controlling-terminal state: CI (and
+# any sandboxed agent shell) has none, matching the real-world bug — any
+# non-interactive automation running install.sh over an existing install. A
+# developer running this file from an interactive terminal has one, so the
+# no-tty-specific assertions below are skipped rather than false-failed.
+if ( : </dev/tty ) 2>/dev/null; then
+	mainflow_have_tty=1
+else
+	mainflow_have_tty=0
+fi
+
+mainflow_root=$(mktemp -d)
+mainflow_http="$mainflow_root/http"
+mainflow_ver="v9.9.9"
+mainflow_bare_ver="9.9.9"
+mainflow_goos=$(detect_os)
+mainflow_goarch=$(detect_arch)
+mainflow_asset="agentchute_${mainflow_bare_ver}_${mainflow_goos}_${mainflow_goarch}.tar.gz"
+mainflow_release_dir="$mainflow_http/releases/download/$mainflow_ver"
+mkdir -p "$mainflow_release_dir"
+
+mainflow_stage="$mainflow_root/stage"
+mkdir -p "$mainflow_stage"
+cat >"$mainflow_stage/agentchute" <<'FAKEBIN'
+#!/bin/sh
+echo "fake-agentchute-test-fixture"
+FAKEBIN
+chmod +x "$mainflow_stage/agentchute"
+tar -C "$mainflow_stage" -czf "$mainflow_release_dir/$mainflow_asset" agentchute
+
+if command -v sha256sum >/dev/null 2>&1; then
+	mainflow_sum=$(sha256sum "$mainflow_release_dir/$mainflow_asset" | awk '{print $1}')
+else
+	mainflow_sum=$(shasum -a 256 "$mainflow_release_dir/$mainflow_asset" | awk '{print $1}')
+fi
+printf '%s  %s\n' "$mainflow_sum" "$mainflow_asset" >"$mainflow_release_dir/checksums.txt"
+
+mainflow_port_file="$mainflow_root/http.port"
+python3 - "$mainflow_http" "$mainflow_port_file" <<'PY' >"$mainflow_root/http.log" 2>&1 &
+import http.server
+import os
+import sys
+
+os.chdir(sys.argv[1])
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), http.server.SimpleHTTPRequestHandler)
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    handle.write(str(server.server_port))
+server.serve_forever()
+PY
+mainflow_server_pid=$!
+
+mainflow_wait_i=0
+while [ ! -s "$mainflow_port_file" ]; do
+	mainflow_wait_i=$((mainflow_wait_i + 1))
+	if [ "$mainflow_wait_i" -ge 50 ]; then
+		FAIL=$((FAIL + 1))
+		printf 'FAIL  main-flow: local release server did not start\n'
+		break
+	fi
+	sleep 0.1
+done
+mainflow_port=$(cat "$mainflow_port_file" 2>/dev/null || true)
+
+if [ -n "$mainflow_port" ]; then
+	mainflow_base="http://127.0.0.1:$mainflow_port"
+
+	# Every real sh install.sh invocation below MUST override
+	# AGENTCHUTE_INSTALL_LIB=0: the AGENTCHUTE_INSTALL_LIB=1 . ./install.sh
+	# line at the top of this file sourced install.sh via the shell's `.`
+	# special builtin, whose variable-assignment prefix persists (and
+	# exports) in the CURRENT shell rather than scoping to the sourced file
+	# — a POSIX special-builtin quirk (`VAR=val cmd` scopes normally;
+	# `VAR=val .` does not). Left unset, every main-flow sh install.sh below
+	# would silently inherit AGENTCHUTE_INSTALL_LIB=1 and skip main()
+	# entirely, exiting 0 having done nothing.
+
+	# Scenario A: fresh install (no existing binary at target), explicit
+	# --no-setup so the scenario doesn't depend on ambient tty state. Must
+	# succeed and actually write the target binary.
+	mainflow_fresh_to="$mainflow_root/fresh-to"
+	mkdir -p "$mainflow_fresh_to"
+	mainflow_rc=0
+	AGENTCHUTE_INSTALL_LIB=0 AGENTCHUTE_BASE_URL="$mainflow_base" HOME="$mainflow_root/fresh-home" AGENTCHUTE_NO_PATH_UPDATE=1 \
+		sh install.sh --version "$mainflow_ver" --to "$mainflow_fresh_to" --no-setup \
+		>"$mainflow_root/fresh.out" 2>"$mainflow_root/fresh.err" || mainflow_rc=$?
+	assert_eq "main-flow: fresh install exits 0" "0" "$mainflow_rc"
+	assert_true "main-flow: fresh install wrote the target binary" "[ -x \"$mainflow_fresh_to/agentchute\" ]"
+
+	if [ "$mainflow_have_tty" = "0" ]; then
+		# Scenario B: upgrade-in-place, do_setup left at its default (auto),
+		# no controlling terminal. Must refuse BEFORE swapping the binary.
+		mainflow_upgrade_to="$mainflow_root/upgrade-to"
+		mkdir -p "$mainflow_upgrade_to"
+		printf '#!/bin/sh\necho old-agentchute\n' >"$mainflow_upgrade_to/agentchute"
+		chmod +x "$mainflow_upgrade_to/agentchute"
+		mainflow_old_marker=$(cat "$mainflow_upgrade_to/agentchute")
+
+		mainflow_rc=0
+		AGENTCHUTE_INSTALL_LIB=0 AGENTCHUTE_BASE_URL="$mainflow_base" HOME="$mainflow_root/upgrade-home" AGENTCHUTE_NO_PATH_UPDATE=1 \
+			sh install.sh --version "$mainflow_ver" --to "$mainflow_upgrade_to" \
+			>"$mainflow_root/upgrade.out" 2>"$mainflow_root/upgrade.err" || mainflow_rc=$?
+
+		assert_true "main-flow: no-tty upgrade-in-place refuses (nonzero exit)" "[ $mainflow_rc -ne 0 ]"
+		assert_true "main-flow: refusal names the cause" \
+			"grep -qi 'no controlling terminal' \"$mainflow_root/upgrade.err\""
+		mainflow_after_marker=$(cat "$mainflow_upgrade_to/agentchute")
+		assert_eq "main-flow: refused upgrade never swapped the binary" "$mainflow_old_marker" "$mainflow_after_marker"
+
+		# Scenario C: same upgrade-in-place, but explicit --no-setup. Must
+		# proceed (deliberate operator intent, not an environmental accident).
+		mainflow_explicit_to="$mainflow_root/explicit-to"
+		mkdir -p "$mainflow_explicit_to"
+		printf '#!/bin/sh\necho old-agentchute\n' >"$mainflow_explicit_to/agentchute"
+		chmod +x "$mainflow_explicit_to/agentchute"
+
+		mainflow_rc=0
+		AGENTCHUTE_INSTALL_LIB=0 AGENTCHUTE_BASE_URL="$mainflow_base" HOME="$mainflow_root/explicit-home" AGENTCHUTE_NO_PATH_UPDATE=1 \
+			sh install.sh --version "$mainflow_ver" --to "$mainflow_explicit_to" --no-setup \
+			>"$mainflow_root/explicit.out" 2>"$mainflow_root/explicit.err" || mainflow_rc=$?
+
+		assert_eq "main-flow: explicit --no-setup upgrade proceeds" "0" "$mainflow_rc"
+		mainflow_swapped_output=$("$mainflow_explicit_to/agentchute")
+		assert_eq "main-flow: explicit --no-setup upgrade swapped the binary" \
+			"fake-agentchute-test-fixture" "$mainflow_swapped_output"
+	else
+		printf 'SKIP  main-flow: no-tty upgrade scenarios (this shell has a controlling terminal)\n'
+	fi
+
+	# Scenario D: a stale agentchute earlier on PATH than the install
+	# target — must warn (not fail) that PATH resolves elsewhere.
+	mainflow_shadow_stale="$mainflow_root/shadow-stale-path"
+	mainflow_shadow_to="$mainflow_root/shadow-to"
+	mkdir -p "$mainflow_shadow_stale" "$mainflow_shadow_to"
+	printf '#!/bin/sh\necho stale\n' >"$mainflow_shadow_stale/agentchute"
+	chmod +x "$mainflow_shadow_stale/agentchute"
+
+	mainflow_rc=0
+	AGENTCHUTE_INSTALL_LIB=0 AGENTCHUTE_BASE_URL="$mainflow_base" HOME="$mainflow_root/shadow-home" AGENTCHUTE_NO_PATH_UPDATE=1 \
+		PATH="$mainflow_shadow_stale:$PATH" \
+		sh install.sh --version "$mainflow_ver" --to "$mainflow_shadow_to" --no-setup \
+		>"$mainflow_root/shadow.out" 2>"$mainflow_root/shadow.err" || mainflow_rc=$?
+
+	assert_eq "main-flow: PATH-shadow scenario still exits 0 (warn, not fail)" "0" "$mainflow_rc"
+	assert_true "main-flow: warns when PATH resolves a different agentchute" \
+		"grep -qi 'not the just-installed' \"$mainflow_root/shadow.err\""
+fi
+
+kill "$mainflow_server_pid" 2>/dev/null || true
+wait "$mainflow_server_pid" 2>/dev/null || true
+rm -rf "$mainflow_root"
+
+# -----------------------------------------------------------------------
 # summary
 # -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `install.sh`'s `do_setup=auto` silently resolved to skip setup in any non-interactive context (CI, cron, an agent's own shell tool). The tty probe now runs before the download/swap; an upgrade-in-place (an existing binary already at the target) refuses when the environment decided to skip setup, rather than silently binary-only-upgrading. An explicit `--setup`/`--no-setup`/`AGENTCHUTE_SETUP` is unaffected.
- Adds a non-fatal warning when the `agentchute` this process's own PATH resolves to isn't the binary just installed (a stale copy from a different install method can silently shadow the fresh one).
- Adds true main-flow tests exercising the real `install.sh` against a local release fixture (no network egress), covering both new behaviors plus the existing fresh-install and explicit-`--no-setup` paths.

Source: 2026-08-11 hook-refresh-reliability investigation (findings 1 and 6), PR 1 of 3 per the follow-up implementation task.

## Test plan
- [x] `shellcheck -s sh install.sh tests/install_test.sh` — clean
- [x] `sh tests/install_test.sh` — 36 passed, 0 failed
- [x] Confirmed red→green: the 4 new-behavior assertions fail against the unmodified `install.sh`, pass after the fix
- [x] `sh tools/test.sh` — gofmt/vet/test/build all clean (no `.go` changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)