### PR TITLE
ci: real-release rehearsal of hook/spec refresh on every PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,8 @@ jobs:
         run: shellcheck -s sh tests/install_test.sh
       - name: shellcheck tests/upgrade_smoke.sh
         run: shellcheck -s sh tests/upgrade_smoke.sh
+      - name: shellcheck tests/upgrade_hook_refresh_smoke.sh
+        run: shellcheck -s sh tests/upgrade_hook_refresh_smoke.sh
       - name: run install_test.sh
         run: sh tests/install_test.sh
 
@@ -69,3 +71,24 @@ jobs:
           check-latest: true
       - name: run upgrade smoke
         run: sh tests/upgrade_smoke.sh
+
+  upgrade-hook-refresh-smoke:
+    name: real-release hook/spec refresh rehearsal
+    # Unlike upgrade-smoke (release/v2.5-only, wrappers=none — it never
+    # installs a hook file, so it can't exercise refresh at all), this job
+    # runs on every PR and main push: it's the CI-level proof, over a real
+    # v1.0.0-tagged binary, that a stale hook and a pre-marker AGENTCHUTE.md
+    # actually refresh across `agentchute setup`/`update` (2026-08-11
+    # hook-refresh-reliability investigation, closing codex's CI-blind-spot
+    # finding).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          check-latest: true
+      - name: run upgrade hook-refresh smoke
+        run: sh tests/upgrade_hook_refresh_smoke.sh

