### PR TITLE
fix(update): resync-gate lease invalidation; name what --no-resync leaves stale

### DIFF
--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -608,6 +608,40 @@ var setupRunRuntimeReset = func(root string, cfg *loop.Config, wrappers []string
 
 func applySetup(root string, opts setupOptions, wrappers []string) error {
 	return runInDir(root, func() error {
+		// Phase 0 — hook COMPATIBILITY, not membership. Moved ahead of every
+		// other phase (2026-08-11 hook-refresh-reliability follow-up, codex
+		// vector 2): this is the single highest-value invariant applySetup
+		// protects — a stale hook file breaks EVERY future session — and it
+		// depends on nothing here but `root`, so it must never be gated
+		// behind cmdInit or the membership/shim/PATH writes below, any of
+		// which can fail for reasons entirely unrelated to hook compatibility
+		// (a malformed AGENTCHUTE.md, a permission error, a missing parent
+		// dir, …). Formerly positioned after those writes; a failure there
+		// returned before this ever ran, leaving a known-repairable stale
+		// hook un-repaired. Keeps every ALREADY-INSTALLED hookWrappers file
+		// working with this binary regardless of which wrappers this run
+		// selects for membership below, then verifies none still references
+		// an unknown subcommand — the v1.5.0 cutover incident (docs/
+		// decisions/agentchute-v150-cutover-incident-and-fix.md) was a
+		// resync that finished green while a hook file invoked a subcommand
+		// the new binary had removed, and the destructive reset then forced
+		// every supervisor to restart straight into that broken hook. On a
+		// verification failure this returns before init, the membership
+		// writes, or the destructive reset ever run — and before update.go
+		// ever invalidates a serve lease for this resync (internal/cli/
+		// update.go, cmdUpdate now waits for the resync to succeed before
+		// invalidating anything).
+		refreshedHooks, err := refreshHookCompatibility(root)
+		if err != nil {
+			return fmt.Errorf("hook compatibility refresh: %w", err)
+		}
+		if len(refreshedHooks) > 0 {
+			fmt.Printf("refreshed %d hook template(s) for compatibility: %s\n", len(refreshedHooks), strings.Join(refreshedHooks, ", "))
+		}
+		if err := applySetupVerifyHookCompatibility(root); err != nil {
+			return fmt.Errorf("hook compatibility verification failed: %w", err)
+		}
+
 		// Phase 1 — idempotent scaffolding. cmdInit writes AGENTCHUTE.md and the
 		// per-wrapper enrollment blocks (CLAUDE.md/CODEX.md/GEMINI.md/AGENTS.md).
 		// Re-runnable; safe to repeat after a partial failure.
@@ -758,41 +792,6 @@ func applySetup(root string, opts setupOptions, wrappers []string) error {
 			UpdatedAt:           time.Now().UTC().Format(time.RFC3339),
 		}); err != nil {
 			return err
-		}
-
-		// Phase 2.5 — hook COMPATIBILITY, not membership. Keep every
-		// ALREADY-INSTALLED hookWrappers file working with this binary
-		// regardless of which wrappers this run selected for membership
-		// above, then verify none still references an unknown subcommand.
-		// This must land before "setup complete" and before the destructive
-		// reset below: the v1.5.0 cutover incident (docs/decisions/
-		// agentchute-v150-cutover-incident-and-fix.md) was a resync that
-		// finished green while a hook file invoked a subcommand the new
-		// binary had removed, and the destructive reset then forced every
-		// supervisor to restart straight into that broken hook. On a
-		// verification failure this returns before the reset runs, so it
-		// never gets a chance to force a restart into that known-broken
-		// hook. What this buys depends on the caller: a DIRECT `agentchute
-		// setup` invocation has not invalidated any serve lease yet at this
-		// point, so its supervisors stay genuinely un-fenced. An `agentchute
-		// update` resync is different — cmdUpdate invalidates every serve
-		// lease BEFORE it ever re-execs `setup` (internal/cli/update.go, well
-		// before the resync call), so by the time this phase could fail here
-		// supervisors are already fenced regardless; what this still buys on
-		// that path is avoiding a redundant local-runner-stop/state-clear and,
-		// more importantly, keeping this process from ever printing "setup
-		// complete" — which is what stops `cmdUpdate` from reaching its own
-		// final restart-success banner (see docs/decisions/
-		// agentchute-update-fix-v2.md).
-		refreshedHooks, err := refreshHookCompatibility(root)
-		if err != nil {
-			return fmt.Errorf("hook compatibility refresh: %w", err)
-		}
-		if len(refreshedHooks) > 0 {
-			fmt.Printf("refreshed %d hook template(s) for compatibility: %s\n", len(refreshedHooks), strings.Join(refreshedHooks, ", "))
-		}
-		if err := applySetupVerifyHookCompatibility(root); err != nil {
-			return fmt.Errorf("hook compatibility verification failed: %w", err)
 		}
 
 		// Phase 3 — destructive runtime reset, LAST. By the time we reach here

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -882,6 +882,54 @@ func TestSetupResync_RefreshesStaleHookOutsideMembership(t *testing.T) {
 	}
 }
 
+// TestSetupResync_HookCompatRepairRunsAheadOfFailingInit proves the
+// reordering codex's vector 2 review required (2026-08-11 hook-refresh-
+// reliability follow-up): hook-compatibility repair (formerly Phase 2.5,
+// now Phase 0) runs BEFORE cmdInit and the membership/shim writes, not
+// after — so a failure in any of those later, less-critical phases can
+// never prevent the highest-value invariant (a working hook file) from
+// being repaired. Forces a deterministic init failure via an unrecognizable
+// existing AGENTCHUTE.md (planSpecFile's own refusal), then asserts the
+// stale hook was refreshed anyway, despite the overall setup call failing.
+func TestSetupResync_HookCompatRepairRunsAheadOfFailingInit(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, ".git"))
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("PATH", "/usr/bin:/bin")
+	t.Setenv("AGENTCHUTE_CONTROL_REPO", "")
+	t.Setenv("AGENTCHUTE_LOOP_DIR", "")
+
+	mustWriteStaleHook(t, root, "claude-code")
+	mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("not a real spec, no sentinel header here"))
+
+	var setupErr error
+	withCwd(t, root, func() {
+		setupErr = cmdSetup([]string{"--wake", "runner", "--wrappers", "none", "--yes"})
+	})
+
+	if setupErr == nil {
+		t.Fatal("expected cmdInit's unrecognizable-AGENTCHUTE.md refusal to surface as a non-zero error")
+	}
+	if !strings.Contains(setupErr.Error(), "does not look like an agentchute spec") {
+		t.Fatalf("expected the planSpecFile refusal specifically, got: %v", setupErr)
+	}
+
+	canonicalClaude, err := fs.ReadFile(hooksFS, "examples/hooks/claude-code/.claude/settings.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := mustRead(t, filepath.Join(root, ".claude", "settings.json"))
+	if string(got) != string(canonicalClaude) {
+		t.Errorf("hook compatibility repair must run before, and survive, a later init failure; hook was not refreshed")
+	}
+	if _, err := os.Stat(filepath.Join(root, ".claude", "settings.json.bak")); err != nil {
+		t.Errorf("expected a backup of the stale hook: %v", err)
+	}
+}
+
 // codex acceptance item 3 / brief acceptance 4: a forced verification
 // failure must propagate through setup as a non-zero error, and must print
 // neither "setup complete" nor reach the destructive runtime reset.

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -585,14 +585,25 @@ func printRestartWarning(tag string, active []string, done bool) {
 	bar := strings.Repeat("=", 70)
 	fmt.Fprintln(os.Stderr, bar)
 	if done {
+		// codex review on PR #130: the pre-resync (done=false) banner below
+		// must not claim supervisors are already fenced or tell the operator
+		// to restart now — under the resync-gated ordering this function
+		// documents, neither is true until invalidation actually runs, which
+		// only happens after a successful resync. Printing it unconditionally
+		// would directly contradict the safety behavior by prompting a
+		// restart into a possibly-incomplete update.
 		fmt.Fprintf(os.Stderr, "agentchute updated to %s; serve leases were invalidated.\n\n", tag)
+		fmt.Fprintln(os.Stderr, "Running supervisors are fenced and will exit with a restart notice on their next tick.")
+		fmt.Fprintln(os.Stderr, "Registration rows stay present. Relaunch each lane with `ac serve <wrapper>`.")
+		if len(active) > 0 {
+			fmt.Fprintf(os.Stderr, "\nRESTART every active agent now (%d): %s\n", len(active), strings.Join(active, ", "))
+		}
 	} else {
 		fmt.Fprintf(os.Stderr, "agentchute is updating to %s; serve leases will be invalidated once the setup re-sync succeeds.\n\n", tag)
-	}
-	fmt.Fprintln(os.Stderr, "Running supervisors are fenced and will exit with a restart notice on their next tick.")
-	fmt.Fprintln(os.Stderr, "Registration rows stay present. Relaunch each lane with `ac serve <wrapper>`.")
-	if len(active) > 0 {
-		fmt.Fprintf(os.Stderr, "\nRESTART every active agent now (%d): %s\n", len(active), strings.Join(active, ", "))
+		fmt.Fprintln(os.Stderr, "Supervisors stay active until then; nothing to restart yet.")
+		if len(active) > 0 {
+			fmt.Fprintf(os.Stderr, "\nActive now (%d), pending the resync outcome: %s\n", len(active), strings.Join(active, ", "))
+		}
 	}
 	fmt.Fprintln(os.Stderr, bar)
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -37,6 +37,15 @@ var updateMaxAsset int64 = 64 << 20 // 64 MiB
 
 var versionTagRE = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$`)
 
+// noResyncStaleness names exactly what --no-resync leaves untouched, printed
+// on both the dry-run and apply paths (2026-08-11 hook-refresh-reliability
+// follow-up, finding 5): the prior wording only said "skipped setup re-sync"
+// with no indication of WHAT that leaves stale or for how long, so an
+// operator following the no-saved-state refusal's own suggested escape
+// hatch had no signal that hooks/enrollment/AGENTCHUTE.md would stay frozen
+// at the old version indefinitely.
+const noResyncStaleness = "hooks, enrollment blocks (CLAUDE.md/AGENTS.md/CODEX.md/GEMINI.md/GROK.md), and AGENTCHUTE.md stay at the OLD version until the next resync (`agentchute setup --yes`, or `agentchute update` without --no-resync)"
+
 func updateHTTPClient() *http.Client {
 	return &http.Client{Timeout: 120 * time.Second}
 }
@@ -57,11 +66,16 @@ Updates an existing install in one step: self-updates the binary to the target
 release, then re-runs ` + "`setup`" + ` with this control repo's saved wake mode and
 wrappers so hooks, enrollment blocks, and shims re-sync to the new version.
 
-This invalidates every serve lease after the binary swap. Running supervisors
-fence out and exit on their next tick; registration rows are preserved.
+This invalidates every serve lease once the setup re-sync succeeds (--no-resync:
+immediately after the binary swap instead, since there is no resync to wait
+on). Running supervisors fence out and exit on their next tick; registration
+rows are preserved. A resync failure leaves leases untouched so a still-
+broken hook never forces a fleet-wide restart -- see the printed warning for
+the manual fix command.
 
-Pass --no-resync to skip the setup re-sync. Lease invalidation still happens,
-because a binary-only update must also force running supervisors to restart.
+Pass --no-resync to skip the setup re-sync. Lease invalidation still happens
+immediately, because a binary-only update must also force running supervisors
+to restart.
 
 Flags:
   --version <tag>   release tag to install (default: latest release)
@@ -180,7 +194,8 @@ func cmdUpdate(args []string) error {
 		fmt.Printf("  asset:         %s\n", asset)
 		if noResync {
 			fmt.Println("  re-sync:       skipped (--no-resync)")
-			fmt.Println("  restart:       would invalidate serve leases after the binary swap")
+			fmt.Println("  restart:       would invalidate serve leases immediately after the binary swap")
+			fmt.Printf("  stays stale:   %s\n", noResyncStaleness)
 		} else {
 			fmt.Printf("  re-sync:       %s\n", setupCmd)
 			fmt.Println("  restart:       would invalidate serve leases; registrations stay present")
@@ -219,29 +234,42 @@ func cmdUpdate(args []string) error {
 	syncDir(filepath.Dir(target))
 	fmt.Printf("Updated agentchute %s -> %s (%s)\n", current, targetTag, target)
 
-	invalidated, err := loop.InvalidateAllServeLeases(cfg)
-	if err != nil {
-		return fmt.Errorf("binary updated to %s but serve-lease invalidation failed: %w; rerun `agentchute setup --yes` before relaunching lanes", targetTag, err)
-	}
-	fmt.Printf("Invalidated %d serve lease(s); running supervisors will exit on their next tick.\n", invalidated)
-
 	if noResync {
-		// Binary-only update: hooks/templates stay untouched, but the wire-break
-		// forcing function still fences every running supervisor.
+		// Binary-only update: there is no resync to wait on, so the wire-break
+		// forcing function fences every running supervisor immediately — that
+		// is the whole point of --no-resync's "swap and force a restart"
+		// contract. Hooks/templates stay untouched.
+		invalidated, err := loop.InvalidateAllServeLeases(cfg)
+		if err != nil {
+			return fmt.Errorf("binary updated to %s but serve-lease invalidation failed: %w; rerun `agentchute setup --yes` before relaunching lanes", targetTag, err)
+		}
+		fmt.Printf("Invalidated %d serve lease(s); running supervisors will exit on their next tick.\n", invalidated)
 		fmt.Println("(--no-resync: skipped setup re-sync; registrations preserved)")
+		fmt.Printf("%s.\n", noResyncStaleness)
 		printRestartWarning(targetTag, active, true)
 		return nil
 	}
 
 	// 6. Re-exec the NEW binary's setup so it writes the new version's
-	// templates/hooks/shims, not the old binary's.
+	// templates/hooks/shims, not the old binary's — BEFORE invalidating any
+	// serve lease. A resync failure must never force a fleet-wide restart
+	// into hooks that might still be broken: leaving supervisors running on
+	// the OLD binary is strictly safer than fencing them into an unverified
+	// new one (2026-08-11 hook-refresh-reliability follow-up, codex vector 2).
 	if err := updateRunResync(target, setupArgs, cfg.ControlRepo); err != nil {
 		fmt.Fprintf(os.Stderr, "\nWARNING: binary updated to %s but `setup` re-sync FAILED: %v\n", targetTag, err)
 		fmt.Fprintf(os.Stderr, "Finish the re-sync manually from this repo:\n  %s %s\n", target, setupCmd)
+		fmt.Fprintln(os.Stderr, "Serve leases were NOT invalidated; existing supervisors keep running on the prior binary until the re-sync succeeds.")
 		return errors.New("setup re-sync after update failed (see warning above)")
 	}
 
-	// 7. Final restart warning.
+	// 7. Resync succeeded — only now is it safe to fence every supervisor
+	// into the new binary and hooks.
+	invalidated, err := loop.InvalidateAllServeLeases(cfg)
+	if err != nil {
+		return fmt.Errorf("binary and hooks updated to %s but serve-lease invalidation failed: %w; rerun `agentchute setup --yes` before relaunching lanes", targetTag, err)
+	}
+	fmt.Printf("Invalidated %d serve lease(s); running supervisors will exit on their next tick.\n", invalidated)
 	printRestartWarning(targetTag, active, true)
 	return nil
 }
@@ -559,7 +587,7 @@ func printRestartWarning(tag string, active []string, done bool) {
 	if done {
 		fmt.Fprintf(os.Stderr, "agentchute updated to %s; serve leases were invalidated.\n\n", tag)
 	} else {
-		fmt.Fprintf(os.Stderr, "agentchute is updating to %s; serve leases will be invalidated immediately after the binary swap.\n\n", tag)
+		fmt.Fprintf(os.Stderr, "agentchute is updating to %s; serve leases will be invalidated once the setup re-sync succeeds.\n\n", tag)
 	}
 	fmt.Fprintln(os.Stderr, "Running supervisors are fenced and will exit with a restart notice on their next tick.")
 	fmt.Fprintln(os.Stderr, "Registration rows stay present. Relaunch each lane with `ac serve <wrapper>`.")

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -538,6 +538,38 @@ func TestUpdate_ResyncFailureLeavesLeaseIntact(t *testing.T) {
 	}
 }
 
+// TestPrintRestartWarningDoneFalseDoesNotClaimFenced is the regression test
+// codex asked for on PR #130's gate: the pre-resync (done=false) banner
+// previously printed "will be invalidated once the setup re-sync succeeds"
+// on its own first line, but then UNCONDITIONALLY continued with "Running
+// supervisors are fenced" and "RESTART every active agent now" — a direct
+// contradiction of the resync-gated ordering (neither is true until
+// invalidation actually runs), and exactly the kind of prompt that would
+// defeat the safety fix by pushing an operator to restart into a possibly-
+// incomplete update. done=true must still say both.
+func TestPrintRestartWarningDoneFalseDoesNotClaimFenced(t *testing.T) {
+	pending := captureStderr(t, func() {
+		printRestartWarning("v0.5.0", []string{"codex-agentchute"}, false)
+	})
+	for _, mustNotContain := range []string{"are fenced", "RESTART every active agent now"} {
+		if strings.Contains(pending, mustNotContain) {
+			t.Errorf("done=false banner must not claim %q before the resync has succeeded:\n%s", mustNotContain, pending)
+		}
+	}
+	if !strings.Contains(pending, "will be invalidated once the setup re-sync succeeds") {
+		t.Errorf("done=false banner missing the resync-gated timing statement:\n%s", pending)
+	}
+
+	done := captureStderr(t, func() {
+		printRestartWarning("v0.5.0", []string{"codex-agentchute"}, true)
+	})
+	for _, mustContain := range []string{"are fenced", "RESTART every active agent now"} {
+		if !strings.Contains(done, mustContain) {
+			t.Errorf("done=true banner missing %q:\n%s", mustContain, done)
+		}
+	}
+}
+
 // codex review on PR #110 [P1]: the forced-verification-failure test in
 // setup_test.go proves cmdSetup's own contract, but acceptance item 3
 // ("forced verification failure propagates through setup/update resync")

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -268,6 +268,14 @@ func TestUpdate_NoResyncAllowsBinaryOnlyWhenNoSetupState(t *testing.T) {
 		if !strings.Contains(out, "skipped (--no-resync)") {
 			t.Fatalf("dry-run plan should report re-sync/reset skipped under --no-resync; got:\n%s", out)
 		}
+		// finding 5 (2026-08-11 hook-refresh-reliability follow-up): the
+		// dry-run plan must name exactly what --no-resync leaves stale, not
+		// just that the re-sync was skipped.
+		for _, want := range []string{"hooks", "enrollment blocks", "AGENTCHUTE.md"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("dry-run plan under --no-resync must name %q as staying stale; got:\n%s", want, out)
+			}
+		}
 	})
 }
 
@@ -331,6 +339,7 @@ func TestUpdate_NoResyncSkipsSetupReSync(t *testing.T) {
 	staleHook := mustRead(t, filepath.Join(root, ".claude", "settings.json"))
 
 	var lease *loop.ServeLease
+	var out string
 	withCwd(t, root, func() {
 		mustExampleRepo(t, root) // deliberately NO saved setup state
 		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
@@ -341,13 +350,24 @@ func TestUpdate_NoResyncSkipsSetupReSync(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := cmdUpdate([]string{"--version", "v0.5.0", "--no-resync"}); err != nil {
+		out, err = captureStdout(t, func() error {
+			return cmdUpdate([]string{"--version", "v0.5.0", "--no-resync"})
+		})
+		if err != nil {
 			t.Fatalf("--no-resync binary-only update failed: %v", err)
 		}
 	})
 
 	if resyncCalled {
 		t.Fatal("--no-resync must NOT invoke the setup re-sync")
+	}
+	// finding 5 (2026-08-11 hook-refresh-reliability follow-up): the apply
+	// path must name exactly what --no-resync leaves stale too, not just the
+	// dry-run plan.
+	for _, want := range []string{"hooks", "enrollment blocks", "AGENTCHUTE.md"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("apply output under --no-resync must name %q as staying stale; got:\n%s", want, out)
+		}
 	}
 	got, err := os.ReadFile(bin)
 	if err != nil {
@@ -368,7 +388,14 @@ func TestUpdate_NoResyncSkipsSetupReSync(t *testing.T) {
 	}
 }
 
-func TestUpdateInvalidatesLeaseBeforeSetupResync(t *testing.T) {
+// TestUpdateInvalidatesLeaseOnlyAfterSetupResyncSucceeds proves the reordering
+// codex's vector 2 review required (2026-08-11 hook-refresh-reliability
+// follow-up): lease invalidation must wait until the resync succeeds, not
+// happen immediately after the binary swap. Asserts the lease is still valid
+// (not fenced) WHILE the resync runs, then fenced only after cmdUpdate
+// returns successfully. Formerly named TestUpdateInvalidatesLeaseBeforeSetup-
+// Resync and asserted the opposite ordering; that ordering was the bug.
+func TestUpdateInvalidatesLeaseOnlyAfterSetupResyncSucceeds(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("root bypasses directory permissions used by the writable probe")
 	}
@@ -423,8 +450,8 @@ func TestUpdateInvalidatesLeaseBeforeSetupResync(t *testing.T) {
 		}
 		updateRunResync = func(target string, setupArgs []string, controlRepo string) error {
 			resyncCalled = true
-			if err := loop.RenewLease(lease); !errors.Is(err, loop.ErrFenced) {
-				t.Fatalf("lease at setup re-sync = %v, want ErrFenced", err)
+			if err := loop.RenewLease(lease); err != nil {
+				t.Fatalf("lease at setup re-sync = %v, want no error (leases must not be invalidated before the resync succeeds)", err)
 			}
 			return nil
 		}
@@ -434,6 +461,80 @@ func TestUpdateInvalidatesLeaseBeforeSetupResync(t *testing.T) {
 	})
 	if !resyncCalled {
 		t.Fatal("normal update did not invoke setup re-sync")
+	}
+	if err := loop.RenewLease(lease); !errors.Is(err, loop.ErrFenced) {
+		t.Fatalf("lease after a successful update = %v, want ErrFenced", err)
+	}
+}
+
+// TestUpdate_ResyncFailureLeavesLeaseIntact is the failure-mode half of the
+// same reordering: when the resync fails, existing supervisors must keep
+// running on the prior binary rather than being fenced into hooks that might
+// still be broken.
+func TestUpdate_ResyncFailureLeavesLeaseIntact(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions used by the writable probe")
+	}
+	root := t.TempDir()
+	installDir := t.TempDir()
+	bin := filepath.Join(installDir, "agentchute")
+	if err := os.WriteFile(bin, []byte{0x7f, 'E', 'L', 'F', 0, 0, 0, 0}, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	asset := fmt.Sprintf("agentchute_0.5.0_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	archive := makeTarGz(t, map[string][]byte{"agentchute": []byte("NEW-BINARY-BYTES")})
+	sum := sha256.Sum256(archive)
+	checksum := hex.EncodeToString(sum[:])
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			fmt.Fprintf(w, "%s  %s\n", checksum, asset)
+		case strings.HasSuffix(r.URL.Path, asset):
+			w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	oldBase := updateGitHubBase
+	oldTarget := resolveUpdateTargetForTest
+	oldResync := updateRunResync
+	updateGitHubBase = srv.URL
+	resolveUpdateTargetForTest = bin
+	updateRunResync = func(target string, setupArgs []string, controlRepo string) error {
+		return errors.New("injected resync failure")
+	}
+	t.Cleanup(func() {
+		updateGitHubBase = oldBase
+		resolveUpdateTargetForTest = oldTarget
+		updateRunResync = oldResync
+	})
+
+	var lease *loop.ServeLease
+	var updateErr error
+	withCwd(t, root, func() {
+		mustExampleRepo(t, root)
+		cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writeSetupPoolState(cfg, "runner", nil, ""); err != nil {
+			t.Fatal(err)
+		}
+		lease, err = loop.AcquireServeLease(cfg, "codex-agentchute")
+		if err != nil {
+			t.Fatal(err)
+		}
+		updateErr = cmdUpdate([]string{"--version", "v0.5.0"})
+	})
+
+	if updateErr == nil {
+		t.Fatal("expected the injected resync failure to surface as a non-zero update error")
+	}
+	if err := loop.RenewLease(lease); err != nil {
+		t.Fatalf("lease after a FAILED resync = %v, want no error — a failed resync must never fence the fleet", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `cmdUpdate` invalidated every serve lease immediately after the binary swap, before the setup re-sync (hook compatibility repair) ever ran. A resync failure still fenced every running supervisor into a binary whose hooks might still be broken. Lease invalidation now waits until the resync succeeds; a failed resync leaves existing supervisors running on the prior binary instead.
- `applySetup`'s hook-compatibility repair moves from Phase 2.5 (after init and the membership/shim/PATH writes) to Phase 0, the very first thing setup does — it depends on nothing but the control-repo root, so it must never be gated behind less-critical writes that can fail for unrelated reasons.
- Both `--no-resync` output paths (dry-run and apply) now name exactly what stays stale — hooks, enrollment blocks, and AGENTCHUTE.md — instead of only saying the re-sync was skipped.

Source: 2026-08-11 hook-refresh-reliability investigation follow-up (codex vector 2 + finding 5), PR 2 of 3 per the implementation task.

## Test plan
- [x] New: `TestUpdateInvalidatesLeaseOnlyAfterSetupResyncSucceeds` (renamed/inverted from the old test that encoded the buggy ordering) — lease stays valid while resync runs, fenced only after success
- [x] New: `TestUpdate_ResyncFailureLeavesLeaseIntact` — a failed resync never fences the fleet
- [x] New: `TestSetupResync_HookCompatRepairRunsAheadOfFailingInit` — forces a deterministic init failure and proves the stale hook was already repaired
- [x] Extended `TestUpdate_NoResyncAllowsBinaryOnlyWhenNoSetupState` and `TestUpdate_NoResyncSkipsSetupReSync` to assert the new staleness wording on both the dry-run and apply paths
- [x] Confirmed red→green: all 5 new/modified tests fail against the unmodified code, pass after the fix
- [x] `sh tools/test.sh` — gofmt/vet/test/build all clean
- [x] `sh tests/upgrade_smoke.sh` (env-stripped, no live pool) — real old→new binary upgrade rehearsal still passes end to end
- [x] `sh tests/install_test.sh` — unaffected, still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)