### PR TITLE
fix(init): symlink guard parity across all init.go planners

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -300,21 +300,6 @@ func rejectSymlinkAncestor(path string) error {
 	return nil
 }
 
-// planSpecFile decides what to do with AGENTCHUTE.md: missing -> write
-// embedded; recognizable spec (sentinel header found) -> version-compare-
-// and-replace against specVersion via specMarkerRE, the same treatment
-// planEnrollmentFile already gives CLAUDE.md/AGENTS.md/etc (2026-08-11
-// hook-refresh-reliability follow-up, finding 3 — this file previously
-// skipped unconditionally once recognizable, so it never refreshed on
-// resync no matter how stale, unlike every other templated file). Older,
-// same-version-but-drifted, or pre-marker legacy content -> replace the
-// whole file (recognized AGENTCHUTE.md is wholly agentchute-owned, matching
-// planEnrollmentFile's own "drift replaces at the current version" ruling).
-// Newer -> leave alone: a deliberately future-dated spec, or a binary older
-// than whatever wrote it. Anything that does not even look like an
-// agentchute spec -> fail: the enrollment block references §5 in the spec,
-// so a non-agentchute AGENTCHUTE.md would silently break the contract, and
-// refusing protects it from being clobbered.
 // rejectSymlinkFile refuses a path that is a symlink (dangling or not),
 // before any read/write of it, since os.ReadFile/os.WriteFile both follow a
 // symlink and this package's init planners write their target unconditionally
@@ -338,6 +323,21 @@ func rejectSymlinkFile(path, rel string) error {
 	return nil
 }
 