--- a/tests/upgrade_hook_refresh_smoke.sh
+++ b/tests/upgrade_hook_refresh_smoke.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+# Rehearse the hook-refresh-reliability fixes (2026-08-11 investigation) across
+# a REAL old-release-to-current binary swap: a genuinely stale hook file and a
+# pre-marker AGENTCHUTE.md (built from the real v1.0.0 tag) must both refresh
+# to the current binary's canonical templates after `agentchute update`, and
+# doctor must report clean afterward. Sibling to upgrade_smoke.sh (which
+# proves the registration/lease wire-break separately, with wrappers=none —
+# it never installs a hook file, so it cannot exercise this at all). This is
+# the CI-level proof that closes the gap: prior to this file, no CI job ever
+# exercised hook-file refresh across a real version boundary — every check
+# was either a Go unit test against synthetic fixtures, or manual rehearsal
+# (see docs/decisions/ if that changes).
+
+set -eu
+
+# Same two-guard safety rationale as upgrade_smoke.sh: `agentchute update`
+# invalidates serve leases and rewrites hook/enrollment files in whatever
+# control repo it resolves. Strip AGENTCHUTE_* and refuse a live-looking pool
+# before doing anything else.
+for _var in $(env | sed -n 's/^\(AGENTCHUTE_[A-Za-z0-9_]*\)=.*/\1/p'); do
+	unset "$_var" || true
+done
+
+pool_has_registration() {
+	loop=$1
+	for f in "$loop"/agents/*.md; do
+		[ -e "$f" ] || continue
+		base=${f##*/}
+		case "$base" in
+		README.md | *.example.md) continue ;;
+		esac
+		return 0
+	done
+	return 1
+}
+
+refuse_live_pool() {
+	candidate=$1
+	label=$2
+	[ -n "$candidate" ] || return 0
+	loop=$candidate
+	[ -d "$loop/agents" ] || loop="$candidate/.agentchute/loop"
+	[ -d "$loop/agents" ] || return 0
+	if pool_has_registration "$loop" || ls "$loop"/state/*/serve.claim >/dev/null 2>&1; then
+		printf 'REFUSING TO RUN: %s points at a real agentchute pool (%s).\n' "$label" "$loop" >&2
+		exit 2
+	fi
+}
+
+refuse_live_pool "$(pwd)" "the current working directory"
+repo=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+refuse_live_pool "$repo" "the repo under test"
+
+tmp=$(mktemp -d)
+cleanup() { rm -rf "$tmp"; }
+trap cleanup EXIT HUP INT TERM
+
+fail() {
+	printf 'FAIL  %s\n' "$*" >&2
+	exit 1
+}
+
+old_source="$tmp/old-source"
+new_build="$tmp/new-build"
+fixture="$tmp/fixture"
+home="$tmp/home"
+shim_dir="$tmp/shims"
+old_bin="$tmp/bin/old-agentchute"
+new_bin="$tmp/bin/new-agentchute"
+mkdir -p "$old_source" "$new_build" "$fixture" "$home" "$shim_dir" "$(dirname "$old_bin")"
+
+# The real v1.0.0 tag: predates the enrollment/spec version marker and ships
+# `poller ensure` in its hook templates, a subcommand later removed — the
+# exact pairing sonnet and codex each independently used by hand to confirm
+# the root cause during the investigation this rehearsal now automates.
+git -C "$repo" archive v1.0.0 | tar -x -C "$old_source"
+(cd "$old_source" && go build -ldflags '-X main.version=1.0.0' -o "$old_bin" .)
+
+(cd "$repo" && go build -o "$new_bin" .)
+new_version=$("$new_bin" --version)
+
+env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" \
+	"$old_bin" setup \
+	--control-repo "$fixture" \
+	--init \
+	--wake runner \
+	--wrappers claude-code \
+	--shim-dir "$shim_dir" \
+	--no-profile \
+	--yes >"$tmp/setup-old.log" 2>&1 ||
+	fail "old (v1.0.0) setup did not succeed:
+$(cat "$tmp/setup-old.log")"
+
+hook_path="$fixture/.claude/settings.json"
+spec_path="$fixture/AGENTCHUTE.md"
+[ -f "$hook_path" ] || fail "old setup did not install a claude-code hook file"
+grep -q 'poller' "$hook_path" ||
+	fail "sanity check failed: v1.0.0 hook does not reference poller (fixture assumption is wrong)"
+grep -q 'agentchute-spec' "$spec_path" &&
+	fail "sanity check failed: v1.0.0 AGENTCHUTE.md already carries a spec marker (fixture assumption is wrong)"
+old_hook=$(cat "$hook_path")
+
+# A real agent would have registered before doctor ever runs; boot it now so
+# the ONLY thing left for doctor to catch is the stale hook/spec, not an
+# unrelated missing-registration blocker.
+env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" \
+	"$new_bin" boot --as claude-code --vendor anthropic --control-repo "$fixture" >"$tmp/boot.log" 2>&1 ||
+	fail "boot did not succeed:
+$(cat "$tmp/boot.log")"
+
+env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" AGENTCHUTE_BIN="$new_bin" \
+	"$new_bin" doctor --as claude-code --control-repo "$fixture" >"$tmp/doctor-before.log" 2>&1 && {
+	fail "doctor unexpectedly passed against the stale v1.0.0 hook/spec BEFORE any update ran"
+}
+grep -qi 'poller' "$tmp/doctor-before.log" ||
+	fail "doctor's pre-update blocker did not name the removed poller subcommand:
+$(cat "$tmp/doctor-before.log")"
+
+# The update path itself: point AGENTCHUTE_BIN at the new binary directly
+# (this rehearsal is proving the setup/hooks refresh logic, not the
+# GitHub-download step install.sh and upgrade_smoke.sh already cover) and run
+# the new binary's own `setup` over the fixture, exactly what `update`'s
+# resync does after swapping the binary.
+env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" \
+	"$new_bin" setup \
+	--control-repo "$fixture" \
+	--wake runner \
+	--wrappers claude-code \
+	--shim-dir "$shim_dir" \
+	--no-profile \
+	--yes >"$tmp/setup-new.log" 2>&1 ||
+	fail "new binary's resync setup did not succeed:
+$(cat "$tmp/setup-new.log")"
+
+new_hook=$(cat "$hook_path")
+[ "$new_hook" != "$old_hook" ] || fail "hook file is byte-identical to the stale v1.0.0 template after resync"
+grep -q 'poller' "$hook_path" &&
+	fail "refreshed hook still references the removed poller subcommand"
+
+grep -q 'agentchute-spec' "$spec_path" ||
+	fail "AGENTCHUTE.md was not stamped with the spec marker after resync"
+
+env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" AGENTCHUTE_BIN="$new_bin" \
+	"$new_bin" doctor --as claude-code --control-repo "$fixture" >"$tmp/doctor-after.log" 2>&1 ||
+	fail "doctor still blocks after resync:
+$(cat "$tmp/doctor-after.log")"
+
+printf 'PASS  v1.0.0 hook (referencing removed poller subcommand) was stale before any update\n'
+printf 'PASS  doctor correctly blocked on the stale hook before resync\n'
+printf 'PASS  resync refreshed the hook to the current (%s) canonical template\n' "$new_version"
+printf 'PASS  resync stamped AGENTCHUTE.md with the current spec marker\n'
+printf 'PASS  doctor is clean after resync\n'

--- a/tests/upgrade_hook_refresh_smoke.sh
+++ b/tests/upgrade_hook_refresh_smoke.sh
@@ -1,15 +1,16 @@
 #!/bin/sh
 # Rehearse the hook-refresh-reliability fixes (2026-08-11 investigation) across
-# a REAL old-release-to-current binary swap: a genuinely stale hook file and a
-# pre-marker AGENTCHUTE.md (built from the real v1.0.0 tag) must both refresh
-# to the current binary's canonical templates after `agentchute update`, and
-# doctor must report clean afterward. Sibling to upgrade_smoke.sh (which
-# proves the registration/lease wire-break separately, with wrappers=none —
-# it never installs a hook file, so it cannot exercise this at all). This is
-# the CI-level proof that closes the gap: prior to this file, no CI job ever
-# exercised hook-file refresh across a real version boundary — every check
-# was either a Go unit test against synthetic fixtures, or manual rehearsal
-# (see docs/decisions/ if that changes).
+# a REAL `agentchute update` run: a genuinely stale hook file and a pre-marker
+# AGENTCHUTE.md (built from the real v1.0.0 tag) must both refresh to the
+# current binary's canonical templates when the OLD installed binary downloads
+# and swaps to the current one and re-execs its own setup resync — not merely
+# when the new binary's `setup` is invoked directly (codex review on this
+# file's first revision [P1]: a direct-setup rehearsal cannot catch a
+# regression in `update`'s own resync invocation/composition, e.g. the PR #130
+# lease-ordering fix). Sibling to upgrade_smoke.sh (which proves the
+# registration/lease wire-break separately, with --wrappers none — it never
+# installs a hook file, so it cannot exercise this at all); this script
+# reuses that file's local-release-server pattern for the same reason.
 
 set -eu
 
@@ -52,7 +53,14 @@ repo=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 refuse_live_pool "$repo" "the repo under test"
 
 tmp=$(mktemp -d)
-cleanup() { rm -rf "$tmp"; }
+server_pid=
+cleanup() {
+	if [ -n "$server_pid" ]; then
+		kill "$server_pid" 2>/dev/null || true
+		wait "$server_pid" 2>/dev/null || true
+	fi
+	rm -rf "$tmp"
+}
 trap cleanup EXIT HUP INT TERM
 
 fail() {
@@ -60,27 +68,80 @@ fail() {
 	exit 1
 }
 
+wait_for_file() {
+	path=$1
+	label=$2
+	i=0
+	while [ "$i" -lt 100 ]; do
+		[ -f "$path" ] && return 0
+		i=$((i + 1))
+		sleep 0.1
+	done
+	fail "timed out waiting for $label: $path"
+}
+
 old_source="$tmp/old-source"
 new_build="$tmp/new-build"
+http_root="$tmp/http"
 fixture="$tmp/fixture"
 home="$tmp/home"
 shim_dir="$tmp/shims"
-old_bin="$tmp/bin/old-agentchute"
-new_bin="$tmp/bin/new-agentchute"
-mkdir -p "$old_source" "$new_build" "$fixture" "$home" "$shim_dir" "$(dirname "$old_bin")"
+installed="$tmp/bin/agentchute"
+mkdir -p "$old_source" "$new_build" "$http_root" "$fixture" "$home" "$shim_dir" "$(dirname "$installed")"
+
+# Build the CURRENT worktree and publish it as a fake v9.9.9 release on a
+# local-only HTTP server. The version number is arbitrary and deliberately
+# unreal (a real repo release is never actually "v9.9.9") — what matters is
+# that it is newer than 1.0.0, so `update`'s version comparison proceeds.
+new_version_tag=v9.9.9
+new_bin="$new_build/agentchute"
+(cd "$repo" && go build -ldflags "-X main.version=${new_version_tag#v}" -o "$new_bin" .)
+
+goos=$(go env GOOS)
+goarch=$(go env GOARCH)
+asset="agentchute_${new_version_tag#v}_${goos}_${goarch}.tar.gz"
+release_dir="$http_root/releases/download/$new_version_tag"
+mkdir -p "$release_dir"
+tar -C "$new_build" -czf "$release_dir/$asset" agentchute
+if command -v sha256sum >/dev/null 2>&1; then
+	checksum=$(sha256sum "$release_dir/$asset" | awk '{print $1}')
+else
+	checksum=$(shasum -a 256 "$release_dir/$asset" | awk '{print $1}')
+fi
+printf '%s  %s\n' "$checksum" "$asset" >"$release_dir/checksums.txt"
+
+port_file="$tmp/http.port"
+python3 - "$http_root" "$port_file" <<'PY' &
+import http.server
+import os
+import sys
+
+os.chdir(sys.argv[1])
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), http.server.SimpleHTTPRequestHandler)
+with open(sys.argv[2], "w", encoding="utf-8") as handle:
+    handle.write(str(server.server_port))
+server.serve_forever()
+PY
+server_pid=$!
+wait_for_file "$port_file" "local release server port"
+port=$(cat "$port_file")
 
 # The real v1.0.0 tag: predates the enrollment/spec version marker and ships
 # `poller ensure` in its hook templates, a subcommand later removed — the
 # exact pairing sonnet and codex each independently used by hand to confirm
-# the root cause during the investigation this rehearsal now automates.
+# the root cause during the investigation this rehearsal now automates. Built
+# with the download base pointed at the local server above, exactly like
+# upgrade_smoke.sh, so `update` never touches the real network.
 git -C "$repo" archive v1.0.0 | tar -x -C "$old_source"
-(cd "$old_source" && go build -ldflags '-X main.version=1.0.0' -o "$old_bin" .)
-
-(cd "$repo" && go build -o "$new_bin" .)
-new_version=$("$new_bin" --version)
+(
+	cd "$old_source"
+	go build \
+		-ldflags "-X main.version=1.0.0 -X github.com/agentchute/agentchute/internal/cli.updateGitHubBase=http://127.0.0.1:$port" \
+		-o "$installed" .
+)
 
 env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" \
-	"$old_bin" setup \
+	"$installed" setup \
 	--control-repo "$fixture" \
 	--init \
 	--wake runner \
@@ -104,10 +165,15 @@ old_hook=$(cat "$hook_path")
 # the ONLY thing left for doctor to catch is the stale hook/spec, not an
 # unrelated missing-registration blocker.
 env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" \
-	"$new_bin" boot --as claude-code --vendor anthropic --control-repo "$fixture" >"$tmp/boot.log" 2>&1 ||
+	"$installed" boot --as claude-code --vendor anthropic --control-repo "$fixture" >"$tmp/boot.log" 2>&1 ||
 	fail "boot did not succeed:
 $(cat "$tmp/boot.log")"
 
+# Deliberately the NEW binary's doctor, not $installed (which is still the
+# OLD v1.0.0 binary at this point — its own doctor doesn't know `poller` was
+# later removed, so it would pass cleanly and prove nothing). This models
+# "swap the binary, then run its doctor before resyncing" — precisely the
+# gap window PR #127/#131 close.
 env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" AGENTCHUTE_BIN="$new_bin" \
 	"$new_bin" doctor --as claude-code --control-repo "$fixture" >"$tmp/doctor-before.log" 2>&1 && {
 	fail "doctor unexpectedly passed against the stale v1.0.0 hook/spec BEFORE any update ran"
@@ -116,37 +182,38 @@ grep -qi 'poller' "$tmp/doctor-before.log" ||
 	fail "doctor's pre-update blocker did not name the removed poller subcommand:
 $(cat "$tmp/doctor-before.log")"
 
-# The update path itself: point AGENTCHUTE_BIN at the new binary directly
-# (this rehearsal is proving the setup/hooks refresh logic, not the
-# GitHub-download step install.sh and upgrade_smoke.sh already cover) and run
-# the new binary's own `setup` over the fixture, exactly what `update`'s
-# resync does after swapping the binary.
+# THE ACTUAL UPDATE PATH: the old installed binary downloads the new one from
+# the local server, swaps itself at $installed, and re-execs setup to resync
+# — the exact composition PR #130 changed the ordering of (hook-compatibility
+# repair now runs before lease invalidation). Nothing here calls `setup`
+# directly.
 env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" \
-	"$new_bin" setup \
+	"$installed" update \
 	--control-repo "$fixture" \
-	--wake runner \
-	--wrappers claude-code \
-	--shim-dir "$shim_dir" \
-	--no-profile \
-	--yes >"$tmp/setup-new.log" 2>&1 ||
-	fail "new binary's resync setup did not succeed:
-$(cat "$tmp/setup-new.log")"
+	--version "$new_version_tag" >"$tmp/update.log" 2>&1 ||
+	fail "update did not succeed:
+$(cat "$tmp/update.log")"
+
+swapped_version=$("$installed" --version)
+[ "$swapped_version" = "agentchute ${new_version_tag#v}" ] ||
+	fail "update did not actually swap the installed binary: reports $swapped_version, want agentchute ${new_version_tag#v}"
 
 new_hook=$(cat "$hook_path")
-[ "$new_hook" != "$old_hook" ] || fail "hook file is byte-identical to the stale v1.0.0 template after resync"
+[ "$new_hook" != "$old_hook" ] || fail "hook file is byte-identical to the stale v1.0.0 template after update"
 grep -q 'poller' "$hook_path" &&
 	fail "refreshed hook still references the removed poller subcommand"
 
 grep -q 'agentchute-spec' "$spec_path" ||
-	fail "AGENTCHUTE.md was not stamped with the spec marker after resync"
+	fail "AGENTCHUTE.md was not stamped with the spec marker after update"
 
-env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" AGENTCHUTE_BIN="$new_bin" \
-	"$new_bin" doctor --as claude-code --control-repo "$fixture" >"$tmp/doctor-after.log" 2>&1 ||
-	fail "doctor still blocks after resync:
+env HOME="$home" XDG_CONFIG_HOME="$home/.config" SHELL=/bin/sh PATH="$shim_dir:/usr/bin:/bin" AGENTCHUTE_BIN="$installed" \
+	"$installed" doctor --as claude-code --control-repo "$fixture" >"$tmp/doctor-after.log" 2>&1 ||
+	fail "doctor still blocks after update:
 $(cat "$tmp/doctor-after.log")"
 
 printf 'PASS  v1.0.0 hook (referencing removed poller subcommand) was stale before any update\n'
-printf 'PASS  doctor correctly blocked on the stale hook before resync\n'
-printf 'PASS  resync refreshed the hook to the current (%s) canonical template\n' "$new_version"
-printf 'PASS  resync stamped AGENTCHUTE.md with the current spec marker\n'
-printf 'PASS  doctor is clean after resync\n'
+printf 'PASS  doctor correctly blocked on the stale hook before update\n'
+printf 'PASS  agentchute update actually swapped the installed binary (%s)\n' "$swapped_version"
+printf 'PASS  agentchute update refreshed the hook to the current canonical template\n'
+printf 'PASS  agentchute update stamped AGENTCHUTE.md with the current spec marker\n'
+printf 'PASS  doctor is clean after update\n'


### PR DESCRIPTION
## What

Adds `upgrade-hook-refresh-smoke`, a new CI job running on **every PR and main push** (not release-branch-only), that rehearses hook and spec refresh across a real v1.0.0-to-current binary swap.

## Why

Codex's investigation (bus ref, hook-refresh-reliability review, 2026-08-11) flagged the actual CI blind spot behind item 9 of the fix list: the existing `upgrade-smoke` job only runs on `release/v2.5` pushes, and even then uses `--wrappers none` — it never installs a hook file at all, so it structurally cannot exercise hook refresh. Every one of today's fixes (install.sh tty gate #128, doctor hardening #127, serve self-heal #129, update ordering #130, spec auto-refresh #131) was proven only by Go unit tests against synthetic fixtures, or by sonnet/codex running rehearsals by hand during the investigation. Nothing encoded that proof permanently into CI.

## How

`tests/upgrade_hook_refresh_smoke.sh`, sibling to `upgrade_smoke.sh` (same safety preamble — strips `AGENTCHUTE_*`, refuses a live-looking pool):

1. Builds the real `v1.0.0` git tag — it predates the spec-version marker and ships a hook template invoking `poller ensure`, a subcommand later removed. The exact pairing sonnet and codex each independently used by hand.
2. Builds the current worktree as the "new" binary.
3. Installs the v1.0.0 hook + pre-marker `AGENTCHUTE.md` into a throwaway fixture, confirms `doctor` correctly blocks on the stale `poller` reference.
4. Runs the new binary's `setup` over the same fixture (what `update`'s resync does after a binary swap).
5. Asserts the hook file was refreshed to the current canonical template, `AGENTCHUTE.md` now carries the spec marker, and `doctor` is clean.

Wired into `.github/workflows/ci.yaml` as its own job (no `if:` gate — every PR and main push), separate from the existing `upgrade-smoke` job so that job's own wire-break semantics stay untouched.

## Verification

- Ran locally end to end: all 5 assertions pass against real `v1.0.0` and current-worktree binaries.
- Confirmed it actually catches a regression: temporarily disabled the `refreshHookCompatibility` call in `setup.go` — the rehearsal failed (caught one layer earlier than expected, at the defense-in-depth verify step, which is itself a good sign). Restored, `git diff` clean, rehearsal green again.
- `shellcheck -s sh` clean on the new script.
- Full `go test ./...`, `gofmt`, `go vet` clean.
- `tests/install_test.sh` (36/36) still passes — untouched.

## Deliberately left out of scope

A dedicated two-repo serve-self-heal rehearsal (fix 2, multi-control-repo stranding) over real released binaries. Already covered by `TestServeRefreshesLaunchedWrapperHookBeforeLaunch` (merged with #129) at the process level — just not yet at this job's real-binary-swap level. Flagging rather than silently dropping; a reasonable follow-up if the team wants that last increment of coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
