### PR TITLE
fix(init): version-compare-and-replace AGENTCHUTE.md, like the enrollment blocks

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -1,4 +1,5 @@
 # AGENTCHUTE.md
+<!-- agentchute-spec v1 -->
 
 *Open spec for inbox-based agent coordination. **Protocol v2 (pull-only) was declared final at CLI v1.0.0.** That declaration held for the primitives (§1), the envelope (§6.4), and the lifecycle guarantees (§6.3, §11.1) — none of those changed. It did **not** hold for the filename/identity grammar (§6.1): v2.5 deliberately replaces the per-`(sender,recipient)` sequence counter with a timestamp+random-suffix identity — a real wire break, the exact kind the 1.0 covenant said would only happen through Protocol v3. It ships as "2.5," not "3.0," on purpose; the reasoning for both the break and that naming choice is recorded in `docs/decisions/agentchute-v2.5-proposal.md` and on the project blog, not left implicit. The reference CLI writes integer `v: 3` on registration rows and renders that wire value as Protocol v2.5; the release history is recorded in [`CHANGELOG.md`](CHANGELOG.md). Conformance invariants remain covenants that change only through the versioned deprecation process in [`CONTRIBUTING.md`](CONTRIBUTING.md).*
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -246,10 +247,26 @@ func checkSpecFreshness(cfg *loop.Config) doctorCheck {
 	if bytes.Equal(onDisk, embedded) {
 		return doctorCheck{Name: name, Severity: severityOK, Message: "AGENTCHUTE.md matches embedded spec"}
 	}
+	// planSpecFile (init.go) now version-compares and auto-replaces AGENTCHUTE.md
+	// on every setup/update resync, same as the enrollment blocks — so the disk
+	// copy differing is only ever a WARN needing a resync, unless it is marked
+	// newer than this binary knows about (deliberately future-dated), which
+	// planSpecFile leaves alone on purpose. Tell the operator which case this is
+	// rather than a generic "this may be expected" hedge.
+	if match := specMarkerRE.FindStringSubmatch(string(onDisk)); match != nil {
+		if diskVersion, err := strconv.Atoi(match[1]); err == nil && diskVersion > specVersion {
+			return doctorCheck{
+				Name:     name,
+				Severity: severityWarn,
+				Message: fmt.Sprintf("AGENTCHUTE.md is marked v%d, newer than this binary's embedded v%d (disk sha256=%s, embedded sha256=%s); this is left alone on purpose — upgrade agentchute to manage it",
+					diskVersion, specVersion, shortSHA256(onDisk), shortSHA256(embedded)),
+			}
+		}
+	}
 	return doctorCheck{
 		Name:     name,
 		Severity: severityWarn,
-		Message: fmt.Sprintf("AGENTCHUTE.md differs from this binary's embedded spec (disk sha256=%s, embedded sha256=%s); if the disk copy is stale, update your checkout; if it is deliberately newer or locally edited, this is expected — update the binary instead (`agentchute update`)",
+		Message: fmt.Sprintf("AGENTCHUTE.md differs from this binary's embedded spec (disk sha256=%s, embedded sha256=%s); stale — run `agentchute setup --yes` or `agentchute update` to refresh it automatically",
 			shortSHA256(onDisk), shortSHA256(embedded)),
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,6 +136,12 @@ func TestDoctorSpecFreshnessMatchesEmbeddedSpec(t *testing.T) {
 	}
 }
 
+// TestDoctorSpecFreshnessWarnsOnStaleSpec: 2026-08-11 hook-refresh-
+// reliability follow-up, finding 3. planSpecFile now actually refreshes a
+// stale AGENTCHUTE.md on resync (init.go's version-compare-and-replace, no
+// longer skip-if-present), so the remediation text must say so instead of
+// the old, actively wrong "update the binary instead" framing that never
+// fixed anything.
 func TestDoctorSpecFreshnessWarnsOnStaleSpec(t *testing.T) {
 	cfg := newDoctorCfg(t)
 	if err := os.WriteFile(filepath.Join(cfg.ControlRepo, "AGENTCHUTE.md"), []byte("# AGENTCHUTE.md\n\nstale copy\n"), 0o644); err != nil {
@@ -145,13 +152,38 @@ func TestDoctorSpecFreshnessWarnsOnStaleSpec(t *testing.T) {
 	if got.Severity != severityWarn {
 		t.Fatalf("spec_freshness severity = %q, want WARN; message=%q", got.Severity, got.Message)
 	}
-	for _, want := range []string{"differs from this binary's embedded spec", "disk sha256=", "embedded sha256=", "update your checkout", "agentchute update"} {
+	for _, want := range []string{"differs from this binary's embedded spec", "disk sha256=", "embedded sha256=", "stale", "agentchute setup", "agentchute update", "automatically"} {
 		if !strings.Contains(got.Message, want) {
 			t.Fatalf("spec_freshness message missing %q: %q", want, got.Message)
 		}
 	}
 	if strings.Contains(got.Message, "agentchute init") {
-		t.Fatalf("spec_freshness message still recommends `agentchute init`, which never fixes divergence (init.go skip-if-present): %q", got.Message)
+		t.Fatalf("spec_freshness message must not recommend `agentchute init`, which never touches an existing recognizable spec: %q", got.Message)
+	}
+}
+
+// TestDoctorSpecFreshnessNewerVersionLeftAlone: a disk copy marked newer
+// than this binary's embedded spec version is the one case planSpecFile
+// deliberately leaves untouched — doctor's message must say so, not claim
+// it is stale and about to be auto-fixed.
+func TestDoctorSpecFreshnessNewerVersionLeftAlone(t *testing.T) {
+	cfg := newDoctorCfg(t)
+	future := fmt.Sprintf("# AGENTCHUTE.md\n<!-- agentchute-spec v%d -->\n\nfrom-the-future copy\n", specVersion+1)
+	if err := os.WriteFile(filepath.Join(cfg.ControlRepo, "AGENTCHUTE.md"), []byte(future), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := checkSpecFreshness(cfg)
+	if got.Severity != severityWarn {
+		t.Fatalf("spec_freshness severity = %q, want WARN; message=%q", got.Severity, got.Message)
+	}
+	for _, want := range []string{"newer than this binary", "left alone on purpose"} {
+		if !strings.Contains(got.Message, want) {
+			t.Fatalf("spec_freshness message missing %q: %q", want, got.Message)
+		}
+	}
+	if strings.Contains(got.Message, "stale") {
+		t.Fatalf("spec_freshness message must not call a deliberately newer spec stale: %q", got.Message)
 	}
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -319,6 +319,20 @@ func planSpecFile(root string) (initAction, error) {
 	path := filepath.Join(root, "AGENTCHUTE.md")
 	rel := "AGENTCHUTE.md"
 
+	// codex review on PR #131 [P1]: os.ReadFile/os.WriteFile both follow a
+	// symlink. Without this Lstat guard, a repo-local AGENTCHUTE.md symlinked
+	// to an external recognizable spec would be read AND, on the new
+	// version-compare-and-replace path, WRITTEN through the link, expanding
+	// mutation outside the discovered control repo. Checked before any read
+	// so a dangling symlink is caught too, not just a followable one.
+	if info, statErr := os.Lstat(path); statErr == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return initAction{}, fmt.Errorf("%s is a symlink; refusing to read or write through it — replace it with a real file", rel)
+		}
+	} else if !os.IsNotExist(statErr) {
+		return initAction{}, fmt.Errorf("stat AGENTCHUTE.md: %w", statErr)
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -20,6 +21,16 @@ import (
 // counting + version extraction work uniformly. Captures: 1=version, 2=kind.
 var enrollmentMarkerRE = regexp.MustCompile(`<!-- agentchute-enrollment v(\d+) (begin|end) -->`)
 
+// specMarkerRE extracts the version from AGENTCHUTE.md's own marker line
+// (`<!-- agentchute-spec vN -->`, right after the `# AGENTCHUTE.md` title).
+// AGENTCHUTE.md is wholly agentchute-owned once recognized (planSpecFile's
+// "does not look like an agentchute spec" branch already refuses to touch
+// anything else), unlike CLAUDE.md/AGENTS.md where the enrollment block is
+// one marked region inside an otherwise operator-owned file — so a single
+// version marker is enough to gate a whole-file replace, no begin/end pair
+// needed.
+var specMarkerRE = regexp.MustCompile(`<!-- agentchute-spec v(\d+) -->`)
+
 // AGENTCHUTE.md content is embedded at build time so `init` writes the spec
 // version pinned to the binary. The embed lives in the root main package
 // (//go:embed cannot reach a parent directory); Main injects it here at
@@ -28,6 +39,7 @@ var embeddedSpecContent string
 
 const (
 	enrollmentVersion       = 29
+	specVersion             = 1
 	gitignoreVersion        = 3
 	gitignoreBegin          = "# agentchute-gitignore v3 begin"
 	gitignoreEnd            = "# agentchute-gitignore v3 end"
@@ -288,10 +300,21 @@ func rejectSymlinkAncestor(path string) error {
 	return nil
 }
 
-// planSpecFile decides what to do with AGENTCHUTE.md. Missing -> write
-// embedded. Recognizable spec (sentinel header found) -> skip. Anything
-// else -> fail: the enrollment block references §5 in the spec, so a
-// non-agentchute AGENTCHUTE.md would silently break the contract.
+// planSpecFile decides what to do with AGENTCHUTE.md: missing -> write
+// embedded; recognizable spec (sentinel header found) -> version-compare-
+// and-replace against specVersion via specMarkerRE, the same treatment
+// planEnrollmentFile already gives CLAUDE.md/AGENTS.md/etc (2026-08-11
+// hook-refresh-reliability follow-up, finding 3 — this file previously
+// skipped unconditionally once recognizable, so it never refreshed on
+// resync no matter how stale, unlike every other templated file). Older,
+// same-version-but-drifted, or pre-marker legacy content -> replace the
+// whole file (recognized AGENTCHUTE.md is wholly agentchute-owned, matching
+// planEnrollmentFile's own "drift replaces at the current version" ruling).
+// Newer -> leave alone: a deliberately future-dated spec, or a binary older
+// than whatever wrote it. Anything that does not even look like an
+// agentchute spec -> fail: the enrollment block references §5 in the spec,
+// so a non-agentchute AGENTCHUTE.md would silently break the contract, and
+// refusing protects it from being clobbered.
 func planSpecFile(root string) (initAction, error) {
 	path := filepath.Join(root, "AGENTCHUTE.md")
 	rel := "AGENTCHUTE.md"
@@ -301,7 +324,7 @@ func planSpecFile(root string) (initAction, error) {
 		if os.IsNotExist(err) {
 			return initAction{
 				Target: rel,
-				Action: "write",
+				Action: fmt.Sprintf("create v%d", specVersion),
 				Detail: fmt.Sprintf("new file (%d bytes)", len(embeddedSpecContent)),
 				Apply: func() error {
 					return os.WriteFile(path, []byte(embeddedSpecContent), 0o644)
@@ -310,14 +333,50 @@ func planSpecFile(root string) (initAction, error) {
 		}
 		return initAction{}, fmt.Errorf("read AGENTCHUTE.md: %w", err)
 	}
-	if strings.Contains(string(data), specRecognitionSentinel) {
+	existing := string(data)
+	if !strings.Contains(existing, specRecognitionSentinel) {
+		return initAction{}, fmt.Errorf("%s exists but does not look like an agentchute spec (missing %q header); refusing to overwrite", rel, specRecognitionSentinel)
+	}
+
+	replace := func(action string) initAction {
+		return initAction{
+			Target: rel,
+			Action: action,
+			Detail: fmt.Sprintf("existing file (%d bytes) -> %d bytes", len(data), len(embeddedSpecContent)),
+			Apply: func() error {
+				return os.WriteFile(path, []byte(embeddedSpecContent), 0o644)
+			},
+		}
+	}
+
+	match := specMarkerRE.FindStringSubmatch(existing)
+	if match == nil {
+		return replace(fmt.Sprintf("replace legacy→v%d", specVersion)), nil
+	}
+	diskVersion, err := strconv.Atoi(match[1])
+	if err != nil {
+		return initAction{}, fmt.Errorf("%s has a malformed agentchute-spec marker: %w", rel, err)
+	}
+	if diskVersion > specVersion {
+		return initAction{
+			Target: rel,
+			Action: "skip (warn)",
+			Detail: fmt.Sprintf("file has newer agentchute-spec v%d; leaving alone — upgrade agentchute to manage", diskVersion),
+		}, nil
+	}
+	if diskVersion == specVersion && existing == embeddedSpecContent {
 		return initAction{
 			Target: rel,
 			Action: "skip",
-			Detail: "recognizable agentchute spec already present",
+			Detail: fmt.Sprintf("v%d already current", specVersion),
 		}, nil
 	}
-	return initAction{}, fmt.Errorf("%s exists but does not look like an agentchute spec (missing %q header); refusing to overwrite", rel, specRecognitionSentinel)
+	if diskVersion < specVersion {
+		return replace(fmt.Sprintf("replace v%d→v%d", diskVersion, specVersion)), nil
+	}
+	// diskVersion == specVersion, content differs — replace per codex (same
+	// ruling planEnrollmentFile already follows for its own marked block).
+	return replace(fmt.Sprintf("replace v%d drift", specVersion)), nil
 }
 
 // planEnrollmentFile applies the decision table for wrapper files: missing,

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -300,6 +300,39 @@ func TestInitFailsOnUnrecognizableAgentchuteMd(t *testing.T) {
 	}
 }
 
+// codex review on PR #131 [P1]: a symlinked AGENTCHUTE.md must never be read
+// or written through — the version-compare-and-replace path would otherwise
+// follow it and mutate whatever it points at, outside the discovered control
+// repo. Errors closed, and the external target is untouched.
+func TestInitRefusesSymlinkedAgentchuteMd(t *testing.T) {
+	root := t.TempDir()
+	outsideDir := t.TempDir()
+	target := filepath.Join(outsideDir, "external-spec.md")
+	targetContent := []byte("# AGENTCHUTE.md\n\nan external file this repo must never touch\n")
+	mustWrite(t, target, targetContent)
+
+	link := filepath.Join(root, "AGENTCHUTE.md")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := computeInitPlan(root, "agentchute", false)
+	if err == nil {
+		t.Fatal("expected a symlink refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error should mention the symlink refusal: %v", err)
+	}
+
+	got, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(targetContent) {
+		t.Errorf("external symlink target was modified; got %q, want unchanged %q", got, targetContent)
+	}
+}
+
 // 2026-08-11 hook-refresh-reliability follow-up, finding 3: planSpecFile now
 // gets the same version-compare-and-replace treatment planEnrollmentFile
 // already has, instead of skipping unconditionally once recognizable.

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -17,7 +18,7 @@ func TestInitFreshEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectAction(t, plan, "AGENTCHUTE.md", "write")
+	expectAction(t, plan, "AGENTCHUTE.md", "create v1")
 	expectAction(t, plan, "CLAUDE.md", "create v29")
 	expectAction(t, plan, "CODEX.md", "create v29")
 	expectAction(t, plan, "GEMINI.md", "create v29")
@@ -297,6 +298,106 @@ func TestInitFailsOnUnrecognizableAgentchuteMd(t *testing.T) {
 	if !strings.Contains(err.Error(), "does not look like an agentchute spec") {
 		t.Errorf("error should mention recognizability: %v", err)
 	}
+}
+
+// 2026-08-11 hook-refresh-reliability follow-up, finding 3: planSpecFile now
+// gets the same version-compare-and-replace treatment planEnrollmentFile
+// already has, instead of skipping unconditionally once recognizable.
+
+// A recognizable AGENTCHUTE.md with no agentchute-spec marker at all predates
+// this versioning scheme entirely — treated as older than any version, so it
+// is replaced with the current embedded content (matching planEnrollmentFile's
+// own "no marker — write current" branch for CLAUDE.md/AGENTS.md/etc).
+func TestInitReplacesLegacySpecWithNoMarker(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte("# AGENTCHUTE.md\n\nan old spec from before versioning existed\n"))
+
+	plan, err := computeInitPlan(root, "agentchute", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectAction(t, plan, "AGENTCHUTE.md", "replace legacy→v1")
+	applyAll(t, plan)
+
+	got, err := os.ReadFile(filepath.Join(root, "AGENTCHUTE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != embeddedSpecContent {
+		t.Errorf("legacy AGENTCHUTE.md was not replaced with the embedded spec")
+	}
+}
+
+// A marker at the current version whose content byte-matches the embedded
+// spec exactly → no-op, no Apply function (planHasMutations-safe).
+func TestInitSkipsWhenSpecMarkerCurrentAndMatches(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte(embeddedSpecContent))
+
+	plan, err := computeInitPlan(root, "agentchute", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range plan.Actions {
+		if a.Target != "AGENTCHUTE.md" {
+			continue
+		}
+		if a.Action != "skip" {
+			t.Errorf("action = %q, want skip", a.Action)
+		}
+		if a.Apply != nil {
+			t.Errorf("an already-current spec must be a no-op")
+		}
+	}
+}
+
+// A marker at the current version whose content has DRIFTED from the
+// embedded spec (e.g. hand-edited) → replace per the same ruling
+// planEnrollmentFile already follows for its own marked block.
+func TestInitReplacesDriftedCurrentVersionSpec(t *testing.T) {
+	root := t.TempDir()
+	drifted := "# AGENTCHUTE.md\n<!-- agentchute-spec v1 -->\n\nhand-edited drift, not the canonical body\n"
+	mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte(drifted))
+
+	plan, err := computeInitPlan(root, "agentchute", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectAction(t, plan, "AGENTCHUTE.md", "replace v1 drift")
+	applyAll(t, plan)
+
+	got, err := os.ReadFile(filepath.Join(root, "AGENTCHUTE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != embeddedSpecContent {
+		t.Errorf("drifted AGENTCHUTE.md was not replaced with the embedded spec")
+	}
+}
+
+// A marker newer than this binary's embedded specVersion → leave alone with
+// a warning, never overwrite a deliberately future-dated spec.
+func TestInitLeavesNewerSpecVersionAlone(t *testing.T) {
+	root := t.TempDir()
+	future := fmt.Sprintf("# AGENTCHUTE.md\n<!-- agentchute-spec v%d -->\n\nfrom a newer binary\n", specVersion+1)
+	mustWrite(t, filepath.Join(root, "AGENTCHUTE.md"), []byte(future))
+
+	plan, err := computeInitPlan(root, "agentchute", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range plan.Actions {
+		if a.Target == "AGENTCHUTE.md" {
+			if a.Action != "skip (warn)" {
+				t.Errorf("expected skip (warn), got %q", a.Action)
+			}
+			if a.Apply != nil {
+				t.Errorf("future-version action should be a no-op")
+			}
+			return
+		}
+	}
+	t.Fatal("AGENTCHUTE.md action not found in plan")
 }
 
 // Existing dir at 0755 → chmod 0700 action.


### PR DESCRIPTION
## Summary
- `planSpecFile` skipped AGENTCHUTE.md unconditionally once it looked recognizable, with no version check at all — unlike every other templated file, which auto-upgrades correctly on every resync. AGENTCHUTE.md never refreshed no matter how stale, contradicting doctor's own remediation text (which told operators to fix it by running the resync — something that provably never touched this file).
- AGENTCHUTE.md gets a version marker (`<!-- agentchute-spec v1 -->`, right after the title) and the same decision table `planEnrollmentFile` already uses for CLAUDE.md/AGENTS.md/etc: older or same-version-but-drifted → replace; no marker at all (legacy content) → treated as older, replaced; newer than this binary's embedded version → left alone.
- `doctor`'s `spec_freshness` WARN text now says what actually happens: stale content names the fix that now works; a disk copy marked newer says so explicitly instead of a generic "may be expected" hedge.

Source: 2026-08-11 hook-refresh-reliability investigation (finding 3), PR 3 of 3 per the implementation task.

## Test plan
- [x] New: `TestInitReplacesLegacySpecWithNoMarker`, `TestInitSkipsWhenSpecMarkerCurrentAndMatches`, `TestInitReplacesDriftedCurrentVersionSpec`, `TestInitLeavesNewerSpecVersionAlone` — full decision-table coverage
- [x] New: `TestDoctorSpecFreshnessNewerVersionLeftAlone`; extended `TestDoctorSpecFreshnessWarnsOnStaleSpec` for the corrected message text
- [x] Updated the existing `TestInitFreshEmpty` assertion (`"write"` → `"create v1"`, matching the enrollment-file action-label convention)
- [x] Confirmed red→green: stashed the implementation (kept tests), all new/modified tests fail to build (undefined symbols) or fail outright; restored, all pass
- [x] `sh tools/test.sh` — gofmt/vet/test/build all clean
- [x] `sh tools/fact-sweep.sh` — clean (the one-line AGENTCHUTE.md insertion doesn't disturb any published numeric claim)
- [x] `sh tests/upgrade_smoke.sh` (env-stripped, no live pool) and `sh tests/install_test.sh` — both still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)