### PR TITLE
fix serve-time wrapper hook refresh

### DIFF
--- a/internal/cli/hooks.go
+++ b/internal/cli/hooks.go
@@ -243,6 +243,46 @@ func installOneHook(w hookWrapper, scopeRoot string, dryRun, force bool) error {
 	return nil
 }
 
+// refreshWrapperHook creates or refreshes the launched wrapper's repo hook and
+// verifies exact parity with this binary before the wrapper starts. This makes
+// each discovered control repo self-healing without a global repo registry.
+func refreshWrapperHook(root, wrapper string) error {
+	var target *hookWrapper
+	for i := range hookWrappers {
+		if hookWrappers[i].Name == wrapper {
+			target = &hookWrappers[i]
+			break
+		}
+	}
+	if target == nil {
+		return nil
+	}
+
+	want, err := fs.ReadFile(hooksFS, target.Src)
+	if err != nil {
+		return fmt.Errorf("read embedded template for %s: %w", target.Name, err)
+	}
+	dest := filepath.Join(root, target.Dest)
+	got, err := os.ReadFile(dest)
+	if err == nil && bytes.Equal(got, want) {
+		return nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", dest, err)
+	}
+	if err := installOneHook(*target, root, false, true); err != nil {
+		return err
+	}
+	got, err = os.ReadFile(dest)
+	if err != nil {
+		return fmt.Errorf("read refreshed %s: %w", dest, err)
+	}
+	if !bytes.Equal(got, want) {
+		return fmt.Errorf("%s does not match the canonical %s template after refresh", dest, target.Name)
+	}
+	return nil
+}
+
 // refreshHookCompatibility keeps every ALREADY-INSTALLED hookWrappers file
 // under root working with this binary, independent of which wrappers are
 // selected for membership in the current setup/update run: the v1.5.0

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -381,6 +382,93 @@ func TestRunExportsRunnerPIDToWrapper(t *testing.T) {
 	}
 	if lines[1] != strconv.Itoa(os.Getpid()) {
 		t.Fatalf("AGENTCHUTE_RUNNER_PID = %q, want %d", lines[1], os.Getpid())
+	}
+}
+
+func TestServeRefreshesLaunchedWrapperHookBeforeLaunch(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		stale bool
+	}{
+		{name: "missing"},
+		{name: "stale", stale: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := setupShortRunFixture(t)
+			launchedPath := filepath.Join(root, "launched")
+			wrapper := filepath.Join(root, "codex")
+			mustWrite(t, wrapper, []byte("#!/bin/sh\nprintf launched > "+shellQuote(launchedPath)+"\n"))
+			if err := os.Chmod(wrapper, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if tc.stale {
+				mustWriteStaleHook(t, root, "codex")
+			}
+
+			withCwd(t, root, func() {
+				if err := cmdServe([]string{
+					"--as", "codex",
+					"--control-repo", root,
+					"--loop-dir", filepath.Join(root, ".agentchute", "loop"),
+					"--interval", "5",
+					"--idle-grace", "100ms",
+					"--", wrapper,
+				}); err != nil {
+					t.Fatalf("cmdServe err = %v", err)
+				}
+			})
+
+			if _, err := os.Stat(launchedPath); err != nil {
+				t.Fatalf("wrapper was not launched: %v", err)
+			}
+			for _, h := range hookWrappers {
+				if h.Name != "codex" {
+					continue
+				}
+				want, err := fs.ReadFile(hooksFS, h.Src)
+				if err != nil {
+					t.Fatal(err)
+				}
+				got, err := os.ReadFile(filepath.Join(root, h.Dest))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(got, want) {
+					t.Fatal("launched wrapper hook does not match the executing binary's canonical template")
+				}
+				return
+			}
+			t.Fatal("codex hook descriptor not found")
+		})
+	}
+}
+
+func TestServeDoesNotLaunchWhenWrapperHookCannotBeRefreshed(t *testing.T) {
+	root := setupShortRunFixture(t)
+	launchedPath := filepath.Join(root, "launched")
+	wrapper := filepath.Join(root, "codex")
+	mustWrite(t, wrapper, []byte("#!/bin/sh\nprintf launched > "+shellQuote(launchedPath)+"\n"))
+	if err := os.Chmod(wrapper, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustMkdir(t, filepath.Join(root, ".codex", "hooks.json"))
+
+	var serveErr error
+	withCwd(t, root, func() {
+		serveErr = cmdServe([]string{
+			"--as", "codex",
+			"--control-repo", root,
+			"--loop-dir", filepath.Join(root, ".agentchute", "loop"),
+			"--interval", "5",
+			"--idle-grace", "100ms",
+			"--", wrapper,
+		})
+	})
+	if serveErr == nil {
+		t.Fatal("cmdServe succeeded with an unrefreshable wrapper hook")
+	}
+	if _, err := os.Stat(launchedPath); !os.IsNotExist(err) {
+		t.Fatalf("wrapper launched despite hook refresh failure: stat err = %v", err)
 	}
 }
 

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -119,11 +119,13 @@ func cmdServe(args []string) error {
 		return runUsage(fmt.Errorf("missing wrapper command after --"))
 	}
 	opts.Vendor = strings.TrimSpace(opts.Vendor)
+	launchedWrapper := ""
 	if spec, ok := wrapperSpecForName(filepath.Base(opts.WrapperArgs[0])); ok {
 		if opts.Vendor == "" {
 			opts.Vendor = spec.Vendor
 		}
 		opts.Guarded = spec.Guarded
+		launchedWrapper = spec.AgentID
 	}
 
 	cwd, err := os.Getwd()
@@ -153,6 +155,9 @@ func cmdServe(args []string) error {
 	}
 	if err := loop.ValidateAgentID(opts.Vendor); err != nil {
 		return fmt.Errorf("--vendor: %w", err)
+	}
+	if err := refreshWrapperHook(cfg.ControlRepo, launchedWrapper); err != nil {
+		return fmt.Errorf("serve: refresh %s hook: %w", launchedWrapper, err)
 	}
 	return runWrapper(cfg, opts, cwd)
 }


### PR DESCRIPTION
## Summary
- create or refresh the launched wrapper hook in the discovered control repo before PTY launch
- verify exact parity with the executing binary’s embedded template and fail closed on repair errors
- leave hookless and custom wrappers unchanged

## Verification
- TDD regression: missing and stale Codex hooks failed before implementation
- `tools/test.sh`

No merge requested.