+// planSpecFile decides what to do with AGENTCHUTE.md: missing -> write
+// embedded; recognizable spec (sentinel header found) -> version-compare-
+// and-replace against specVersion via specMarkerRE, the same treatment
+// planEnrollmentFile already gives CLAUDE.md/AGENTS.md/etc (2026-08-11
+// hook-refresh-reliability follow-up, finding 3 — this file previously
+// skipped unconditionally once recognizable, so it never refreshed on
+// resync no matter how stale, unlike every other templated file). Older,
+// same-version-but-drifted, or pre-marker legacy content -> replace the
+// whole file (recognized AGENTCHUTE.md is wholly agentchute-owned, matching
+// planEnrollmentFile's own "drift replaces at the current version" ruling).
+// Newer -> leave alone: a deliberately future-dated spec, or a binary older
+// than whatever wrote it. Anything that does not even look like an
+// agentchute spec -> fail: the enrollment block references §5 in the spec,
+// so a non-agentchute AGENTCHUTE.md would silently break the contract, and
+// refusing protects it from being clobbered.
 func planSpecFile(root string) (initAction, error) {
 	path := filepath.Join(root, "AGENTCHUTE.md")
 	rel := "AGENTCHUTE.md"

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -315,22 +315,35 @@ func rejectSymlinkAncestor(path string) error {
 // agentchute spec -> fail: the enrollment block references §5 in the spec,
 // so a non-agentchute AGENTCHUTE.md would silently break the contract, and
 // refusing protects it from being clobbered.
+// rejectSymlinkFile refuses a path that is a symlink (dangling or not),
+// before any read/write of it, since os.ReadFile/os.WriteFile both follow a
+// symlink and this package's init planners write their target unconditionally
+// once a plan is applied. Without this, a repo-local file symlinked to
+// something external would be read AND written through the link, expanding
+// mutation outside the discovered control repo (codex review on PR #131 [P1],
+// against planSpecFile; sibling-path-gate-parity follow-up applies the same
+// guard everywhere else in this file with the identical read-then-maybe-write
+// shape: planEnrollmentFile, planGitignore). rel is used only in the message.
+func rejectSymlinkFile(path, rel string) error {
+	info, statErr := os.Lstat(path)
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return nil
+		}
+		return fmt.Errorf("stat %s: %w", rel, statErr)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is a symlink; refusing to read or write through it — replace it with a real file", rel)
+	}
+	return nil
+}
+
 func planSpecFile(root string) (initAction, error) {
 	path := filepath.Join(root, "AGENTCHUTE.md")
 	rel := "AGENTCHUTE.md"
 
-	// codex review on PR #131 [P1]: os.ReadFile/os.WriteFile both follow a
-	// symlink. Without this Lstat guard, a repo-local AGENTCHUTE.md symlinked
-	// to an external recognizable spec would be read AND, on the new
-	// version-compare-and-replace path, WRITTEN through the link, expanding
-	// mutation outside the discovered control repo. Checked before any read
-	// so a dangling symlink is caught too, not just a followable one.
-	if info, statErr := os.Lstat(path); statErr == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return initAction{}, fmt.Errorf("%s is a symlink; refusing to read or write through it — replace it with a real file", rel)
-		}
-	} else if !os.IsNotExist(statErr) {
-		return initAction{}, fmt.Errorf("stat AGENTCHUTE.md: %w", statErr)
+	if err := rejectSymlinkFile(path, rel); err != nil {
+		return initAction{}, err
 	}
 
 	data, err := os.ReadFile(path)
@@ -397,6 +410,10 @@ func planSpecFile(root string) (initAction, error) {
 // no marker, marker-current, marker-older, marker-newer, malformed/multiple.
 func planEnrollmentFile(path, rendered string) (initAction, error) {
 	rel := filepath.Base(path)
+
+	if err := rejectSymlinkFile(path, rel); err != nil {
+		return initAction{}, err
+	}
 
 	existing, err := os.ReadFile(path)
 	if err != nil {
@@ -518,6 +535,10 @@ func planGitignore(root string, inGit bool, stanza string) (initAction, error) {
 			Action: "skip",
 			Detail: "not in a git worktree",
 		}, nil
+	}
+
+	if err := rejectSymlinkFile(path, rel); err != nil {
+		return initAction{}, err
 	}
 
 	existing, err := os.ReadFile(path)

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -333,6 +333,69 @@ func TestInitRefusesSymlinkedAgentchuteMd(t *testing.T) {
 	}
 }
 
+// sibling-path-gate-parity follow-up: the same symlink guard proven above for
+// AGENTCHUTE.md must also cover planEnrollmentFile's targets (CLAUDE.md/
+// CODEX.md/GEMINI.md/GROK.md/AGENTS.md) and planGitignore's .gitignore — all
+// three share the identical read-then-maybe-write-through-a-symlink shape.
+func TestInitRefusesSymlinkedEnrollmentFile(t *testing.T) {
+	root := t.TempDir()
+	outsideDir := t.TempDir()
+	target := filepath.Join(outsideDir, "external.md")
+	targetContent := []byte("an external file this repo must never touch\n")
+	mustWrite(t, target, targetContent)
+
+	link := filepath.Join(root, "CLAUDE.md")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := computeInitPlan(root, "agentchute", false)
+	if err == nil {
+		t.Fatal("expected a symlink refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error should mention the symlink refusal: %v", err)
+	}
+
+	got, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(targetContent) {
+		t.Errorf("external symlink target was modified; got %q, want unchanged %q", got, targetContent)
+	}
+}
+
+func TestInitRefusesSymlinkedGitignore(t *testing.T) {
+	root := t.TempDir()
+	mustMkdir(t, filepath.Join(root, ".git"))
+	outsideDir := t.TempDir()
+	target := filepath.Join(outsideDir, "external.gitignore")
+	targetContent := []byte("an external file this repo must never touch\n")
+	mustWrite(t, target, targetContent)
+
+	link := filepath.Join(root, ".gitignore")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := computeInitPlan(root, "agentchute", true)
+	if err == nil {
+		t.Fatal("expected a symlink refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("error should mention the symlink refusal: %v", err)
+	}
+
+	got, readErr := os.ReadFile(target)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != string(targetContent) {
+		t.Errorf("external symlink target was modified; got %q, want unchanged %q", got, targetContent)
+	}
+}
+
 // 2026-08-11 hook-refresh-reliability follow-up, finding 3: planSpecFile now
 // gets the same version-compare-and-replace treatment planEnrollmentFile
 // already has, instead of skipping unconditionally once recognizable.


### PR DESCRIPTION
## Summary
Security review of PR #131's commit flagged sibling-path-gate-parity: `planEnrollmentFile` (CLAUDE.md/CODEX.md/GEMINI.md/GROK.md/AGENTS.md) and `planGitignore` (.gitignore) have the identical read-then-maybe-write-through-a-symlink shape `planSpecFile` had (fixed in #131) — pre-existing, not introduced by that PR. Extracts the Lstat guard into a shared `rejectSymlinkFile` helper and applies it everywhere.

## Test plan
- [x] New: `TestInitRefusesSymlinkedEnrollmentFile`, `TestInitRefusesSymlinkedGitignore`
- [x] Confirmed red→green
- [x] `sh tools/test.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)