### PR TITLE
docs(ssh-hub): reviewed design and implementation plan

### DIFF
--- a/proposal/ssh-hub/BRIEF.md
+++ b/proposal/ssh-hub/BRIEF.md
@@ -1,0 +1,92 @@
+# SSH hub — design-round brief (2026-08-14, Alex-directed)
+
+Deliverable: `proposal/ssh-hub/DESIGN.md` — a complete, implementation-ready
+design for the SSH hub reference implementation. Design only; no code changes.
+
+## Binding inputs (consensus from the 2026-08-14 research round)
+
+Verdict + vetoes: `.agentchute/loop/scratch-synthesis-2026-08-14-next-ref-impl.md`
+("FINAL CONSENSUS" section). Non-negotiables:
+
+1. One authoritative pool host (the hub); state stays plain files on its disk;
+   every existing invariant (flock, link-no-clobber, rename claim, lease
+   fencing) keeps executing on the hub's kernel.
+2. Remote lanes use a LONG-LIVED SSH subsystem helper that owns lease
+   acquire/renew/poll — never one-shot interpolated `ssh host agentchute <argv>`.
+3. Forced-command per-key identity pinning ships day one: one authorized key →
+   one agent id; server side rejects any `--as`/`--from` mismatch.
+4. Release gates: hard connect/read/heartbeat timeouts; dropped session
+   stops/fences the local child; explicit protocol/version handshake; NEVER
+   auto-replay `send` after an ambiguous disconnect (unknown outcome → fail
+   closed and report).
+5. First implementation PR carves the operation seam (extract structured
+   operations from `cmdSend`/`cmdCheck`/`ack`/lease lifecycle); filesystem
+   remains the only backend; no generic low-level Store rewrite.
+6. Zero new Go dependencies. Client side shells out to the system `ssh`
+   binary (justify and specify exactly how) or justifies an alternative that
+   adds no dep.
+7. Structured framing over the wire (stdin/stdout of the subsystem), never
+   argv re-parsing or shell text; `--body-file` bodies ship over the channel.
+8. Vetoed: federation, SFTP-as-filesystem, loop-dir sync, unrestricted keys,
+   unbounded SSH waits.
+
+## Alex's priority for THIS round (weight it above everything)
+
+Deployment and end-user seamlessness. "As simple as possible to deploy and
+use, zero issues, very seamless for end user." Concretely:
+- Hub setup and joining a new machine must each be a handful of commands at
+  most; design the exact UX (`agentchute hub ...` / join flow), the exact
+  quickstart text, and the key-provisioning story (who runs what, where keys
+  land, how the authorized_keys line gets installed — can the hub generate it?).
+- Every failure an end user can plausibly hit gets a named, actionable error
+  message (catalog them).
+- Existing single-host pools keep working untouched; a hub pool must be
+  adoptable incrementally (hub is just today's pool; remotes join it).
+- Tailscale documented as the blessed deployment recipe (incl. `tailscale ssh`
+  where it removes key management) — recipe, never a dependency.
+
+## Required DESIGN.md table of contents (all sections mandatory)
+
+1. Goals / non-goals (incl. the vetoes above).
+2. Architecture overview + one ASCII diagram (hub, remote lane, helper,
+   runner, wrapper).
+3. Operation seam: the extracted operation set — for each operation its
+   inputs, outputs, error cases, and which existing internal functions it
+   wraps (cite file:line at HEAD). This is the API both FS-local and SSH
+   transports call.
+4. Wire protocol: subsystem name, framing (choose and specify exactly — e.g.
+   newline-delimited JSON with length-prefixed bodies; version handshake
+   message; every message type with fields and an example); timeout values
+   and where enforced; heartbeat cadence; how `check`-claimed bytes flow back;
+   how send bodies flow in; ambiguous-outcome reporting for `send`.
+5. Identity & security: authorized_keys template (exact line), the hub-side
+   entry command, key→id mapping storage, `--as`/`--from` enforcement point,
+   what a compromised remote key can and cannot do, host-key verification
+   story (first-connect UX), threat table.
+6. Lease & liveness: how the helper acquires/renews the serve lease over the
+   channel, fencing token flow, what happens on channel drop (both sides),
+   reconnect/backoff, interaction with the local runner + wake cues + guard
+   latch (guard-latch reads must stay local-cached — specify).
+7. End-user experience: exact quickstarts (hub operator; joining agent), all
+   new commands/flags (keep them minimal — subtract-default guardrail),
+   config/pointer-file format, the error-message catalog, `doctor`
+   integration, Tailscale recipe.
+8. Failure-mode matrix: every fault (hub down, TCP half-open, helper crash,
+   wrapper crash, version skew, clock skew, key revoked, disk full on hub,
+   duplicate id join) × detection × behavior × user-visible message.
+9. Compatibility & spec delta: exact AGENTCHUTE.md sections to amend (spec PR
+   comes first per Working rule 1), conformance-suite additions (serve
+   lease/fencing coverage gap is known), what EXTENSIONS.md keeps.
+10. Test plan: in-process operation-seam tests, framing tests with a fake
+    transport, real-sshd integration matrix (disconnect-after-claim,
+    disconnect-after-send, reclaim-during-send, identity mismatch, version
+    mismatch), CI wiring on ubuntu+macos.
+11. Implementation plan: ordered PR list with scope, rough LOC, and its
+    reviewer gate; which PRs touch spec vs code; what ships in which release.
+12. Open questions (should be near-empty — resolve, don't punt).
+
+## Review loop (after the draft)
+
+Internal critics first (seamlessness critic + adversarial correctness critic),
+then codex and grok review the pinned doc; loop FIX→revise→delta-re-review
+until both return SHIP. Reviews are prose; no repo mutation by reviewers.

--- a/proposal/ssh-hub/DESIGN.md
+++ b/proposal/ssh-hub/DESIGN.md
@@ -1,0 +1,3154 @@
+# SSH Hub — Design (implementation-ready)
+
+Status: DESIGN — for review, then merge-by-merge execution (§11, M1–M6).
+Brief: [`proposal/ssh-hub/BRIEF.md`](BRIEF.md). Consensus inputs:
+`.agentchute/loop/scratch-synthesis-2026-08-14-next-ref-impl.md` ("FINAL CONSENSUS").
+All code citations are `file:line @ 1244ae4` (repo HEAD at design time).
+OpenSSH facts cited below were verified against `sshd(8)` and `ssh_config(5)`
+(man.openbsd.org, fetched 2026-08-14); Tailscale SSH facts against
+tailscale.com/kb/1193 (fetched 2026-08-14).
+
+---
+
+## 1. Goals / non-goals
+
+### Goals
+
+1. **One authoritative pool host (the hub).** The hub is *today's pool*,
+   unchanged: plain files under `.agentchute/loop/`, every CI-tested invariant
+   (flock, `link()`-no-clobber, rename claim, serve lease + fencing token)
+   executing on the hub's kernel exactly as it does now. The network moves the
+   **operation** to where the state lives; it never moves, syncs, or replicates
+   the state.
+2. **Remote lanes via a long-lived channel.** A remote machine's `agentchute
+   serve` drives a persistent SSH session (the *channel*) whose hub-side peer
+   process owns the lane's serve lease, lease renewal, registration heartbeat,
+   and inbox poll. Never one-shot interpolated `ssh host agentchute <argv>`
+   shell text.
+3. **Forced-command per-key identity pinning, day one.** One authorized key =
+   one agent id. The hub-side entry point is a forced command
+   (`command="…",restrict`); the wire protocol carries **no actor field at
+   all** — the actor *is* the pinned identity, so a `--as`/`--from` mismatch is
+   structurally impossible past the handshake (§5).
+4. **Deployment seamlessness above all** (Alex's stated priority): hub setup is
+   zero commands; joining a machine is one command in the common case (§7.2,
+   one paste when an admin sits in the middle); every
+   plausible end-user failure has a named, actionable error (§7.5); existing
+   single-host pools keep working untouched and a hub pool is adoptable
+   incrementally (the hub *is* the existing pool; remotes join it).
+5. **Release gates** (consensus, non-negotiable): hard connect/read/heartbeat
+   timeouts everywhere (§4.6); a dropped channel fences and stops the local
+   child (§6.4); explicit protocol/version handshake (§4.3); **never**
+   auto-replay `send` after an ambiguous disconnect — fail closed and report
+   (§4.5.3).
+6. **Operation seam first.** The first implementation PR extracts structured
+   operations from `cmdSend`/`cmdCheck`/`cmdAck`/the lease lifecycle
+   (§3); the filesystem remains the only backend; both the in-process (local)
+   and SSH (remote) paths call the same seam.
+7. **Zero new Go dependencies.** The client shells out to the system `ssh`
+   binary (§4.2, with the exact invocation); the hub side is the existing
+   binary reading stdin/stdout. `ssh-keygen` is shelled out for join-time key
+   generation. No `golang.org/x/crypto/ssh`, no new module requirements.
+
+### Non-goals (the vetoes, restated as binding)
+
+- **Federation** (per-host pools + remote-delivery verb): stays a later
+  extension. Not v1.
+- **SFTP-as-filesystem / any network-mounted loop dir** as the multi-host
+  story: the hub replaces it.
+- **Loop-dir sync/mirroring** (Syncthing/rsync/Dropbox/git/brokers): fails
+  claim exclusivity; permanently rejected.
+- **Unrestricted keys**: every hub key ships with `restrict` + forced command;
+  there is no documented "trusted key with a shell" mode.
+- **Unbounded SSH waits**: every network wait in this design has a numeric
+  deadline (§4.6).
+- **Auto-replay of `send`** after an ambiguous outcome: never (§4.5.3).
+- **S3 / HTTP backends**: phase-2+ behind the same seam; not designed here
+  beyond the seam being shaped so they slot in.
+- **Resuming the SAME child across a dropped channel**: never — the child's
+  fencing token is baked into its environment at launch
+  (`internal/cli/serve.go:502-530 @ 1244ae4`) and cannot be swapped
+  mid-session, so a dropped channel always fences and stops the running child
+  (§6.4). What IS in scope — and consensus-compatible, because the veto
+  targets resuming a fenced child, not supervision — is the **full-lane
+  relaunch** (§6.7, default-on for remote lanes; `--relaunch=false` opts
+  out): fresh channel, fresh lease, fresh token, fresh child.
+
+---
+
+## 2. Architecture overview
+
+Three processes on the remote machine, one per-connection process on the hub,
+and the pool state exactly where it is today.
+
+```
+REMOTE MACHINE (laptop)                      HUB (today's pool host)
+┌──────────────────────────────────────┐     ┌──────────────────────────────────────┐
+│ agentchute serve (runner, remote     │     │ sshd                                 │
+│ mode)                                │     │   │ authorized_keys:                 │
+│  ├─ child wrapper (claude/codex/…)   │     │   │  restrict,command="agentchute    │
+│  │    PTY, cue injection — all local │     │   │  hub session --agent codex …"    │
+│  │    env: AGENTCHUTE_SERVE_TOKEN    │     │   ▼                                  │
+│  │         (minted hub-side)         │     │ agentchute hub session (per conn)    │
+│  └─ CHANNEL: one dedicated `ssh`     │◄───►│  ├─ owns the serve lease (its OWN    │
+│     child process, framed NDJSON     │ SSH │  │  hub pid is in serve.claim)       │
+│     hello → lease-acquire → register │     │  ├─ tick: RenewLease + Heartbeat +   │
+│     → tick every 5 s → lease-release │     │  │  throttled sweep + inbox counts   │
+│                                      │     │  └─ calls the operation seam         │
+│ child's CLI calls (send/check/ack/   │     │         │                            │
+│ gate/pending/boot): ONE-SHOT framed  │◄───►│         ▼                            │
+│ sessions over `ssh` with             │ SSH │ internal/op (operation seam)         │
+│ ControlMaster=auto mux               │     │         │                            │
+│                                      │     │         ▼                            │
+│ LOCAL-ONLY state (per-hub dir §7.4): │     │ internal/loop — unchanged invariants │
+│  guard.latch, runner.json,           │     │ .agentchute/loop/{inbox,agents,      │
+│  runner.log, spool/, mux sockets,    │     │   archive,malformed,state}/          │
+│  known_hosts, keys                   │     │ (flock, link-no-clobber, rename      │
+└──────────────────────────────────────┘     │  claim, lease + fencing token)       │
+                                             └──────────────────────────────────────┘
+```
+
+Load-bearing choices, each detailed later:
+
+- **The hub session process is the lane's presence on the hub.** It acquires
+  the serve lease with `loop.AcquireServeLease`
+  (`internal/loop/lease.go:150 @ 1244ae4`); `serve.claim.pid` is the *hub-side
+  session pid*, so the existing same-host pid-proof reclaim rule
+  (`internal/loop/lease.go:242-244 @ 1244ae4`) works again for remote lanes —
+  no cross-host freshness-only reclaim, no lease-timing changes. When the SSH
+  connection dies, sshd tears the session process down, the session's exit
+  path releases the lease (token-checked, `internal/loop/lease.go:345
+  @ 1244ae4`), and relaunch is immediate.
+- **Hub clock everywhere.** Timestamps (`MintSendStamp`,
+  `internal/loop/floor.go:111 @ 1244ae4`), `last_seen` heartbeats
+  (`internal/loop/registration.go:192 @ 1244ae4`), and lease freshness are all
+  minted on the hub. A remote lane's clock skew has **zero** protocol effect —
+  strictly stronger than today's NTP-loose assumption (AGENTCHUTE.md §5.4).
+- **Local things stay local.** The PTY, cue injection, idle detection, guard
+  latch (§6.6), runner state, and the send spool never cross the wire.
+- **Two connection shapes, one wire protocol.** The channel (long-lived,
+  dedicated TCP connection, owns the lease lifecycle) and one-shot operation
+  sessions (short, multiplexed over a ControlMaster socket). Both speak the
+  identical framed protocol (§4); the hub session process cannot tell them
+  apart until the first request arrives (`lease-acquire` marks a channel).
+
+---
+
+## 3. Operation seam (`internal/op`)
+
+Merge M1 (§11) extracts a package `internal/op` whose functions are the **only** way
+`send`/`check`/`ack`/`serve`/`boot`/`gate`/`pending`/`status` mutate or read
+pool state. The CLI keeps parsing/rendering; `internal/op` owns
+validate-and-mutate; `internal/loop` keeps the primitives, unchanged. The hub
+session process (§4) is a thin dispatcher from wire frames to these same
+functions. No generic low-level Store rewrite: the seam is at *operation*
+granularity, the filesystem is the only backend, and `internal/loop` signatures
+do not change.
+
+Conventions:
+
+- **Actor context (C1).** Actor-scoped ops take an explicit, **non-wire**
+  context: `op.Context{ActorID string}` — signature
+  `(*loop.Config, op.Context, Request) (Response, error)`. Neither
+  `loop.Config` nor the request structs carry identity (`loop.Config` has no
+  identity field, `internal/loop/config.go:34-53 @ 1244ae4`), so the actor
+  must arrive as its own argument, never smuggled through config or global
+  state. The local CLI builds it from `resolveAgentID`
+  (`internal/cli/identity.go:13-38 @ 1244ae4`); the hub session builds it
+  once, from the forced command's pinned `--agent`, and reuses it for every
+  dispatch. The wire structs stay actor-free (§5.3). Every actor-scoped op
+  is tested through **both** constructors (§10.1).
+- **Wire shape.** Requests/responses are plain JSON-taggable structs — they
+  are also the wire payloads (§4.4); errors are typed sentinels mapped 1:1
+  to wire error codes (§4.4.2). Lines that today go straight to a stream
+  become `NoteEvent`s on the typed event stream (next bullet) so the remote
+  client can render them in order — at **both** levels, where the level is
+  the stream (`warn` → stderr, `info` → stdout; §4.3): `warn` for the stderr
+  warnings (`check.go` alone has five distinct stderr warning sites, e.g.
+  `internal/cli/check.go:141-151 @ 1244ae4`), `info` for the stdout status
+  lines produced inside the stream rather than at its end
+  (`check.go:201,207,262 @ 1244ae4`).
+- **Streaming producers — ONE ordered, typed event stream (C4, D2).** Ops
+  whose results are unbounded — `Claim`, `Ack`, `Pending` — do not
+  materialize result slices *of any kind*, side channels included. Each
+  takes a single typed emitter:
+  `emit func(op.Event) error`, where `op.Event` is a tagged union with
+  exactly one non-nil arm:
+  `{Message *MessageEvent, Note *NoteEvent, Owed *OwedEvent, Ack
+  *AckItemEvent}`. Events are emitted **in production order** — a
+  quarantine warning lands between the messages it actually occurred
+  between, an expired-owed entry where the code produced it — so ordering
+  survives the wire and nothing buffers until return (an earlier draft
+  returned `Notes[]`/`ExpiredOwed[]` on the summary, which both re-created
+  unbounded buffering and lost every note on a mid-stream failure).
+  Terminal summaries carry **counts and truncation metadata only** — no
+  slices. The hub dispatcher's `emit` writes one wire frame per event
+  through the single codec writer and releases it; peak hub memory is one
+  event (≤4 MiB body), never N×4 MiB for a `check --limit 0` over a full
+  inbox. The local CLI's `emit` renders directly — today's per-message
+  display loop, so local behavior is unchanged by construction. An `emit`
+  error (connection gone) aborts the op after the current event; for `Claim`
+  the already-claimed residue is redelivered by the next check (§4.5.2), for
+  `Ack` the archive commit already happened per item and re-acking is
+  idempotent (`internal/loop/inbox.go:269-292 @ 1244ae4`).
+
+### 3.1 `op.Send`
+
+- **Input**: `SendReq{To string, Content []byte, Ask bool, ReplyBy
+  time.Duration, ServeToken string}` — `Content` is the fully composed message
+  (frontmatter + body). Composition (`loop.ComposeMessage`,
+  `internal/loop/message.go:20 @ 1244ae4`; `applyAskHeading`,
+  `internal/cli/send.go:483 @ 1244ae4`; `applyReplyRequiredFrontmatter`,
+  `internal/cli/send.go:500 @ 1244ae4`) stays client-side/CLI-side so the hub
+  never rewrites bodies. **There is no `From` field** — the actor is
+  `op.Context.ActorID` (locally from `resolveAgentID`, remotely the pinned
+  key id; §3 conventions, §5.3). This is the B4 pattern the codebase already
+  teaches: delete the second source of a fact instead of equality-checking
+  it (`internal/loop/seq.go:283-291 @ 1244ae4`).
+- **Wraps**: sender-enrollment stat (`internal/cli/send.go:141-148
+  @ 1244ae4`), lock-free recipient preflight `loop.CheckRecipientReachability`
+  (`internal/loop/seq.go:226 @ 1244ae4`), `loop.SendTsMessageWithCommit`
+  (`internal/loop/floor.go:160 @ 1244ae4`) = `MintSendStamp`
+  (`floor.go:111`) + `DeliverUnderRecipientLock`
+  (`internal/loop/seq.go:307 @ 1244ae4`, incl. the fresh-suffix EEXIST retry,
+  `seq.go:334-350`), and — when `Ask` — `loop.RecordOwed`
+  (`internal/loop/owed.go:202 @ 1244ae4`). The asker's `.owed` ledger lives
+  hub-side (`state/<id>/owed.json` on the hub), so gate/check/clean all see
+  one ledger.
+- **Output**: `SendResp{Filename, Ref string, Committed bool, DurabilityNote
+  string}` — `Ref` is `TsID.RefString()` (`internal/loop/tsid.go:76
+  @ 1244ae4`). `Committed && DurabilityNote != ""` is the linked-but-sync-
+  failed partial success (`internal/loop/seq.go:179-181 @ 1244ae4`), which the
+  CLI already renders as "delivered … Do NOT resend"
+  (`internal/cli/send.go:269 @ 1244ae4`).
+- **Errors**: `ErrNotRegistered` (sender — one sentinel and one wire code, but
+  the sender-path *text* stays with this call site; §7.5 carries both texts),
+  `loop.ErrRecipientUnknown`
+  (`seq.go:191`), `loop.ErrRecipientUnreadable` (`seq.go:206`), stale
+  (preflight, C29b) vs racing (`*loop.ErrRecipientStale` post-preflight,
+  C29c — classification stays in `internal/cli/send.go:397-416 @ 1244ae4`,
+  which becomes the renderer for the seam's typed result), `loop.ErrFenced`
+  (`internal/loop/lease.go:51 @ 1244ae4`), collision exhaustion
+  (`seq.go:350`). The spool-on-failure path (`preserveSendBody`,
+  `internal/cli/send.go:418-458 @ 1244ae4`) stays CLI-side: the spool is
+  sender-local state and must survive precisely when the hub is unreachable.
+
+### 3.2 `op.Claim` (the state half of `check`)
+
+- **Signature**: `op.Claim(cfg, ctx, ClaimReq{Limit int, NoArchive bool},
+  emit func(op.Event) error) (ClaimSummary, error)` — the typed event
+  stream of the §3 conventions (C4/D2): each claimed/redelivered message is
+  claimed, read, emitted as a `MessageEvent`, and released one at a time;
+  quarantine warnings are `NoteEvent`s in place; expired obligations are
+  `OwedEvent`s where the loop reaches them. Nothing accumulates a slice
+  with N bodies (or N notes) in memory.
+- **Wraps**, in `cmdCheck`'s exact order (`internal/cli/check.go:125-283
+  @ 1244ae4`): `loop.ListInboxMessagesWithSkipped`
+  (`internal/loop/inbox.go:121 @ 1244ae4`), §11 filename quarantine
+  `loop.QuarantineInboxFile` (`internal/loop/inbox.go:58 @ 1244ae4`), claimed
+  residue `loop.ListClaimedMessages` (`internal/loop/inbox.go:388
+  @ 1244ae4`), per-message `loop.ReadFileLimit` at `MaxInboxMessageBytes`
+  (`internal/loop/registration.go:34,19 @ 1244ae4`), frontmatter validation +
+  quarantine `loop.ValidateMessageFrontmatter`
+  (`internal/loop/message.go:105 @ 1244ae4`), `loop.ClaimMessage`
+  (`internal/loop/inbox.go:328 @ 1244ae4`), the asker-side owed discharge
+  `loop.ClearOwed` keyed by `in_reply_to` (`internal/cli/check.go:321-331`,
+  `internal/loop/owed.go:241 @ 1244ae4`), and the expired-obligation report
+  `loop.LoadOwedLedger`/`ExpiredOwed` (`internal/loop/owed.go:149,273
+  @ 1244ae4`).
+- **Output**: emitted events — `MessageEvent{Filename, Sender, Stamp
+  string, Redelivered, ReplyRequired bool, ReplyRef string, Body []byte}`,
+  `NoteEvent{Level, Msg string}` (`Level` ∈ {`warn`,`info`}, routed per
+  §4.3 — `check`'s three in-stream stdout status lines are `info` notes, so
+  their POSITION survives, not just their text), and `OwedEvent` carrying
+  the **full**
+  `loop.OwedEntry` fields — `{To, From string, Seq uint64, Stamp, Suffix
+  string, By, RecordedAt time.Time, Ref string}` (`Ref` = precomputed
+  `Key().RefString()` convenience; the rest byte-for-byte what the ledger
+  holds, `internal/loop/owed.go:114-122 @ 1244ae4` — an earlier
+  `{Ref, ExpiredAgo}` shape could not reproduce `pending --json`'s full
+  `Owed []loop.OwedEntry` output, E4; expired-ness is derived client-side
+  from `By` + the §4.3 hub-time offset) — then `ClaimSummary{Claimed,
+  Redelivered, Quarantined, OwedExpired int}` (counts only, D2). **Display stays client-side**: the
+  STALE age banner
+  (`printConsumedBody`, `internal/cli/check.go:348-364 @ 1244ae4`), control-
+  byte sanitization (`sanitizeControlBytes`, `check.go:374 @ 1244ae4`), and
+  the reply-ref print (`check.go:393-408`) render the seam's data. The guard
+  latch is **not** part of this op — it is local (§6.6), and the CLIENT
+  EMITTER arms it on the **first MessageEvent of any kind, before rendering
+  it** (E1) — redelivered residue included, and in both the normal and
+  `--no-archive` paths. That matches the local loop, whose `setLatch`
+  closure (`internal/cli/check.go:169-175 @ 1244ae4`, via
+  `maybeSetGuardLatch`, `check.go:292`) is called at **three** sites, all
+  before their display: `check.go:185` (non-empty `.claimed` residue, armed
+  once before the redelivery loop), `check.go:243` (`--no-archive`
+  display-in-place), and `check.go:256` (after `ClaimMessage`, before
+  `displayConsumed`). All three must be covered — an emitter armed only for
+  freshly claimed mail leaves the redelivery path unarmed, which is exactly
+  the E1 failure this rule exists to prevent. Arming after the op returns is
+  likewise wrong: a disconnect after one displayed message must leave the
+  latch armed over the claimed residue.
+- **Errors**: `ErrNotRegistered` (agent-path text, §7.5), `loop.ErrInboxMissing`
+  (`internal/loop/inbox.go:111 @ 1244ae4`), read/claim I/O errors.
+
+### 3.3 `op.Ack`
+
+- **Signature**: `op.Ack(cfg, ctx, AckReq{}, emit func(op.Event) error)
+  (AckSummary, error)` — typed event stream (§3 conventions, C4/D2): each
+  archived message is emitted as an `AckItemEvent` as it commits.
+- **Wraps**: `archiveAllClaimed`'s body moves from `internal/cli/ack.go:164
+  @ 1244ae4` into `internal/op` (`loop.ListClaimedMessages` +
+  `loop.ArchiveMessage`, `internal/loop/inbox.go:257 @ 1244ae4`, idempotent
+  EEXIST/SameFile handling included) reshaped to emit per item, then the
+  read-only finish-gate evaluation `finishGateClear`
+  (`internal/cli/gate.go:262 @ 1244ae4`, itself `evaluateGate`,
+  `gate.go:129`).
+- **Output**: emitted `AckItemEvent{Filename, ArchivePath string}` events,
+  then `AckSummary{Acked int, GateClear bool, BlockReasons []string}` — the
+  same information `ackResult` carries today (`internal/cli/ack.go:204
+  @ 1244ae4`; `BlockReasons` is the one inline list kept on a summary — a
+  fixed-small set of gate reason strings, §4.4.3). The unconditional-commit contract and the `--quiet`/exit-2
+  semantics (`ack.go:20-55`) stay in the CLI. The guarded-session `ack`
+  denial (`ack.go:105-109`) stays CLI-side too — it reads the **local** latch.
+
+### 3.4 `op.AcquireLease` / `op.Tick` / `op.ReleaseLease`
+
+- **AcquireLease**: `LeaseReq{}` → `LeaseResp{Token string}`. Wraps
+  `loop.AcquireServeLease` (`internal/loop/lease.go:150 @ 1244ae4`) exactly as
+  `refuseLiveRunnerCollision` does (`internal/cli/serve.go:571 @ 1244ae4`).
+  Errors: `loop.ErrLeaseHeld` (`lease.go:46`) with the holder's
+  `{host,pid,age}` attached for the error message (read via
+  `loop.ReadServeClaim`, `lease.go:297`).
+- **Tick**: `TickReq{}` → `TickResp{Pending, Skipped int, Swept []string,
+  Warnings []string}`.
+  Wraps, in `pollOnce`'s order (`internal/cli/serve.go:609-677 @ 1244ae4`):
+  `loop.RenewLease` (`lease.go:317`), `loop.HeartbeatRegistration`
+  (`internal/loop/registration.go:192 @ 1244ae4`) using the same
+  `heartbeatTemplate` fields (`serve.go:554`) — the template is **not** in
+  the (empty) `TickReq`: `HeartbeatRegistration` hard-errors without a
+  validating template (Vendor, ControlRepo, …, `registration.go:192,217-242
+  @ 1244ae4`), and the hub session only knows id + pool, so the template is
+  the `op.Register` payload the channel supplies at startup (§6.1), cached by
+  the session for the lane's lifetime exactly as `regTemplate` is in the
+  local runner (`serve.go:237 @ 1244ae4`); a `tick` arriving on a channel
+  before `register` is refused with `E_ORDER` — then
+  `loop.SweepStaleRegistrations`
+  (`internal/loop/sweep.go:60 @ 1244ae4`) throttled to once per 10 min
+  (mirror of `sweepInterval`, `serve.go:51`), and the pending-mail count
+  (`ListInboxMessagesWithSkipped` counts, the seam version of
+  `hasPendingInboxMail`, `serve.go:757 @ 1244ae4`). Error: `loop.ErrFenced` —
+  terminal for the session, and the **only** hard error a tick returns.
+  **`Warnings` carries the non-fatal step failures**, in production order, one
+  entry each: today's runner logs a failed non-fenced lease renew
+  (`serve.go:622`), a failed heartbeat (`serve.go:631`), and a failed sweep
+  (`serve.go:641`) and continues past all three — so on the wire they cannot
+  become errors without changing behavior. Each entry is the exact string
+  `r.logf` receives today minus its trailing newline (`agentchute serve: renew
+  serve lease: <err>` / `heartbeat registration: <err>` / `sweep stale
+  registrations: <err>`), and the client re-logs it verbatim, so the runner log
+  stays byte-identical. The sweep throttle still advances on failure
+  (`serve.go:643`).
+- **ReleaseLease**: wraps `loop.ReleaseLease` (`lease.go:345`; `ErrFenced` is
+  a no-op there by design).
+
+(There is deliberately **no `poll` op** — an earlier draft had a count-only
+tick subset for the runner's pre-injection re-check; cut because the
+re-check can always use the last tick's counts, ≤5 s stale, §6.5.)
+
+### 3.5 `op.Register`
+
+- **Input** (C2/D1 — the wire contract must preserve `registerOpts`'s full
+  semantics, `internal/cli/register.go:35-44 @ 1244ae4`):
+  `RegisterReq{Vendor *string, Host string, Bio *string, WorkingRepos
+  []string, Announce bool, Sweep bool, ServeToken string}`. Three deliberate,
+  deliberately different field shapes:
+  - **`Host` is a plain string, CLIENT-resolved (D1a)** — not a presence
+    pointer, because the local semantics it must preserve are not
+    "preserve": with no `--host` flag, `performRegister` calls
+    `os.Hostname()` and overwrites (`register.go:80-87 @ 1244ae4`). A nil
+    pointer resolved hub-side would record the HUB's hostname for every
+    remote self-check — wrong machine. So the CLIENT resolves it before
+    framing: flag value when provided (explicit empty stays empty),
+    otherwise the remote machine's own `os.Hostname()`. The hub session maps
+    it to `HostProvided:true` unconditionally, so `performRegister`'s
+    hostname substitution simply never runs hub-side. Test: omitted host
+    after a machine move records the NEW remote hostname (§10.3).
+  - **`Vendor` is a presence pointer, HUB-resolved when nil (D1b)** — bare
+    hook invocations (`turn-end`/`self-check`, env-identity-only per C26)
+    carry no `--vendor`, and the client-side fallback `resolveAgentVendor`
+    reads the registration through cfg (`internal/cli/identity.go:72-82
+    @ 1244ae4`) — which on a remote lane is the mail-free SHADOW, so a
+    custom id's vendor (one the canonical-prefix table,
+    `identity.go:57-70`, can't name — the live roster's "sonnet" is the
+    recorded example) would never resolve and every step-0 repair would
+    fail. So: non-nil = explicit, wins; nil ⇒ the HUB resolves it from the
+    pinned actor's existing registration row in the hub pool, then the
+    canonical-id fallback, and only then fails with the existing
+    missing-vendor error. Test: omitted vendor against an existing
+    custom-id row succeeds (§10.3).
+    **Client call sites, normative (S2)** — "the client sends nil" is not
+    automatic: `resolveAgentVendor` is called unconditionally at four sites
+    today, each of which would resolve against the shadow and put a WRONG
+    non-nil value on the wire (or refuse outright) before the hub ever gets
+    a chance. When `cfg.Remote != nil`, all four **skip local resolution
+    entirely** and send `Vendor: nil` unless `--vendor` was given
+    explicitly: `cmdServe` (`internal/cli/serve.go:152 @ 1244ae4`),
+    `cmdRegister` (`internal/cli/register.go:259 @ 1244ae4`), `cmdBoot`
+    (`internal/cli/boot.go:86 @ 1244ae4`), and `selfRepairRegistration`
+    (`internal/cli/self_check.go:126 @ 1244ae4`, the step-0 repair
+    `turn-end` drives). `resolveAgentVendor` itself is unchanged — the
+    branch is at the call sites, because only they know whether this is a
+    local or a wire register. Consequently `cmdServe`'s hard
+    missing-vendor refusal (`serve.go:153-155 @ 1244ae4`, `missing --vendor
+    (recommended values: …)`) is **suppressed for remote lanes**: an empty
+    vendor there is now the legitimate "let the hub resolve it" case, and
+    keeping the refusal would make every bare `agentchute serve <wrapper>`
+    on a custom id fail before it dialed. The `ValidateAgentID(opts.Vendor)`
+    check (`serve.go:156-158`) likewise runs only on a non-empty explicit
+    value. A vendor the hub cannot resolve either still fails — with the
+    hub's own missing-vendor error, one layer later and with the roster it
+    needs (§10.3, register-field-semantics row).
+  - **`Bio` stays a presence pointer** — here "nil = keep, non-nil = set
+    (empty clears)" IS the local behavior (`BioProvided`,
+    `register.go:147-149,226-233 @ 1244ae4`); without it every remote
+    re-register would clobber a hand-set bio.
+  - **`ServeToken`**: `registrationLiveElsewhere` refuses a register when a
+    FRESH serve claim exists and the caller's token is empty or mismatched
+    (`register.go:126-128,189-195 @ 1244ae4`). A remote lane's own
+    `self-check`/`turn-end` one-shots run while that lane's channel holds a
+    fresh claim — with no token on the wire they would be refused as "live
+    elsewhere" by their own lease. So: the channel dispatch injects the
+    session's held token into its startup `register`; one-shot register-
+    bearing ops send the child's inherited `AGENTCHUTE_SERVE_TOKEN`. Tested
+    under a live lease (§10.3).
+  - **`Sweep` is a plain bool discriminator, set by `cmdBoot` alone** — the
+    sweep this op wraps is **boot's**, not every registrant's. In the shipped
+    code `loop.SweepStaleRegistrations` runs in exactly two places: `cmdBoot`,
+    right after its own registration (`internal/cli/boot.go:99-101
+    @ 1244ae4`, C11's "register-self-first, THEN sweep peers"), and the
+    runner's 10-minute-throttled tick (`serve.go:640 @ 1244ae4`), which is
+    `op.Tick`'s (§3.4) and not this op's. A `register` op that always swept
+    would add a pool-wide sweep to `register`, `self-check`, `turn-end`'s
+    step-0 repair and `serve`'s startup registration — four commands that do
+    not sweep today; one that never swept would strand remote `boot` with no
+    hub-side trigger at all, since a remote lane's own filesystem sweep would
+    walk the mail-free shadow (§6.8). So the request carries the fact: `true`
+    only from `cmdBoot`, and the hub runs the sweep after the registration
+    write, in boot's order. Every other caller sends `false`, including the
+    channel's mandatory startup `register` (§6.1) — that lane's sweeping is
+    the tick's, whose first pass is due immediately, so sweeping here too
+    would double it. A sweep failure is a warning, never an error (boot's own
+    rule): it appends `sweep stale registrations: <err>` to `Warnings` below,
+    which is the exact string `cmdBoot` formats today (`boot.go:100`).
+- **Wraps**: the registration write path `performRegister` (used by
+  `registerRunner`, `internal/cli/serve.go:532-545 @ 1244ae4`, and by
+  `cmdBoot`, `internal/cli/boot.go:25 @ 1244ae4`), — when `Sweep` —
+  `loop.SweepStaleRegistrations` (`internal/loop/sweep.go:60 @ 1244ae4`,
+  boot's post-register trigger), and — when `Announce` —
+  `loop.AnnounceEnrollment`
+  (`internal/loop/message.go:56 @ 1244ae4`). `Host` records the **remote
+  machine's** hostname (display truth: where the wrapper runs);
+  `serve.claim.Host` records the hub (lease truth: where the live process
+  is). Turn-start `self-check` is `RegisterReq{Announce:false}` with the
+  inherited token. On a channel, `register` is a mandatory startup step
+  between `lease-acquire` and child start (§6.1): besides registering, it
+  hands the session its tick heartbeat template (§3.4).
+- **Output**: `RegisterResp{Announce *AnnounceView, Pending int, Reg
+  RegistrationView, InboxDir string, Refreshed, ExistingFound bool,
+  ResolvedHost string, Warnings []string}`. The first two are the op's own
+  facts (announce fan-out, post-register inbox depth); the
+  **last six are forced, not optional** — they are exactly what today's
+  `registerResult` hands its callers (`internal/cli/register.go:54-61
+  @ 1244ae4`), under the same names and semantics. An op returning less
+  cannot reproduce what the CLI already renders, and M1's "existing tests
+  pass unmodified" done-when would be unsatisfiable. `Announce` is forced by
+  the same rule one layer out — `cmdRegister` renders an announce *result*,
+  not a count:
+  - **`Announce`** — `nil` unless the request set `Announce`; otherwise
+    `AnnounceView{Sent, Total int, Warnings []string}`, a JSON-tagged mirror
+    of `loop.AnnounceResult` (`internal/loop/message.go:37-41 @ 1244ae4`)
+    under that struct's own field names and semantics ("how many peers were
+    candidates, how many got the message in their inbox, and any per-peer
+    delivery (inbox-write) warnings", `message.go:33-36`). A single `AnnouncedTo int`
+    carries one of the three facts the CLI already prints: each per-peer warning
+    (`register.go:285-287 @ 1244ae4`), then either `no peers to announce to`
+    when `Total == 0` or `sent to %d of %d peer(s)` from `Sent` AND `Total`
+    (`register.go:288-292 @ 1244ae4`). A mirror rather than
+    `loop.AnnounceResult` itself for the `RegistrationView` reason below: no
+    JSON tags, and `internal/loop` does not change in M1 (§3). In M1 the
+    `performRegister` adapter passes `Announce:false` and `cmdRegister` keeps
+    calling `loop.AnnounceEnrollment` itself (`register.go:280-294
+    @ 1244ae4`), so local rendering is unchanged by construction; a remote
+    lane cannot do that — its fan-out must reach the HUB's pool, not the
+    mail-free shadow — so it sets `Announce:true` and renders these three
+    fields alone. The announce's own hard failure (`AnnounceEnrollment`
+    returned an error, `register.go:282-284 @ 1244ae4`) is **not** a fourth
+    field: it leaves `Announce` nil and rides in `Warnings` as `announce
+    failed: <err>`, which the client prints through the same `warning: %s`
+    loop (`register.go:276-278 @ 1244ae4`) — the same bytes, and in the same
+    stderr position, because `performRegister` returns no warnings of its own
+    today (`register.go:180-186 @ 1244ae4`).
+  - **`Reg`** — `cmdBoot` reads `Reg.LastSeen` to detect inherited mail
+    (`internal/cli/boot.go:111 @ 1244ae4`), `cmdSelfCheck` renders it as
+    `last_seen` (`internal/cli/self_check.go:80 @ 1244ae4`), and
+    `register_test.go` asserts `Reg.{AgentID,LastSeen,Body}`
+    (`internal/cli/register_test.go:347,376,379 @ 1244ae4`). Its type is
+    `RegistrationView`: a JSON-tagged mirror of `loop.Registration`'s eight
+    fields (`internal/loop/registration.go:58-68 @ 1244ae4`) keyed by the
+    frontmatter's own names (`agent_id`, `v`, `vendor`, `control_repo`,
+    `working_repos`, `host`, `last_seen`, `body`). A mirror is required, not
+    preferred: `loop.Registration` carries no JSON tags and `internal/loop`
+    does not change in M1 (§3). `op.Status` does **not** reuse this view — its
+    rows carry a narrower, status-specific set (§3.6), because a `status` row
+    renders no body and no vendor and a pool-visible listing must carry only
+    what it prints. On the wire, `body` rides as the `register-ok` trailer
+    rather than inside the control line (§4.4.3).
+  - **`InboxDir`** — `cmdBoot` runs its side-effect-free inbox peek through it
+    (`boot.go:104 @ 1244ae4`), `cmdRegister` prints it (`register.go:274
+    @ 1244ae4`), and `register_test.go:144-145 @ 1244ae4` asserts it. Remote
+    lanes need the HUB's path here (that is where the mail is), which is
+    exactly what a hub-side op returns.
+  - **`Refreshed`** — the AGENTCHUTE.md §5 wire semantic: true on every
+    successful registration write, fresh or merge (`register.go:183
+    @ 1244ae4`); `cmdBoot` serializes it as `refreshed` (`boot.go:137
+    @ 1244ae4`).
+  - **`ExistingFound`** — the pre-write existence fact (`register.go:184
+    @ 1244ae4`), deliberately NOT a second spelling of `Refreshed` (which is
+    unconditionally true): it alone picks boot's "Refreshed" vs "Registered"
+    verb (`boot.go:137-138,199-201 @ 1244ae4`) and
+    `register_test.go:344,373 @ 1244ae4` asserts it directly. It is also the
+    **only** spelling of the fresh-enrollment fact: an earlier draft carried
+    a `Created bool` beside it, cut because `Created` is exactly
+    `!ExistingFound` in every returned response — `publishRegistrationOnce`
+    sets `existingFound` from the pre-write read (`register.go:112,120-125
+    @ 1244ae4`) and takes the exclusive-create arm on precisely
+    `!existingFound` (`:159-171`), the EEXIST re-read re-enters that same
+    read-then-write arm (`:90-97`), and any other read error returns no
+    response at all (`:123-124`). `emitBootText` already derives the
+    "Registered" verb that way (`boot.go:200 @ 1244ae4`), and today's
+    `registerResult` has no such field (`register.go:54-61`), so nothing
+    reads one.
+  - **`ResolvedHost`** — the post-merge host actually written, printed by
+    `cmdRegister` (`register.go:270 @ 1244ae4`), `cmdBoot` (`boot.go:142
+    @ 1244ae4`) and `cmdSelfCheck` (`self_check.go:79 @ 1244ae4`). It is the
+    only place the D1a client-resolved `Host` becomes observable, so it is
+    also what the §10.3 "machine move records the NEW remote hostname" row
+    asserts against.
+  - **`Warnings`** — printed by `cmdRegister` (`register.go:276-278
+    @ 1244ae4`) and appended to by `cmdBoot`, which adds its post-register
+    sweep failure before rendering (`boot.go:99-101,143 @ 1244ae4`). Empty
+    from today's `performRegister`, and it stays a response field precisely
+    because the `Sweep` arm runs hub-side: a sweep failure on a remote lane
+    has no other way home — and neither does the announce failure the bullet
+    above routes here. In local mode `cmdBoot` keeps appending its own entry
+    exactly as today; in remote mode the hub appends the identical string and
+    `cmdBoot` renders it through the same `bootStatus.Warnings` field
+    (`boot.go:143`), so the two arms print the same bytes and neither sweeps
+    twice.
+
+### 3.6 `op.Status`, `op.Gate`, `op.Pending`, `op.CleanOwed`
+
+- **Status**: `StatusReq{}` → `StatusResp{Agents []StatusAgent, Truncated
+  bool, Now time.Time}`, plus a `NoteEvent` emitter (§3 conventions). Wraps
+  `loop.ReadRegistrationsLenient`
+  (`internal/loop/registration.go:522 @ 1244ae4`) + per-agent inbox depth +
+  `loop.ReadServeClaim`/`ClaimIsStale` (`lease.go:297,308`). Read-only.
+  - **The row is a status-specific view, not `RegistrationView`**:
+    `StatusAgent{AgentID string, LastSeen time.Time, Host string,
+    ProtocolVersion int, InboxDepth int, Status string}` — JSON `agent_id`,
+    `last_seen`, `host`, `v`, `inbox_depth`, `status`, the first four keyed
+    exactly as `RegistrationView` keys them. That is precisely what
+    `printStatus` renders — AGENT / STATUS / INBOX / LAST_SEEN / AGE / HOST /
+    PROTO plus the protocol-warning block
+    (`internal/cli/status.go:97-139,242-247 @ 1244ae4`) — and nothing else.
+    `Vendor`, `ControlRepo`, `WorkingRepos` and `Body` are excluded because no
+    column shows them (the header's `vendor:` line is `cfg.Vendor`,
+    `status.go:100`), and `Body` in particular is a bio bounded at 1 MiB
+    (`internal/loop/registration.go:18 @ 1244ae4`) that cannot ride a 64 KiB
+    control line (§4.4.3). The serve claim is excluded for the same reason
+    `ServeClaim.ServeToken` (`lease.go:59`) is: `status` is pool-visible to
+    every member, and the claim's only rendered consequence is the `Status`
+    label. `InboxDepth` and `Status` are HUB-derived — a remote client can
+    neither stat the hub's inbox dirs nor read its serve claims.
+  - **`Now`** is the hub's evaluation instant: the AGE column and the STATUS
+    label must come off one clock, and on a remote lane that clock is the
+    hub's (same reason `hello-ok` carries `hub_time`, §4.3).
+  - **The op never truncates.** `Agents` carries every row, sorted by
+    `loop.RegistrationsByAgentID` (`status.go:111`), and `Truncated` is
+    always `false` coming out of the op. Both framing limits — the 64 KiB
+    line budget and the 64-row cap — are applied by the WIRE producer when
+    it frames `status-ok`, which is also the only writer of `truncated:true`
+    (§4.4.3). Capping inside the op would silently drop rows in local mode,
+    where there is no line to overflow and no renderer that reports a
+    truncation. (The trailing notice the remote client prints when
+    `truncated` is true is pinned verbatim in §4.4.3.)
+  - **The header is local config, not row data — and on a remote lane it
+    prints the hub's pointer, not the shadow's.** `printStatus`'s three
+    header lines come from `cfg`, never from any row
+    (`internal/cli/status.go:98-100 @ 1244ae4`), so the row shape above
+    settles nothing about them. The rule, normative for the merge that
+    switches the renderer (§11 M4):
+    - `control_repo:` prints the canonical `ssh://` URL carried on
+      `cfg.Remote` — **not** `cfg.ControlRepo`, which on a remote lane is
+      merely the nearest local ancestor holding `AGENTCHUTE.md` and exists
+      for local concerns like hook refresh (§6.8 rule 2). The rows below it
+      are the hub's; a header naming a local directory that holds none of
+      them is the §6.8 rule 5 failure one command later. The existing
+      `(via <origin>)` suffix is kept and stays truthful — the URL is what
+      the flag/env/pointer arm actually resolved.
+    - `loop_dir:` keeps printing the **local shadow**, with one parenthetical
+      line under it marking it as the shadow. **Its exact text is pinned**
+      (PLAN WI-4.5 states the identical literal; a byte-exact assertion
+      cannot be written against a paraphrase) — printed immediately under the
+      `loop_dir:` line and ahead of `vendor:`, with **two leading spaces** and
+      no trailing space, only when `cfg.Remote != nil`:
+
+      `  (local shadow: this process's own loop dir, not the hub's)`
+
+      Modelled on the marker line already in this same header block,
+      `  (shadowed pointer: %s)` (`internal/cli/status.go:101-103 @
+      1244ae4`), for its two-space indent and parenthesised `label: value`
+      form, and on `  (pull-only: senders deliver to your inbox; you poll it
+      yourself)` (`internal/cli/boot.go:204 @ 1244ae4`) for a label followed
+      by prose rather than by a path. It genuinely is this process's
+      loop dir — guard latch, `runner.json`, the send spool (§4.5.3, §6.8
+      rule 3) all live there — and the hub's loop dir is on another
+      filesystem and rides on no frame (`hello-ok` carries `pool`, the pool
+      path, not a loop dir). Printing the shadow unmarked is what misleads;
+      inventing a wire field to print a remote path the operator cannot open
+      is not the fix.
+    - `vendor:` is unchanged and needs no rule: `cfg.Vendor` is the loop
+      dotdir namespace, and vendor namespacing is gone — auto-discovery
+      resolves `<controlRepo>/.agentchute/loop`
+      (`fixedNamespace`, `internal/loop/config.go:19-25,348-357 @ 1244ae4`)
+      and §6.8 rule 3 deliberately gives the shadow the same
+      `.agentchute/loop` shape, so both modes print the same string.
+    - `ShadowedPointers` is unchanged: it is a diagnostic about *local*
+      pointer files that lost discovery, which is a local fact in both modes.
+  - **The lenient-read warnings stream as `note` frames**, `level:"warn"`,
+    one per malformed row, in `ReadRegistrationsLenient`'s own order and
+    before the response — never as a response array. They are genuinely
+    unbounded (one per malformed `*.md` under the agents dir,
+    `registration.go:522-549 @ 1244ae4`; malformed files are not
+    registrations, so the pool-scale assumption does not bound them), which
+    is §4.4.3's rule exactly. The `warn`→stderr routing (§4.3) reproduces
+    today's `warning: %s` lines in today's position, ahead of the table
+    (`status.go:67-70 @ 1244ae4`).
+- **Gate**: `GateReq{Phase string, RequireConfirm, AckStaleReg bool}` →
+  wraps `evaluateGate` (`internal/cli/gate.go:129 @ 1244ae4`); response
+  carries the same fields `gateStatus` renders. The request is exactly
+  `evaluateGate`'s parameters minus `cfg`/`agentID`/`now` (`cfg` is the op's
+  first argument, `agentID` is `Context.ActorID`, `now` is hub-minted, §2).
+  The two booleans are real shipped flags — `gate --require-confirm` and
+  `gate --ack-stale-reg` (`internal/cli/gate.go:55-56,97 @ 1244ae4`) — and
+  they change the verdict, so a `{Phase}`-only request would silently drop
+  them on every remote gate: `--require-confirm` would stop refusing on
+  warn-level conditions, and `--ack-stale-reg` would stop acknowledging a
+  stale registration. They are request fields.
+- **Pending**: typed event stream (§3 conventions, C4/D2) over the read
+  half of `cmdPending` (`internal/cli/pending.go:23 @ 1244ae4`):
+  `MessageEvent`s for unread mail (metadata always; `Body` populated only
+  when the request sets `ShowBody` — today's `--show-body` reads full
+  bodies, `pending.go:136-144 @ 1244ae4`, so the wire must carry them as
+  §4.4.1 body trailers under the same 4 MiB cap, never inside control
+  JSON), `OwedEvent`s for every outstanding obligation (today's output
+  emits each one in full-entry form, `pending.go:269-287 @ 1244ae4` — a
+  control-JSON array would re-create the 64 KiB failure for a large
+  ledger), then `PendingSummary{Unread, Owed, Malformed int, NeedsBoot
+  bool}`. `NeedsBoot` is HUB-derived (E4): it comes from the actor's
+  registration-row stat and `ErrInboxMissing` on the hub pool
+  (`pending.go:77-97 @ 1244ae4`) — facts the remote shadow cannot supply —
+  and the CLIENT keeps today's rendering semantics on top of it: the boot
+  hint (`needsBootMessage`, `pending.go:182`) and the `--fail-if-any`
+  exit-2 rule "unread mail OR needs boot" (`pending.go:167-169`).
+  Read-only.
+- **CleanOwed**: wraps the `clean --owed` prune so the hint `check` prints
+  (`internal/cli/check.go:279-281 @ 1244ae4`) works verbatim from a remote
+  lane.
+
+(There is deliberately **no `ping` op** — cut; its payload folded into
+`hello-ok` (`pool`, `writable`, `hub_bin`, `hub_time`, §4.3), which every
+session already performs. `doctor` and `hub join` probe by opening a
+one-shot session, reading `hello-ok`, and closing. The `writable` field is a
+create/remove of one temp file under the pool's `state/`, computed per
+session.)
+
+Local mode calls these functions in-process (zero behavior change — M1 is a
+pure refactor gated on the existing CLI test suite). Remote mode marshals the
+same request/response structs as wire frames (§4.4): the seam **is** the wire
+schema.
+
+---
+
+## 4. Wire protocol
+
+### 4.1 Name and carriage
+
+- Protocol name: **`agentchute-hub`**, version **1** (integer). The name
+  appears in the client's SSH exec request, the `hello` frame, and error
+  text.
+- Carriage: **forced-command pseudo-subsystem**, not an sshd `Subsystem`
+  directive. The client requests exec of the literal string `agentchute-hub`;
+  the hub's `authorized_keys` forced command ignores it and runs
+  `agentchute hub session …` (verified `sshd(8)`: *"command= … applies to
+  shell, command or subsystem execution"*, with the client's request preserved
+  in `SSH_ORIGINAL_COMMAND` — which is why the client sends a fixed marker
+  string: hub-side audit logs read cleanly). **Rejected alternative**: a real
+  `Subsystem agentchute-hub` directive in `sshd_config` — it requires root,
+  an sshd reload, and a second install step on the hub, and a forced command
+  overrides it anyway; it would add a whole "subsystem not found" error class
+  for zero benefit. One carriage path only.
+
+### 4.2 Client transport: exact `ssh` invocation
+
+The client execs the system `ssh` via `exec.Command` (argv array — no shell,
+no interpolation). Justification for shelling out (consensus item 6): zero Go
+dependencies; inherits the user's entire SSH ecosystem (`~/.ssh/config` Host
+aliases, ProxyJump, hardware keys, agents) for free; OpenSSH's keepalive and
+multiplexing are two decades more battle-tested than anything we would write.
+Argv-injection risk is closed structurally: URL components are validated
+against a strict grammar at join time (§7.4 — user/host must match
+`[A-Za-z0-9._-]+` and must not begin with `-`; port is numeric; path is
+absolute), and every variable value is a distinct argv element.
+
+**Channel** (long-lived; one per remote `serve`):
+
+```
+ssh -T \
+  -o BatchMode=yes \
+  -o ConnectTimeout=5 \
+  -o ServerAliveInterval=5 -o ServerAliveCountMax=2 \
+  -o StrictHostKeyChecking=accept-new \
+  -o UserKnownHostsFile=<hubdir>/known_hosts \
+  -o IdentitiesOnly=yes -i <hubdir>/keys/<agent-id>_ed25519 \
+  -o ClearAllForwardings=yes \
+  -o ControlMaster=no -o ControlPath=none \
+  -o LogLevel=ERROR \
+  [-p <port>] [<user>@]<host> agentchute-hub
+```
+
+**One-shot** (per CLI command): identical except
+`-o ServerAliveInterval=15 -o ServerAliveCountMax=2` and
+
+```
+  -o ControlMaster=auto -o ControlPath=<hubdir>/mux/%C -o ControlPersist=60s
+```
+
+Rationale for the split (each verified against `ssh_config(5)`):
+
+- `BatchMode=yes`: disables every interactive prompt — a hook- or runner-
+  invoked ssh must never hang on a passphrase (failure surfaces as
+  `E_UNAUTHORIZED`, §7.5).
+- `ConnectTimeout=5`: hub-down is detected in ≤5 s at every entry point.
+- `ServerAliveInterval=5 -o ServerAliveCountMax=2` on the channel: OpenSSH
+  itself terminates the session ~10–15 s after the peer goes silent
+  (verified: on reaching the threshold *"ssh will disconnect from the server,
+  terminating the session"*) — the transport-level dead-hub detector that
+  backs up the tick deadline (§4.6). One-shots use 15 s ×2: they are
+  short-lived and the mux master must not be churned by aggressive probing.
+- `ControlMaster=no` on the channel, **deliberately**: the channel *is* the
+  lane's liveness signal, so it must own a dedicated TCP connection — its
+  health must never be entangled with a shared mux socket that one-shot
+  traffic also uses. One-shots use `ControlMaster=auto` + `ControlPersist=60s`
+  so a turn's `check`/`send`/`ack` burst pays one authentication, then
+  ~tens-of-ms per op on a tailnet; `auto` degrades gracefully (falls back to a
+  fresh connection if the socket is stale/absent — verified semantics).
+- `StrictHostKeyChecking=accept-new` + a **per-hub** `known_hosts`: first
+  connect records the hub's key silently (no prompt — BatchMode-safe);
+  a *changed* key hard-fails (verified: accept-new *"will not permit
+  connections to hosts with changed host keys"*) → `E_HOSTKEY_CHANGED`
+  (§5.6, §7.5). The user's global known_hosts is never touched.
+- `IdentitiesOnly=yes -i <pinned key>`: exactly one key is offered — an agent
+  with five keys loaded must not accidentally authenticate as a different
+  pinned identity (key = identity in this design).
+- `ClearAllForwardings=yes`, `-T`: belt (client) and suspenders (server-side
+  `restrict`): no forwarding, no PTY.
+- `LogLevel=ERROR`: ssh's own stderr is passed through to the operator only
+  when the CLI reports a transport error; suppress routine banner noise.
+
+**`ControlPath` length rule (normative).** A ControlPath is a Unix domain
+socket, so its expanded path is capped by `sun_path` — ~104 bytes on macOS,
+108 on Linux — and `<hubdir>/mux/%C` under a deep `$HOME` can silently exceed
+it, breaking multiplexing with an opaque ssh error. The codebase already
+solves exactly this for the runner socket and this design reuses that shape
+rather than inventing a second one (`Config.RunnerSocketPath`,
+`internal/loop/config.go:168-193 @ 1244ae4`):
+
+- **Threshold, the shipped one.** The builder refuses the preferred path when
+  `len(muxDir) + 1 + 64 >= 100`, where `100` is the literal
+  `RunnerSocketPath` already uses (`config.go:170` — one number in the
+  codebase, not two) and `64` is a deliberately conservative upper bound for
+  `%C`'s expansion, which the client cannot compute itself. Over-triggering
+  costs one extra authentication; under-triggering costs a broken mux.
+- **Preferred**: `muxDir = <hubdir>/mux` (§7.4).
+- **Fallback when it does not fit**: a per-user temp dir
+  `<tempRoot>/agentchute-hub-<uid>/<hub-id>`, trying `os.TempDir()` then
+  `/tmp` and taking the first that passes the same budget (macOS's `$TMPDIR`
+  is itself a long `/var/folders/…` path, so `/tmp` is a real second
+  candidate). Created and checked through the shipped owned-0700 discipline —
+  `EnsureRunnerSocketDir` → `ensureOwnedRunnerSocketDir`
+  (`internal/loop/config.go:200-206`,
+  `internal/loop/runner_socketdir_unix.go:24-49 @ 1244ae4`: `MkdirAll` 0700,
+  symlink reject, uid-ownership reject, `Chmod` 0700), generalized to a
+  caller-supplied path rather than copied. The uid suffix plus the ownership
+  check is what keeps a shared `/tmp` from being squattable.
+- **If neither fits (or the temp root is unusable)**: **disable multiplexing
+  for this hub** — one-shots run `-o ControlMaster=no -o ControlPath=none`,
+  as the channel already does — and emit exactly one `warn` note naming both
+  attempted paths. Correctness is unaffected; only the per-op authentication
+  cost is. Never a hard refusal: an unusually deep `$HOME` must not make the
+  CLI unusable.
+- The **channel** is unaffected — it is `ControlMaster=no
+  -o ControlPath=none` by design (above).
+
+### 4.3 Framing and handshake
+
+**Framing: newline-delimited JSON control frames + raw body trailers.**
+
+- A frame is one UTF-8 JSON object on one line, LF-terminated. Max frame line:
+  **64 KiB** (`E_TOO_LARGE` past it).
+- A frame that carries a payload declares `"body_len": N` (bytes); exactly N
+  raw bytes follow the frame's LF, then the next frame begins. Max body:
+  **4 MiB** = `loop.MaxInboxMessageBytes`
+  (`internal/loop/registration.go:19 @ 1244ae4`). Bodies are byte-exact
+  message content — no base64, no re-encoding, no argv re-parsing anywhere.
+- Client requests carry a client-assigned monotonically increasing integer
+  `"id"`; responses echo it as `"re"`. **One request in flight per session,
+  strictly serial** — concurrency comes from opening more one-shot sessions
+  over the mux, never from interleaving frames. (Simplest correct thing; a
+  future v2 could relax it behind the version handshake.)
+- Unknown JSON fields are ignored (mirror of AGENTCHUTE.md §6.5). An unknown
+  `"t"` gets `{"t":"error","code":"E_UNSUPPORTED",…}` and the session stays
+  up. A *framing* violation (non-JSON line, body_len mismatch, oversize) gets
+  an error frame and the session closes — there is no resynchronization.
+  Violation-closes-session applies to **received** frames only: §4.4.3's
+  producer rules guarantee the hub never composes an oversized line, so a
+  session can never be killed by the size of its own response — in
+  particular never *after* a commit (an `ack` that archived 200 messages
+  must not die reporting them).
+- On the channel, all client frames are written by a single goroutine
+  (§6.5) — one-request-in-flight is structural, not just a rule.
+- Hub→client `note` frames (the wire form of §3's `NoteEvent`) may precede a
+  response. **`level` is one of exactly two values, and the level IS the
+  stream**: `warn` → the client's **stderr**, rendered `warning: <msg>`;
+  `info` → the client's **stdout**, rendered `<msg>` with no prefix. `msg`
+  never carries its own level prefix — the renderer adds it, so the local
+  path and the wire cannot drift. A third level is a spec change (M2), never
+  an implementer's choice.
+
+  ```
+  H: {"t":"note","re":3,"level":"warn","msg":"quarantined junk.txt (malformed §6.1 filename) -> …"}
+  H: {"t":"note","re":3,"level":"info","msg":"(reached limit of 5; 12 more pending)"}
+  ```
+
+  Both arms are load-bearing. `warn` carries today's stderr warnings (e.g.
+  quarantine, `internal/cli/check.go:144 @ 1244ae4`). `info` carries the
+  three **stdout** status lines `check` produces *inside* the stream rather
+  than at its end — the empty-inbox line, before the claim loop
+  (`check.go:201 @ 1244ae4`); the limit line, between two message renders
+  (`check.go:207`); and the CLAIMED-not-yet-archived line, after the claim
+  loop but before the owed/expired section (`check.go:262`,
+  whose text begins with its own `note: ` wording, which is emitted
+  byte-for-byte and is not a level prefix). Re-deriving those from the
+  terminal `check-ok` summary would print them after the `owed-item` events
+  the op emits before them — a silent reordering inside a merge whose whole
+  claim is zero behavior change. Only `info`'s stdout routing keeps them on
+  the one ordered stream (D2), in the position they occupy today.
+
+**Handshake** (mandatory first exchange on every session, both shapes):
+
+```
+C: {"t":"hello","id":1,"proto":"agentchute-hub","v":1,"min_v":1,"agent":"codex","bin":"1.7.0"}
+H: {"t":"hello-ok","re":1,"v":1,"agent":"codex","pool":"/home/alex/code/agentchute",
+    "pool12":"9c4e12ab77f0","writable":true,"hub_bin":"1.7.0",
+    "hub_time":"2026-08-14T21:05:03.123456Z"}
+```
+
+- Version selection: hub computes `use = min(hub_max, client v)`; if
+  `use < client min_v` or `use < hub_min` → `{"t":"error","code":"E_VERSION",
+  "msg":"hub speaks agentchute-hub v1; client requires ≥2"}` and close. v1 is
+  the only version at ship; the negotiation exists so v2 can ship without a
+  flag day. Fleet rule stated in the error text: **the hub upgrades first.**
+- Identity check: `hello.agent` is the client's resolved id
+  (`resolveAgentID`, `internal/cli/identity.go:13 @ 1244ae4`); the hub
+  compares it to the key's pinned `--agent`. Mismatch →
+  `{"t":"error","code":"E_IDENTITY","msg":"key is authorized as \"codex\"; you
+  are acting as \"grok\""}` and close. Past this point **no frame carries an
+  actor field** — every op executes as the pinned id (§5.3).
+- Pool check (D3): `hello-ok` reports the pool's hub-side identity —
+  `pool` (the normalized path, for display) and `pool12` (read from the
+  pool's own `state/pool.id` at session start, after the session validated
+  it against the forced command's `--pool-id` — §5.1, F1; never an argv
+  echo, so a key line whose `--pool` alone was edited dies hub-side at
+  startup). At join time the client records both in `config.json`; on
+  every later session it hard-fails unless `hello-ok.pool12` equals the
+  RECORDED value — the **client-emitted arm** of `E_POOL_MISMATCH`
+  (§4.4.2, §7.5); the hub emits the same code at session start for the
+  complementary case (§5.1). The raw URL path is authorize
+  input and display text only, never an identity: comparing against URL
+  text would false-alarm on any symlinked spelling of the same pool. The
+  chain is still closed end-to-end: join's URL path feeds `hub authorize`,
+  authorize canonicalizes and pins `--pool` into the forced command,
+  `hello-ok` echoes what the forced command actually serves, and the
+  recorded `pool12` detects a key line later edited toward a different
+  pool.
+- `hub_time`: the client computes `offset = hub_time − local_now` once per
+  session and applies it to *display-only* age math (the C18 stale banner,
+  `internal/cli/check.go:349 @ 1244ae4`), so a skewed laptop clock cannot
+  mislabel mail age. Protocol state never uses the client clock.
+
+### 4.4 Message types
+
+Complete v1 vocabulary. Client→hub requests: `hello`, `send`, `check`,
+`ack`, `register`, `status`, `gate`, `pending`, `clean-owed`,
+`lease-acquire`, `tick`, `lease-release`. Hub→client: `hello-ok`,
+`send-ok`, `msg`, `owed-item`, `check-ok`, `ack-item`, `ack-ok`,
+`register-ok`, `status-ok`, `gate-ok`, `pending-ok`, `clean-owed-ok`,
+`lease-ok`, `tick-ok`, `release-ok`, `note`, `error`. The event-stream
+frames map 1:1 onto §3's `op.Event` arms: `msg` = MessageEvent (used by
+`check` AND `pending` — a pending `msg` omits `body_len` unless the request
+set `show_body`, in which case the body follows as a normal ≤4 MiB
+trailer), `note` = NoteEvent, `owed-item` = OwedEvent, `ack-item` =
+AckItemEvent; all stream interleaved in production order (D2). (`ping`/
+`poll`/`pending-item` from earlier drafts are cut: `ping`'s payload lives in
+`hello-ok`, §3.6; the pre-injection re-check uses last-tick counts, §6.5;
+pending reuses `msg`.)
+
+#### 4.4.1 Examples (normative shapes)
+
+`send` — body flows in as the trailer:
+
+```
+C: {"t":"send","id":2,"to":"claude-code","ask":true,"reply_by_s":3600,
+    "serve_token":"9f2c…32hex","body_len":184}
+   <184 raw bytes: the composed message, frontmatter + body>
+H: {"t":"send-ok","re":2,
+    "filename":"20260814T210503123456Z_from-codex_r4b1d….md",
+    "ref":"to-claude-code_from-codex_20260814T210503123456Z_r4b1d…",
+    "committed":true,"durability_note":""}
+```
+
+`committed` is **mandatory on every `send-ok`** and is the field the
+never-replay rule (§4.5.3) is written against: `committed:true` means the
+recipient-side `link()` succeeded, so the message IS delivered and must
+never be resent — including the `committed:true` + non-empty
+`durability_note` partial success (linked, dir-sync failed,
+`internal/loop/seq.go:179-181 @ 1244ae4`), which the CLI renders as
+"delivered … Do NOT resend" (`internal/cli/send.go:269 @ 1244ae4`). It
+mirrors `op.SendResp.Committed` (§3.1) 1:1; a `send-ok` without it is a
+malformed response, not a defaulted `false`.
+
+`serve_token` is present only when the sender runs under a serve lease (the
+child got it via `AGENTCHUTE_SERVE_TOKEN`, `internal/cli/serve.go:520
+@ 1244ae4`); the hub passes it into `MintSendStamp`/`DeliverUnderRecipientLock`
+for the in-lock fence checks (`internal/loop/floor.go:127-131`,
+`internal/loop/seq.go:328-332 @ 1244ae4`). Empty/absent = intentionally
+unfenced (a human's ad-hoc send), same as today.
+
+`check` — claimed bytes flow back as one `msg` frame + trailer per item,
+terminated by `check-ok`:
+
+```
+C: {"t":"check","id":3,"limit":0,"no_archive":false}
+H: {"t":"msg","re":3,"filename":"20260814T…_from-claude-code_r….md",
+    "sender":"claude-code","stamp":"20260814T205900000000Z",
+    "redelivered":true,"reply_required":false,"reply_ref":"","body_len":812}
+   <812 raw bytes>
+H: {"t":"note","re":3,"level":"warn","msg":"quarantined junk.txt (malformed §6.1 filename) -> …"}
+H: {"t":"note","re":3,"level":"info","msg":"note: messages CLAIMED (at-least-once), not yet archived. …"}
+H: {"t":"owed-item","re":3,"to":"grok","from":"codex",
+    "stamp":"20260814T190211000042Z","suffix":"4b1d…32hex",
+    "by":"2026-08-14T19:32:11Z","recorded_at":"2026-08-14T19:02:11Z",
+    "ref":"to-grok_from-codex_20260814T190211000042Z_r4b1d…"}
+H: {"t":"check-ok","re":3,"claimed":1,"redelivered":1,"quarantined":1,"owed_expired":1}
+```
+
+(`quarantined` is a **count**; the per-file details travel in the preceding
+`note` frames — §4.4.3. The two `note` frames show both levels and why order
+matters: the `warn` one goes to stderr, the `info` one to stdout, and the
+`info` line must land *before* the `owed-item` events, which is exactly the
+position a summary-derived renderer would lose — §4.3.)
+
+`ack` — results stream one frame per archived message, then the terminal
+frame carries counts:
+
+```
+C: {"t":"ack","id":4}
+H: {"t":"ack-item","re":4,"filename":"20260814T…_from-claude-code_r….md",
+    "archive_path":"…/archive/2026-08-14T21-06-11Z_to-codex_…"}
+H: {"t":"ack-ok","re":4,"acked":1,"gate_clear":false,
+    "block_reasons":["unread inbox mail: 1"]}
+```
+
+`register` — the §3.5 structs verbatim, with `reg.body` as the trailer (its
+own one-shot session, so the ids restart after its `hello`):
+
+```
+C: {"t":"register","id":2,"host":"tiny","working_repos":["/home/alex/code/dash"],
+    "announce":true,"serve_token":"9f2c…32hex"}
+H: {"t":"register-ok","re":2,
+    "announce":{"sent":2,"total":3,"warnings":["send to grok: …"]},
+    "pending":0,
+    "reg":{"agent_id":"codex-tiny","v":3,"vendor":"openai",
+           "control_repo":"/home/alex/code/agentchute",
+           "working_repos":["/home/alex/code/dash"],"host":"tiny",
+           "last_seen":"2026-08-14T21:05:03.123456Z"},
+    "inbox_dir":"/home/alex/code/agentchute/.agentchute/loop/inbox/codex-tiny",
+    "refreshed":true,"existing_found":true,"resolved_host":"tiny",
+    "warnings":[],"body_len":142}
+   <142 raw bytes: reg.body>
+```
+
+`announce` is the §3.5 `AnnounceView` verbatim — `sent`, `total`, `warnings`,
+all three, because the client renders all three — and is present only when the
+request set `announce`; `null` otherwise, including when the hub-side announce
+failed outright (that text rides in the top-level `warnings` as `announce
+failed: …`, §3.5). `vendor` is absent from the request here (`Vendor:nil` ⇒
+hub-resolved, §3.5/D1b), as is `bio` (`Bio:nil` ⇒ keep). Both `warnings` lists
+are always present — `[]` when clean, never omitted — the same rule
+`send-ok.durability_note` and `tick-ok.warnings` follow.
+
+Lease lifecycle (channel only):
+
+```
+C: {"t":"lease-acquire","id":5}
+H: {"t":"lease-ok","re":5,"token":"9f2c…32hex"}
+     — or —
+H: {"t":"error","re":5,"code":"E_LEASE_HELD",
+    "msg":"serve lease for codex is held (host=hub pid=48122, fresh 2s ago)"}
+
+C: {"t":"tick","id":6}
+H: {"t":"tick-ok","re":6,"pending":3,"skipped":0,"swept":[],"warnings":[]}
+     — with a non-fatal step failure —
+H: {"t":"tick-ok","re":6,"pending":3,"skipped":0,"swept":[],
+    "warnings":["agentchute serve: heartbeat registration: no space left on device"]}
+     — after a reclaim/fence —
+H: {"t":"error","re":6,"code":"E_FENCED","msg":"serve lease was reclaimed; stop"}   (hub closes)
+
+C: {"t":"lease-release","id":7}
+H: {"t":"release-ok","re":7}
+```
+
+`warnings` is `[]string` and, like `durability_note` on `send-ok`, is
+**always present** — `[]` when the tick was clean, never omitted — so a
+missing field is a malformed response rather than a defaulted empty. It
+mirrors `op.TickResp.Warnings` (§3.4) 1:1: the fenced case is the tick's only
+hard error, and every other step failure (non-fenced lease renew, heartbeat,
+sweep) rides back here in production order with the exact text today's runner
+logs, which the client re-logs verbatim. It is a **fixed-small** list — at
+most one entry per tick step — so it rides inline like `block_reasons`
+(§4.4.3), never as `note` frames.
+
+`register`, `status`, `gate`, `pending`, `clean-owed` carry/return the §3
+request/response structs as their JSON fields verbatim (the seam structs are
+the schema; one source of truth), with two exceptions, both of them framing
+concessions to the 64 KiB line cap (§4.4.3):
+
+1. `register-ok` sends `reg.body` as the frame's trailer rather than inline,
+   because a bio is capped at 1 MiB and the control line at 64 KiB.
+2. `status-ok` may send FEWER rows than `op.Status` returned: the producer
+   appends rows only while the encoded control line stays within 64 KiB
+   **and** the count stays within 64, and sets `"truncated":true` when
+   either budget excluded a row (§4.4.3). The op itself never truncates and
+   always reports `truncated:false` (§3.6), so this flag is a property of
+   the framing, not of the read — which is also why the budgets are
+   invisible in local mode.
+
+Actor context never appears: it is the session's pinned identity
+(§3 conventions, §5.3).
+
+#### 4.4.2 Error frame and code registry
+
+`{"t":"error","re":N,"code":"E_…","msg":"<human text>","retriable":false}`
+
+| code | meaning | maps from |
+|---|---|---|
+| `E_VERSION` | protocol version mismatch | handshake |
+| `E_IDENTITY` | hello.agent ≠ pinned key id | handshake |
+| `E_POOL_NOT_FOUND` | forced command's `--pool` invalid hub-side | session start |
+| `E_NOT_REGISTERED` | actor has no registration row — **two exact texts, selected client-side by call site** (§7.5) | `internal/cli/send.go:145`, `check.go:120`, `status.go:62 @ 1244ae4` |
+| `E_RECIPIENT_UNKNOWN` | no row for `to` | `loop.ErrRecipientUnknown`, `seq.go:191` |
+| `E_RECIPIENT_UNREADABLE` | row exists, unparseable | `loop.ErrRecipientUnreadable`, `seq.go:206` |
+| `E_RECIPIENT_STALE` | preflight stale (C29b) | `seq.go:240` |
+| `E_RECIPIENT_RACING` | fresh-then-stale under lock (C29c) | `*loop.ErrRecipientStale`, `seq.go:253` |
+| `E_FENCED` | serve token check failed | `loop.ErrFenced`, `lease.go:51` |
+| `E_LEASE_HELD` | fresh lease owns the id | `loop.ErrLeaseHeld`, `lease.go:46` |
+| `E_HUB_IO` | hub filesystem error (ENOSPC, EACCES…) | any loop I/O error |
+| `E_MALFORMED_FRAME` | framing violation (session closes) | codec |
+| `E_TOO_LARGE` | frame >64 KiB or body >4 MiB | codec |
+| `E_UNSUPPORTED` | unknown `t` (session survives) | codec |
+| `E_ORDER` | request out of order (e.g. `tick` before `register` on a channel; lease ops mid-one-shot); session survives | session dispatcher |
+| `E_POOL_ID_INVALID` | the pool's `state/pool.id` fails the J1 contract (not a regular 0600 non-symlink file, or content ≠ `[0-9a-f]{12}` + LF); session refuses at startup, before any op | session start (§5.1) |
+| `E_POOL_MISMATCH` (hub arm) | the pool's `state/pool.id` is **absent**, or present-and-valid but ≠ the forced command's `--pool-id`; session refuses at startup, before any op | session start (§5.1) |
+
+**`E_POOL_MISMATCH` is emitted by BOTH sides (F9/X1), deliberately one code
+with two emitters.** They are the two halves of one fact — "this key is not
+serving the pool it is supposed to serve" — and an operator who sees the
+code gets the same §7.5 remedy either way, so splitting it into two codes
+would buy a distinction without a difference:
+
+- **Hub-emitted, at session start** (registry row above, §5.1): `hub
+  session` re-reads `state/pool.id` from the ACTUAL `--pool` it was handed
+  and refuses when that value is absent or ≠ `--pool-id`. This catches a
+  key line whose `--pool` alone was edited — the case a verbatim argv echo
+  would make invisible. It travels as a normal `error` frame before any op,
+  and the session closes. (A `pool.id` that is *present but malformed* is
+  the distinct `E_POOL_ID_INVALID` above — malformed state, not a mismatch.)
+- **Client-emitted, after `hello-ok`** (§4.3, D3): the client compares
+  `hello-ok.pool12` against the value RECORDED in `config.json` at join and
+  fails closed on inequality. This catches a key line re-pointed
+  *consistently* (`--pool` and `--pool-id` moved together) at some other
+  validly-authorized pool — which the hub arm passes by construction.
+
+The two arms are ordered and non-overlapping: the hub arm runs before
+`hello-ok` exists, the client arm only on a `hello-ok` the hub arm already
+let through. §7.5 carries a distinct exact message for each.
+
+Client-side only (never on the wire): `E_CONNECT`, `E_UNAUTHORIZED`,
+`E_HOSTKEY_CHANGED`, `E_CHANNEL_LOST`, `E_SEND_UNKNOWN`, `E_HELLO_TIMEOUT`,
+`E_HUB_NO_BINARY` (ssh remote exit 127 mapped immediately — no 10 s wait),
+`E_NOT_JOINED`, `E_NO_SSH` — produced by the
+transport/discovery layer from ssh exit codes/stderr, deadline expiry, and
+the §7.4 join-state check; user-facing text in §7.5. (`E_POOL_MISMATCH` is
+NOT in this list — it is the both-sides code above.)
+
+#### 4.4.3 Producer rules (aggregate responses)
+
+Unbounded lists never ride inside one control frame — a 64 KiB line cap must
+never become a semantic failure, least of all after a commit:
+
+- `check` and `pending` message events stream as `msg` frames (pending
+  bodies only under `show_body`, as trailers); `ack` results stream as
+  `ack-item` frames; owed entries stream as `owed-item` frames; notes — at
+  BOTH levels, `warn` and `info` (§4.3) — as `note` frames; all interleaved
+  in production order (D2). The terminal
+  `*-ok` frame carries **counts** (plus truncation metadata) for those
+  streams, never arrays.
+- Streaming reaches all the way down (C4): the §3 seam's emitter APIs
+  produce items one at a time, and the dispatcher's emitter writes each
+  frame through the single codec writer before the next item is read — the
+  hub never materializes an unbounded `[]Item` (peak buffering is one ≤4 MiB
+  body). Tested with many max-size messages and with a connection failure
+  after the first emitted item (§10.2, §10.3).
+- Quarantine details travel as per-item `note` frames;
+  `check-ok.quarantined` is a count.
+- A pending `msg` frame carries `body_len` (and a trailer) only when the
+  request set `show_body`; bodies obey the same 4 MiB cap as every trailer
+  (§4.3) — pending bodies never ride inside control JSON (D2).
+- `register-ok` carries its `reg` (the `RegistrationView` of §3.5) in the
+  control line **except `body`**, which rides as that frame's trailer. A
+  registration body is a free-form bio bounded by `loop.MaxRegistrationBytes`
+  (1 MiB, `internal/loop/registration.go:18 @ 1244ae4`) — inside the 4 MiB
+  trailer cap but far outside the 64 KiB line cap, so inlining it would let a
+  long bio turn a response that *already wrote the registration* into a
+  framing violation. `status-ok`'s rows carry no body at all — its row view is
+  status-specific (§3.6), because `status` renders
+  AGENT/STATUS/INBOX/LAST_SEEN/AGE/HOST/PROTO and never the body
+  (`internal/cli/status.go:97-139 @ 1244ae4`). That drops the one 1 MiB
+  field; it does **not** make the row a bounded shape — see the next bullet.
+- **`status-ok`: TWO budgets, both enforced against the ENCODED response.**
+  A row count alone does not bound a line, because the row is not a bounded
+  shape. `Host` is free-form: `ReadRegistration` copies the frontmatter
+  `host` through verbatim under only the 1 MiB whole-file cap
+  (`internal/loop/registration.go:72,88 @ 1244ae4`), `Registration.Validate`
+  imposes no length bound on it (`registration.go:217-241 @ 1244ae4`), and
+  `register --host` is an unconstrained string flag
+  (`internal/cli/register.go:206 @ 1244ae4`) — so ONE otherwise-valid
+  registration with, say, a 70 KiB host blows the line cap before row count
+  matters. `AgentID` has no length bound either (`agentIDPattern =
+  [a-z0-9][a-z0-9-]*`, `internal/loop/inbox.go:40 @ 1244ae4`); only the
+  filesystem's `NAME_MAX` on `<id>.md` bounds it in practice. The producer is
+  therefore written to depend on **no** field being bounded. Normatively, when
+  it frames `status-ok` it appends rows from the op's sorted slice **in
+  order**, keeping a row only while BOTH hold:
+  1. **wire budget** — the complete control line, measured as encoded bytes
+     including every non-row field (`t`, `re`, `now`, `truncated`), the
+     `agents` array's own punctuation and the terminating LF, stays ≤ 64 KiB;
+  2. **row cap** — the kept-row count stays ≤ 64 (the pool-scale assumption,
+     AGENTCHUTE.md §2, 2–~10 agents: a several-hundred-row table is a bug
+     report, not a listing).
+
+  The first row that fails either check **ends the append** — every later row
+  is dropped too, so the emitted list is always a PREFIX of the op's sort
+  order. (Skip-and-continue is rejected: it would omit a middle row while
+  showing later ones, and `truncated` cannot say which.) `"truncated":true`
+  is written whenever ANY row was excluded, by **either** budget — it is not
+  a row-cap flag. Measure the budget with `"truncated":false` encoded: `true`
+  is one byte shorter, so a frame that fit while the flag was false still
+  fits once it flips, and the producer needs no second pass.
+
+  **The non-row fields count against the budget**, deliberately. The
+  normative rule below is that the hub must never emit a control line over
+  64 KiB; a rows-only budget would balance its own books and still emit an
+  over-cap line — the exact defect the budget exists to prevent. The
+  bookkeeping cost is one integer.
+
+  **If the FIRST row alone does not fit**, `agents` is `[]` and `truncated`
+  is `true`. That is a valid response, not an error: `status` is read-only
+  and pool-wide, and refusing the whole listing because one row is
+  pathological would lose every other agent's row. The client's truncation
+  notice (§11 M4) names the wire limit as well as the row cap, so the
+  operator is not told "64 rows" when the cause was one 70 KiB host.
+
+  **That notice's exact text is pinned** (PLAN WI-4.5 states the identical
+  literal; two compliant implementations must not print two different lines,
+  and the byte-exact test rows in §10.3 assert these bytes) — one
+  unindented line on **stdout**, emitted only when `truncated` is true, as
+  the LAST line of `status` output (after the table and after any
+  `PROTOCOL WARNINGS:` block), preceded by one blank line:
+
+  `note: listing truncated by the hub at the first row that would exceed 64 rows or a 64 KiB response; later agent ids are missing.`
+
+  Modelled on the shipped trailing notice at
+  `internal/cli/check.go:262 @ 1244ae4` — the lowercase `note: ` prefix, no
+  indent, one sentence, a semicolon before the consequence. It names both
+  budgets, states that rows were withheld, and states the PREFIX rule (the
+  missing rows are the TAIL of the agent-id sort, never an arbitrary
+  subset). It states no total: `status-ok` carries only the kept rows and
+  the flag, so "N of M" would have to be invented.
+
+  **Rejected alternative — streaming status rows as individual frames.** It
+  would keep an oversized row visible remotely, at the cost of a new frame
+  type, a second terminal-count contract, and a renderer that must buffer the
+  whole listing anyway to compute the tabwriter's column widths — so unlike
+  `msg`/`owed-item`, whose items are individually unbounded *and* individually
+  useful, streaming buys no memory bound here. It would also still not render
+  a 70 KiB host into a HOST column. The only row the wire budget drops that
+  the row cap would not is one that cannot be displayed as a table cell
+  anyway. The root fix for that row is a length bound on `host` at the
+  registration layer — shipped-code scope, deliberately outside this
+  proposal, and the hub must not depend on it landing.
+
+  Both budgets are applied when the response is FRAMED, never inside
+  `op.Status`, which returns every row with `truncated:false` (§3.6): a rule
+  that exists to keep one line under 64 KiB has no business dropping rows on a
+  path that has no line, and `printStatus` reports no truncation, so an in-op cap would
+  lose rows silently in local mode. (`expired_owed` no longer needs a cap —
+  owed entries stream as `owed-item` frames, D2. The `status` lenient-read
+  warnings are likewise NOT a `status-ok` field: they are unbounded — one per
+  malformed file, not per agent — and stream as `warn` `note` frames, §3.6.)
+  `block_reasons` (gate reason strings), `tick-ok.warnings` (at most one entry
+  per tick step, §3.4) and `register-ok.announce.warnings` (at most one entry
+  per peer, bounded by the same pool-scale assumption as the row cap above)
+  are fixed-small sets and ride inline.
+- Normative: the hub MUST NOT emit a control line over 64 KiB; a response
+  that would exceed the cap is a hub implementation bug, not a session-fatal
+  wire event (§4.3). Every aggregate response above satisfies this
+  **structurally**, not by assumption: the unbounded lists stream, the one
+  unbounded scalar (`reg.body`) rides as a trailer, and `status-ok` — the
+  only response that composes an inline list from unbounded strings —
+  measures the encoded line as it appends. No producer is permitted to reason
+  "this field is small in practice".
+
+### 4.5 Semantics of the three delicate flows
+
+#### 4.5.1 Send bodies in
+
+The client composes the full message locally (so `--body-file` reads, ASK
+heading, and `reply_required` splicing behave identically to
+`internal/cli/send.go:174-224 @ 1244ae4`), then transmits it once as the
+`send` trailer. The hub-side `op.Send` performs mint + deliver under hub
+locks. Honesty note on the local-mode guarantee "a piped body is untouched
+on every preflight failure" (`send.go:135-137 @ 1244ae4`): it survives only
+**partially** on the wire path. Stdin/`--body-file` are read after the hello
+succeeds, so connect/auth/version/identity/pool failures leave a piped body
+untouched — but the hub's own preflights (sender enrollment, recipient
+freshness) can only run after the body has necessarily been read and
+transmitted. The compensation is the spool: every hub-side preflight failure
+spools the body locally with the retry command (§4.5.3); nothing is lost,
+but "stdin untouched" is a local-mode property and this design says so.
+(For calibration: local mode itself already reads `--body-file` before its
+preflights, `send.go:114-125 @ 1244ae4` — the wire path's read-after-hello
+ordering is the stricter of the two.)
+
+#### 4.5.2 Check-claimed bytes back
+
+Claiming happens hub-side (rename into `.claimed/`,
+`internal/loop/inbox.go:328 @ 1244ae4`) **before** the bytes stream back. If
+the connection dies mid-stream, the mail is claimed-but-undisplayed — which is
+exactly the crash-window the two-phase design already covers: the next `check`
+lists `.claimed` residue and re-displays it with the REDELIVERED banner
+(`internal/cli/check.go:180-193 @ 1244ae4`). At-least-once for the work,
+unchanged.
+
+#### 4.5.3 Ambiguous `send` outcome — fail closed, never replay
+
+The **ambiguity window** opens when the first byte of the `send` frame is
+handed to the ssh child's stdin, and closes when `send-ok` or an `error` frame
+for that `id` is read. Failure semantics:
+
+- **Before the window** (connect, hello, preflight error frame): the send
+  provably did not happen. The CLI spools the body
+  (`writeSendSpool`, `internal/cli/send.go:427 @ 1244ae4`) and prints the
+  retry command. In remote mode the spool directory is
+  `~/.agentchute/hub/<hub-id>/spool/` (§7.4) — deliberately **outside** the
+  shadow loop tree, because the shipped `--body-file` guard refuses any path
+  that resolves inside `<LoopDir>/state/` (`rejectLoopStateBodyFile`,
+  `internal/cli/send.go:600-633 @ 1244ae4`): a spool under the shadow state
+  dir would make the printed retry command refuse its own file. The remote
+  retry command is `--body-file <spool>` (one inert command; works while
+  guard-latched), not local mode's `< <spool>` stdin redirection
+  (`sendRetryCommand`, `send.go:465-477 @ 1244ae4`). Exit 1. Retrying is
+  safe and the text says so.
+- **Inside the window** (channel drops, ssh exits, response deadline expires
+  with no frame): the outcome is **unknown** — the hub may or may not have
+  linked the message. The CLI spools the body, exits 1 with `E_SEND_UNKNOWN`
+  (§7.5 text), and **never retries automatically**. There is no
+  delivery-side dedup to hide behind (AGENTCHUTE.md §6.2: at-most-once, no
+  idempotency key); a blind replay would be a duplicate message. The text
+  tells the operator how to resolve the ambiguity (ask the recipient /
+  `agentchute status` shows their inbox depth) before deciding to resend.
+- A `send-ok` with non-empty `durability_note` is the existing
+  linked-but-dir-sync-failed partial success: report, do not resend
+  (`internal/cli/send.go:269 @ 1244ae4` text reused).
+
+### 4.6 Timeouts, deadlines, cadence (all values final)
+
+| timer | value | enforced where |
+|---|---|---|
+| TCP connect | 5 s | client, `-o ConnectTimeout=5` |
+| hello → hello-ok | 10 s | client (kills ssh child on expiry); hub kills session if no `hello` within 10 s of start |
+| one-shot response deadline | 30 s per request | client (covers a 4 MiB body on a slow link) |
+| channel tick interval | 5 s | client serve loop (parity with `defaultRunnerIntervalSeconds`, `internal/cli/serve.go:23 @ 1244ae4`) |
+| tick response deadline | 10 s | client; expiry ⇒ kill ssh child ⇒ fence path (§6.4) |
+| transport dead-peer kill | ~10–15 s | ssh itself, `ServerAliveInterval=5 ×2` (channel) |
+| hub session read deadline | 20 s (channel, = 3 missed ticks + margin); 30 s idle (one-shot) | hub, `os.Stdin.SetReadDeadline` |
+| hub session write deadline | 30 s per response | hub |
+| one-shot session max lifetime | 10 min | hub (safety net) |
+| mux master linger | 60 s | `-o ControlPersist=60s` |
+| serve lease timeout | **10 s — unchanged** | hub, `leaseTimeout`, `internal/loop/lease.go:34 @ 1244ae4` |
+| heartbeat / registration refresh | every tick (5 s) — unchanged cadence | hub session |
+| sweep throttle | 10 min — unchanged | hub session (mirror of `serve.go:51`) |
+| lease reclaim protection | stale ≥10 s **and** (hub-pid dead **or** the claim's recorded `boot_ref` differs from this host's current one, §6.9) | `lease.go:242-244` |
+
+Why the lease numbers don't change: the hub session's own pid sits in
+`serve.claim`, so a lane whose ticks are delayed but whose session process is
+alive is protected by the same-host pid-proof — network jitter alone can never
+lose a lease. Only a genuinely dead connection (session process gone) opens
+reclaim, and the session's exit path releases the lease immediately anyway
+(§6.4), making the 10 s window moot in the common case.
+
+---
+
+## 5. Identity & security
+
+### 5.1 authorized_keys template (exact line)
+
+One line per (key, agent id), written by `agentchute hub authorize` (§7.3):
+
+```
+restrict,command="/usr/local/bin/agentchute hub session --agent codex --pool /home/alex/code/agentchute --pool-id 9c4e12ab77f0" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI… agentchute:codex:9c4e12ab77f0
+```
+
+- `restrict` (verified `sshd(8)`): disables port/agent/X11 forwarding, PTY
+  allocation, and `~/.ssh/rc` execution. Future-proof default-deny.
+- `command="…"` (verified): runs for shell, exec, **and subsystem** requests —
+  the client's requested command (`agentchute-hub`) is ignored and preserved
+  in `SSH_ORIGINAL_COMMAND` for audit.
+- The binary path is absolute (resolved via `os.Executable()` at authorize
+  time) — forced commands run with a minimal env; PATH must not be trusted.
+- `--pool` is the hub pool's absolute control-repo path, baked in — no
+  discovery ambiguity, no client influence over which pool is touched.
+- **Shell-safety decision (one rule everywhere): reject, never encode.**
+  The forced command runs through the hub user's login shell AND through
+  authorized_keys' own quoted-string layer, and the auto-authorize path adds
+  a third interpreter (the interactive ssh's remote shell, §7.2). Writing a
+  correct encoder for that three-layer stack — spaces, `$()`, backticks,
+  `;`, `'`, `"`, `\` — is exactly the kind of quoting machinery this project
+  deletes. Instead every value is validated against a grammar that makes all
+  three layers inert, or refused with a remediation:
+  - pool path and binary path: absolute, matching `^[A-Za-z0-9._/+-]+$`
+    (no whitespace, no quotes, no shell metacharacters, no backslash) —
+    else the broadened `E_POOL_PATH_UNSAFE` refusal (§7.5);
+  - agent id: the existing slug (`ValidateAgentID`,
+    `internal/loop/inbox.go:494-504 @ 1244ae4`);
+  - the public key (the one value that inherently contains spaces): composed
+    of an exactly-validated key type (`^[a-z0-9-]+$`), base64 blob
+    (`^[A-Za-z0-9+/=]+$`), and the marker comment (grammar below) — and it
+    is the **only** value ever wrapped in single quotes on the interactive
+    auto-authorize command line, where its charset is inert by construction.
+  The rejected alternative — an opaque binding id in authorized_keys with an
+  agent/pool mapping in a separate 0600 file — was considered and declined:
+  it would reintroduce a second mapping store that can drift from the key
+  line (§5.2's whole point is that the line IS the mapping), for a benefit
+  (exotic paths with spaces) the refusal text already remediates ("move or
+  symlink the pool to a plain path"). The full metacharacter set is tested
+  as refusals (§10.3).
+- The trailing comment `agentchute:<id>:<pool12>` is the machine-readable
+  marker `hub authorize --list/--revoke/--replace-key` operates on.
+  Per-(id, pool), not per-id (G-M2): one hub account may serve several
+  control repos, and a per-id marker would make authorize/--list/--revoke
+  collide across them. **`<pool12>` is anchored by a durable identity file
+  INSIDE the pool** (F1 — one small file, superseding round-4's SameFile
+  scan with something simpler and edit-proof): `hub authorize` reads
+  `<pool>/.agentchute/loop/state/pool.id` — one line, the pool's `pool12` —
+  and reuses it as the marker when present; only a pool with no `pool.id`
+  yet mints a fresh `pool12 = hex(sha256(normalized))[:12]` (normalized =
+  `EvalSymlinks(Clean(abs(--pool)))`, killing trailing-slash/symlink
+  spellings) and writes the file — by **exclusive create** (`O_EXCL` /
+  link-no-clobber, the codebase's existing first-writer-wins idiom,
+  `loop.WriteRegistrationExclusive`, `internal/loop/registration.go:133-169
+  @ 1244ae4`), never a plain atomic replace: two concurrent first
+  authorizes reaching the pool through different spellings (case alias,
+  bind mount) could otherwise both see "no file", mint different hashes,
+  and each replace the other — one line instantly inconsistent (H2). The
+  loser of the exclusive create re-reads and adopts the winner's value.
+  **Validation contract (J1)** — pool.id is reused AND interpolated into
+  the forced-command line, so it is never trusted on read: it must be
+  exactly one regular, non-symlink, 0600 file whose entire content matches
+  `^[0-9a-f]{12}\n$`, read through the bounded no-follow reader
+  (`loop.ReadFileLimit` — `O_NOFOLLOW` + fstat-on-the-open-fd, the shipped
+  idiom, `internal/loop/registration.go:34-48 @ 1244ae4`) with a 64-byte
+  cap. Both consumers validate BEFORE any comparison or interpolation:
+  `hub authorize` (the fresh-read path AND the H2 loser-re-read path) and
+  `hub session` at startup. Anything else — oversized, symlinked, embedded
+  newline/quote/`$()`/whitespace, wrong length — is refused with the named
+  error `E_POOL_ID_INVALID` (§7.5): authorize writes NOTHING to
+  authorized_keys, the session refuses before any op. Only a value that
+  matched the 12-lowercase-hex grammar can ever reach the key line, which
+  is inert in the authorized_keys, shell, and JSON layers alike — the
+  reject-not-encode rule (above) applied to our own state file, not just
+  operator input.
+  `pool.id` is also **preserved non-runtime scaffold** against the shipped
+  wipe (H1): `setup --reset --wipe-state` currently deletes every `state/`
+  entry except `setup.json` and its post-wipe rescan flags any other
+  survivor (`wipeStateCategory`, `internal/cli/setup_wipe.go:295-316
+  @ 1244ae4`; `rescanWipeLeftovers`, `setup_wipe.go:519-536`) — M5 adds
+  `pool.id` to the preserved list in the wipe plan, the rescan, and the
+  dry-run/preserved output alike (spec'd in M2, §9.1), because wiping it
+  would remint a new identity on the next authorize and silently invalidate
+  every existing key binding for that pool. Because the file travels
+  WITH the pool directory, every spelling that reaches the pool — symlink,
+  macOS case alias, bind mount, even a wholesale pool move — reads the same
+  identity with no filesystem-identity comparison needed at all. Path text
+  is still never identity (the round-3/4 lesson stands; the file simply
+  anchors identity more durably than any stat comparison — cf. the
+  SameFile-over-path-strings precedent, `internal/cli/send.go:590-599
+  @ 1244ae4`). `hub authorize` writes the marker AND bakes the same value
+  into the forced command as `--pool-id` (template above). **The session
+  never echoes argv** (F1 — a verbatim `--pool-id` echo would make an edit
+  of `--pool` alone invisible): at startup `hub session` re-reads `pool.id`
+  from the ACTUAL `--pool` it was handed and refuses with an
+  `E_POOL_MISMATCH` error frame, before any op, when that value is absent
+  or ≠ `--pool-id` — this is the **hub-emitted arm** of that code, a wire
+  `error` frame registered in §4.4.2 alongside its client-emitted twin
+  (F9/X1: one code, two emitters, two exact texts in §7.5), not a
+  client-only condition; `hello-ok.pool12` always carries the value READ
+  FROM THE POOL. The CLIENT still records pool/pool12 at join and compares
+  thereafter (§4.3) — the second layer, catching a key line re-pointed
+  *consistently* (`--pool` and `--pool-id` together) at some other
+  validly-authorized pool. Duplicate-id detection (§7.5) stays keyed on
+  `(id, pool12)`; all spellings of one pool collapse to one marker (§10.3:
+  realpath / symlink / trailing-slash / macOS case-alias spellings, the
+  `--pool`-only edit, duplicate refusal, `--list`, `--revoke`).
+- `hub authorize` validates before writing: the `--pool` path must exist and
+  contain `AGENTCHUTE.md` + `.agentchute/loop/` (a typo'd join URL dies
+  loudly here, on the hub, before any key lands — §7.1), and the resolved
+  binary path must be executable.
+- `hub authorize` must run **as the SSH login user** — the account whose
+  `~/.ssh/authorized_keys` sshd consults for the join URL's `user@`. On a
+  macOS hub, Remote Login must be enabled for that user.
+- `hub session` builds its `loop.Config` **directly** from `--pool`
+  (`ControlRepo=<pool>`, `LoopDir=<pool>/.agentchute/loop`) and never calls
+  the discovery cascade: under Debian-family sshd the forced command runs
+  via the login shell with the hub user's rc files sourced, so a stray
+  `AGENTCHUTE_CONTROL_REPO`/`AGENTCHUTE_LOOP_DIR` in the hub user's
+  environment would otherwise outrank the pinned pool
+  (`internal/loop/config.go:218-225,299-329 @ 1244ae4`).
+- `hub session` logs `SSH_ORIGINAL_COMMAND` for audit only after stripping
+  C0/C1 control bytes (same treatment message bodies get,
+  `sanitizeControlBytes`, `internal/cli/check.go:374 @ 1244ae4`) — a hostile
+  client-supplied string must not repaint a hub operator's terminal.
+
+### 5.2 Key→id mapping storage
+
+**The authorized_keys line is the mapping** — single source of truth, no
+side database, nothing to drift (subtract-default; also why the
+opaque-binding-id alternative was declined, §5.1). `hub authorize` manages
+lines exclusively by the `agentchute:<id>:<pool12>` marker (§5.1 — scoped
+per (id, pool) so one hub account can serve several control repos, G-M2):
+`--list` prints and health-checks them, `--revoke <id>` (resolving pool12
+from the current pool) deletes them, and a second `authorize --agent <id>`
+for the **same pool** with a *different* key is **refused** (duplicate-id
+join protection, §8 row 12) unless `--replace-key` is given (the
+moved-laptop case; also what `hub join --rotate-key` drives, §7.2). The same
+id under a different pool is a different marker — no collision. The one
+adjacent file, `state/pool.id` (§5.1, F1), is not a mapping store — it is
+the pool's own name tag, living inside the pool the way `AGENTCHUTE.md`
+already marks a control repo; key↔id↔pool mapping still lives only in the
+authorized_keys lines.
+
+### 5.3 `--as`/`--from` enforcement point
+
+Two layers, then structural absence:
+
+1. **Handshake** (the enforcement point): hub compares `hello.agent` to the
+   forced command's `--agent`; mismatch → `E_IDENTITY`, close. Mismatches are
+   *rejected, never silently rewritten* — a mis-set `AGENTCHUTE_AGENT_ID`
+   must surface, not be masked.
+2. **Structure**: past hello, no frame carries an actor field. `send` has no
+   `from`; `check`/`ack`/`register`/`gate` have no `as`. The hub session
+   builds one `op.Context{ActorID: <pinned id>}` at startup and passes it to
+   every `internal/op` dispatch (§3 conventions — the actor is an explicit
+   seam argument, never config or global state). There is no request a
+   client can compose that acts as someone else — the B4 lesson applied to
+   the wire (`internal/loop/seq.go:283-291 @ 1244ae4`).
+3. Client-side, the CLI still resolves and validates identity exactly as
+   today (`resolveAgentID`, `internal/cli/identity.go:13 @ 1244ae4`) and
+   refuses locally before dialing when `--from`/`--as` disagrees with the
+   joined identity for that hub (cheap fast-fail; the handshake remains the
+   authority).
+
+### 5.4 What a compromised remote key can and cannot do
+
+**Can** (blast radius = exactly one lane):
+
+- Act fully *as that one agent id*: send as it (to any recipient), read/claim/
+  ack its inbox, hold its serve lease, refresh its registration, read the
+  pool roster (`status` is read-only and pool-visible by design — same as any
+  pool member today).
+- Poison peers with malicious message *content* — the §15 prompt-injection
+  posture (bodies are untrusted data) is unchanged and remains the control.
+
+**Cannot**:
+
+- Get a shell, run arbitrary commands, or allocate a PTY (forced command +
+  `restrict` — the client's exec request is discarded).
+- Forward ports / tunnel into the hub's network (`restrict` +
+  client-side `ClearAllForwardings`).
+- Act as any other agent id (§5.3), read another agent's `state/` or claim
+  another agent's mail (no wire op exposes them; ops are actor-scoped).
+- Tamper with pool state outside the protocol (no filesystem access is
+  exposed — the vetoed SFTP surface does not exist).
+
+**Honest boundary**: the session process runs as the hub's UNIX user, so this
+containment is enforced by sshd's forced command plus the `agentchute`
+binary's own dispatcher — a vulnerability in `hub session` parsing would be a
+real escape. That is why the codec is deliberately dumb (NDJSON + fixed-length
+trailers, no argv parsing, no shell anywhere hub-side). Compared to today's
+baseline — where any process on the shared host can impersonate anyone by
+writing files (AGENTCHUTE.md §15 cooperative trust) — per-key pinning is a
+strict *strengthening*: remote sender identity becomes unforgeable at the
+transport layer.
+
+### 5.5 Threat table
+
+| threat | control | residual |
+|---|---|---|
+| stolen laptop / leaked private key | one-lane blast radius (§5.4); `hub authorize --revoke <id>`; key files 0600 under `~/.agentchute/hub/…/keys/` | revoke applies at next auth (§8 row 10); operator kills a live session for immediate cut |
+| MITM on first connect | `accept-new` TOFU into a per-hub known_hosts; documented out-of-band fingerprint check for the paranoid (`ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub` on the hub) | first connect is TOFU by explicit choice — the seamlessness/security trade is documented, not hidden |
+| MITM after first connect / hub swapped | changed host key → hard refusal `E_HOSTKEY_CHANGED` | none |
+| malicious/compromised peer *content* | unchanged §15 posture: bodies are untrusted data; wrapper-enforced human confirmation for scope expansion | unchanged |
+| client impersonating another agent | forced-command pinning + handshake + actor-free wire (§5.3) | hub-binary parsing bugs (mitigated: dumb codec, fuzz tests §10.2) |
+| hub host compromise | out of scope — identical to today (the pool lives there) | full pool compromise, as today |
+| replay of captured traffic | SSH transport (fresh session keys); no app-layer replay surface (ids are per-session, ops are not signed requests) | none |
+| DoS: connection flooding by an authorized key | sshd's own `MaxStartups`/`MaxSessions`; one-shot session cap 10 min; per-request deadlines | an *authorized* key can busy the pool — same trust level as a pool member today |
+| unauthorized network peer | no key → sshd refuses at auth; recommend tailnet/firewall so port 22 isn't public (§7.7) | standard sshd exposure, standard mitigation |
+
+### 5.6 Host-key verification story (first-connect UX)
+
+- `hub join` performs the first connect; `accept-new` records the hub key
+  into `<hubdir>/known_hosts` and join prints the fingerprint it recorded:
+  `hub key recorded: ED25519 SHA256:xxxx… (verify out-of-band if this pool
+  crosses trust boundaries)`. No prompt, no hang — BatchMode-safe.
+- Any later change → every command fails with `E_HOSTKEY_CHANGED` (§7.5) and
+  the two-line remediation (confirm with the hub operator; then
+  `agentchute hub join --reset-hostkey`). No silent re-trust, ever.
+
+---
+
+## 6. Lease & liveness
+
+### 6.1 Acquisition over the channel
+
+Remote `serve` startup order (derived from local `runWrapper`, with the
+deliberate registration reordering noted at step 3 —
+`internal/cli/serve.go:363-475 @ 1244ae4`, with the lease moved to the far
+end of the channel):
+
+1. Spawn the channel ssh child (§4.2); `hello`/`hello-ok` within 10 s.
+2. `lease-acquire` → hub session calls `loop.AcquireServeLease`
+   (`lease.go:150`) — link-no-clobber under `withAgentLock(id)`, stale-reclaim
+   CAS, pid-proof — all on the hub, unchanged. `serve.claim` now records
+   `{host: <hub>, pid: <session pid>, serve_token, …}`.
+3. `register` (`RegisterReq{Vendor, Host: <remote hostname>, WorkingRepos,
+   Announce:false}`; the channel dispatch injects its held serve token,
+   §3.5) → the hub session executes `op.Register` **and caches the payload
+   as its tick heartbeat template** (§3.4). Ordering note (C10): the LOCAL
+   runner actually starts the child first and registers after
+   (`runWrapper`: lease `serve.go:374`, child start `serve.go:384`,
+   `registerRunner` `serve.go:393 @ 1244ae4`) — remote
+   register-**before**-child is a deliberate strengthening (a remote lane is
+   never a live child without a registration row), not parity; M1's
+   zero-behavior-change tests assert the local order **unchanged**. A
+   channel that skips this step gets `E_ORDER` on its first tick.
+4. `lease-ok{token}` (from step 2) → serve exports
+   `AGENTCHUTE_SERVE_TOKEN=<token>` into the child wrapper's env
+   (`runnerChildEnv`, `serve.go:502-530`) per the §6.8 env contract, and only
+   then starts the child. A fenced lane's own sends fail closed exactly as
+   today.
+5. On `E_LEASE_HELD`: refuse to start, naming the holder
+   (`runner for codex is already active (serve lease held by hub pid 48122,
+   fresh)`) — the same fail-closed refusal as `refuseLiveRunnerCollision`
+   (`serve.go:571-580`).
+
+### 6.2 Renewal — the tick
+
+Every 5 s the serve loop sends `tick`; the hub session runs `RenewLease` +
+`HeartbeatRegistration` + throttled sweep + inbox count (§3.4) and answers
+`tick-ok{pending,skipped,swept,warnings}`. The counts feed the existing
+wake-cue predicate unchanged (`pollOnce`'s re-cue logic,
+`internal/cli/serve.go:659-668 @ 1244ae4`); `warnings` is re-logged verbatim
+into the local runner log, so a hub-side heartbeat or sweep failure reads
+exactly as it does on a local lane (§3.4). `E_FENCED` on a tick = this lane was reclaimed → client runs the
+exact fence path that exists today (`serve.go:616-623`): buffer the fatal
+message, `requestShutdown(SIGTERM)` the child, exit.
+
+### 6.3 Fencing token flow
+
+```
+AcquireServeLease (hub)  ──lease-ok──▶  serve (remote)  ──env──▶  child wrapper
+        │                                                            │
+        │                                   one-shot send frame: serve_token
+        ▼                                                            │
+serve.claim on hub  ◀──VerifyFence (in-lock, floor.go:127 / seq.go:328)──┘
+```
+
+The token is minted hub-side, travels to the remote once, and returns inside
+every fenced op. All verification happens hub-side inside the same
+`withAgentLock` critical sections as today — the TOCTOU analysis in
+`MintSendStamp`'s doc comment (`internal/loop/floor.go:91-104 @ 1244ae4`)
+holds verbatim because none of that code moves.
+
+### 6.4 Channel drop — both sides
+
+**Client side** (any of: ssh child exits; tick response deadline (10 s)
+expires; ServerAlive kills the transport):
+
+1. Stop the poll/inject loops (`stopLoops`, `serve.go:955`).
+2. Fence the child: `requestShutdown(SIGTERM)` (`serve.go:937-953`) — the
+   wrapper gets SIGTERM, then SIGKILL after the existing 2.3 s escalation.
+3. Then, by mode (§6.7): by default (remote lanes relaunch unless
+   `--relaunch=false`), enter the supervised relaunch loop — fresh channel,
+   fresh lease/token, fresh child, never the old child (its env token is
+   dead, and env is immutable post-launch — fence-then-fresh-child is
+   structural, not policy). With `--relaunch=false`: exit with
+   `E_CHANNEL_LOST` (§7.5), whose text echoes the lane's own launch
+   invocation. Manual relaunch always works, and §6.4-hub makes it
+   immediate.
+
+**Hub side** (any of: stdin EOF because sshd tore down; read deadline (20 s)
+expires on a silent channel; SIGTERM/SIGHUP):
+
+1. `ReleaseLease` (`lease.go:345`) — token-checked, so if the lane was
+   *already* reclaimed this is a safe `ErrFenced` no-op that never deletes the
+   new owner's claim.
+2. Exit. Because release happens on **every** exit path, a relaunched serve
+   acquires instantly instead of waiting out the 10 s staleness + pid-proof —
+   and the early release is safe precisely because of the fence: a half-open
+   client that still believes it holds the lease can only reach the pool
+   through ops carrying the old token, which now fail `VerifyFence`
+   (absent claim ⇒ `ErrFenced`, `lease.go:279-281 @ 1244ae4`).
+
+Worst case (hub session wedged in read, connection half-open hub-side): the
+20 s read deadline bounds it; a relaunch during that window sees
+`E_LEASE_HELD` for ≤20 s (stale-but-pid-alive protection, `lease.go:242-244`),
+then succeeds. Documented in §7.5's `E_LEASE_HELD` text.
+
+### 6.5 Interaction with the runner, wake cues, and the injection re-check
+
+The runner's PTY supervision is untouched: cue text, submit sequences,
+idle/injection windows, recue interval (`serve.go:44,710-843 @ 1244ae4`) all
+operate on local observations. Two substitutions:
+
+- `hasPendingInboxMail` (`serve.go:757`) becomes "last tick's counts" —
+  at most 5 s stale, same cadence as the local poll.
+- `injectIfPending`'s immediately-before-injecting re-check (M4,
+  `serve.go:740-750`) reads the **last tick's counts** (≤5 s stale) — there
+  is no `poll` op (cut, §3.4): a dedicated wire round-trip bought at most
+  5 s of freshness at the cost of a second channel producer. The
+  consequence — a cue can fire into an inbox the agent drained within the
+  last 5 s — is the fail-open direction the local listing-error path already
+  chose (`serve.go:754-763 @ 1244ae4`): a spurious cue is acceptable, a
+  suppressed real one is not, and the next tick corrects the count.
+- **Single channel writer**: with `poll` gone, the tick loop is the ONLY
+  goroutine that ever writes to the channel — the §4.3 serial-frames rule
+  holds by construction (nothing else has a reference to the ssh child's
+  stdin). Two goroutines interleaving bytes on one pipe would corrupt
+  framing (`E_MALFORMED_FRAME`) and spuriously fence the child; the design
+  now makes that structurally impossible rather than merely forbidden.
+
+### 6.6 Guard latch stays local-cached (mandated; specified)
+
+The guard latch **never crosses the wire**. In remote mode, `loop.Discover`
+returns a Config whose `LoopDir` is the **local shadow loop dir**
+(`~/.agentchute/hub/<hub-id>/.agentchute/loop/`, §6.8/§7.4), so every
+existing latch accessor —
+`cfg.GuardLatchPath` (`internal/loop/config.go:158 @ 1244ae4`),
+`loop.SetGuardLatch`/`ReadGuardLatch`/`ClearGuardLatch`
+(`internal/loop/guard.go:41,72,118 @ 1244ae4`), the PreToolUse evaluation
+(`evaluateGuardDecision`, `internal/cli/guard.go:216 @ 1244ae4`), and the
+`check`/`ack` self-denials (`internal/cli/check.go:101-105`,
+`internal/cli/ack.go:105-109`) — reads and writes a local file with **zero
+network I/O**, unchanged code. The session key remains the serve token
+(`resolveGuardSession`, `internal/cli/guard.go:109 @ 1244ae4`), which the
+remote serve exports as the local one does. Arming point (E1): the remote
+CLI's event emitter sets the latch on the FIRST message event it receives —
+redelivered residue included — **before** rendering it, the same
+before-display discipline the local loop applies at all three of its arming
+sites (`setLatch()` at `internal/cli/check.go:185,243,256 @ 1244ae4`;
+redelivery, `--no-archive`, and claim respectively — §3.2) — never after the
+wire op
+returns, so a channel/one-shot disconnect mid-stream (mail already claimed
+hub-side, partially displayed) still leaves the latch armed over the
+residue. Same session key, same clear path.
+
+Ordering in remote `turn-end` (mirrors the local ordered handler,
+`turn_end.go:15-39 @ 1244ae4`): (0) **best-effort** wire `register` — the
+step-0 registration self-repair, carrying the inherited serve token (§3.5);
+a failure here (hub briefly unreachable, vendor unresolvable) is reported
+and **does not abort** steps 1–3, exactly matching the local best-effort
+contract (`turn_end.go:110-120 @ 1244ae4`: a repair failure must never
+prevent committing this session's own claimed mail); (1) wire `ack` op
+commits hub-side; (2) local `ClearGuardLatch`; (3) wire `gate` op for the
+finish verdict. The latch clears only after the commit is confirmed; if the
+hub is unreachable at step 1, `turn-end` fails, the latch stays armed, and
+the claimed mail stays in the hub's `.claimed/` — the existing
+wedge-then-redeliver semantics
+(AGENTCHUTE.md §15 mixed-hook-trust recovery) apply with "hub unreachable" as
+just another reason turn-end didn't complete. Note also: `ssh` is *not* on
+the guard's deny list (deliberately cut in the livelock fix,
+`internal/cli/guard.go:45-58 @ 1244ae4`), and the transport runs inside the
+`agentchute` binary anyway — the guard inspects tool command text, so remote
+transport adds no new guard interactions.
+
+### 6.7 Supervised lane relaunch (`serve --relaunch`)
+
+Laptops sleep and hubs reboot — both kill the channel in **daily normal
+use**, and "a human retypes `ac serve` per lane per event" is not seamless.
+The consensus veto targets resuming the SAME child across a drop (impossible
+anyway, §6.4); a supervised **full-lane relaunch** is compatible and is
+designed in, **default-on for remote lanes** (G-B3: lid-close is a daily
+event, and an opt-in flag would leave the written quickstart path producing
+dead lanes; a recovery default that only ever launches a *fresh* fenced-off
+lane is safe to default):
+
+- **Surface**: one boolean flag, `--relaunch` — **default true when
+  `Remote != nil`**, `--relaunch=false` to opt out; passing it to a local
+  serve is an error (local lanes have no channel). No `--relaunch-args` and
+  no interactive prompt (both cut — C9/G-m3: an opt-out default needs no
+  prompt, and a string flag reparsed into argv is exactly the shell-text
+  re-parsing this design bans elsewhere).
+- **Trigger set**: transport-loss only — ssh child exit, tick deadline,
+  `E_CONNECT` during a relaunch attempt. `E_FENCED` gets exactly **one**
+  relaunch attempt: that is the hub-update case (§8 row 24 — `update`
+  invalidates every lease, `internal/loop/lease.go:371-376 @ 1244ae4`, and a
+  fresh lane under the new binary is precisely what is wanted); if the
+  attempt sees `E_LEASE_HELD`, a live rival owns the id — stop for real.
+  Never relaunches on `E_IDENTITY` / `E_VERSION` / `E_POOL_MISMATCH` /
+  `E_HOSTKEY_CHANGED` (config/security errors need a human).
+- **Loop**: fence + stop the old child fully (§6.4 steps 1–2, unchanged),
+  then repeat the §6.1 startup sequence — fresh channel, `hello`,
+  `lease-acquire`, `register`, fresh token, fresh child process — with
+  backoff 1 s, 2 s, 4 s … capped at 60 s, ±20 % jitter, unbounded attempts
+  (the overnight-sleep case is the point), one status line per attempt to
+  the terminal and the runner log.
+- **Wrapper argv**: a relaunch starts the wrapper with its **original argv,
+  verbatim** (`opts.WrapperArgs` held as `[]string` from the first launch,
+  `internal/cli/serve.go:117 @ 1244ae4`) — argv-exact, no reparsing, no
+  per-vendor resume args in v1 (cut with `--relaunch-args`; a vendor
+  session-resume flag can arrive later as a repeatable `--relaunch-arg`
+  once verified against that vendor's docs, if ever wanted).
+- **Guard/lease interplay**: the fresh serve token is a new guard session
+  key, so a latch armed by the dead session reads as foreign/inert
+  (`internal/loop/guard.go:20-24 @ 1244ae4`) and claimed residue redelivers
+  on the first `check` — the existing crash-recovery semantics, reached the
+  existing way. Hub-side the dead session already released the lease (§6.4);
+  after a hub **reboot**, the surviving claim becomes reclaimable once it is
+  stale (≥10 s past its last renew — long past by the time sshd is back) via
+  the boot-ref pid-proof (§6.9); the freshness check still runs first
+  (C8), so "reclaimable" is never claimed for a fresh row.
+- **Hub reboot, N lanes**: every remote serve (relaunch is the default)
+  retries independently; when sshd returns, each lane relaunches within one
+  backoff interval (≤60 s worst case) with zero human action on any machine.
+  This is the designed recovery for §8 rows 22–24.
+
+### 6.8 Child environment & discovery contract (normative)
+
+The local runner exports `AGENTCHUTE_CONTROL_REPO=<cfg.ControlRepo>` and
+`AGENTCHUTE_LOOP_DIR=<cfg.LoopDir>` verbatim to the child
+(`internal/cli/serve.go:512-514 @ 1244ae4`), and env outranks the pointer
+file in discovery (`internal/loop/config.go:218-225 @ 1244ae4`). Exporting
+local paths from a REMOTE serve would therefore silently re-point every
+child CLI call at a dead local/shadow pool — and letting Discover hard-error
+instead would be worse: the PreToolUse guard fails **open** on any Discover
+error (`internal/cli/guard.go:191-204 @ 1244ae4`), which would leave the
+guard latch permanently inert on every remote lane. The contract:
+
+1. Remote serve exports `AGENTCHUTE_CONTROL_REPO=<canonical ssh:// URL>` and
+   exports **no** `AGENTCHUTE_LOOP_DIR` (stripping an inherited one — the
+   same hygiene `runnerChildEnv` already applies to `AGENTCHUTE_GUARD`,
+   `serve.go:502-511 @ 1244ae4`).
+2. Discover's control-repo arms (flag, env, pointer) all branch on the
+   `ssh://` prefix **before** `validateExplicitControlRepo`'s local-directory
+   checks (`config.go:264-273 @ 1244ae4`). The ssh arm is pure local
+   derivation — parse the URL, compute `<hub-id>`, return
+   `Config{Remote: …, LoopDir: <shadow>, ControlRepo: <nearest ancestor of
+   cwd containing AGENTCHUTE.md, else cwd — used only for local concerns
+   like hook refresh, serve.go:159>}` — no network, so `guard` and every
+   hook path resolve instantly and correctly even fully offline.
+3. The shadow loop dir is `~/.agentchute/hub/<hub-id>/.agentchute/loop/` —
+   note the literal `.agentchute` segment: the existing invariant that a
+   loop dir is named `loop` under a dotdir parent (`vendorFromLoopDir`,
+   `config.go:348-357 @ 1244ae4`) holds for the shadow too, so nothing that
+   validates loop-dir shape needs a special case.
+4. An explicit `AGENTCHUTE_LOOP_DIR`/`--loop-dir` combined with an `ssh://`
+   control repo is a hard error — one authority for where local state lives.
+5. **The launchers forward the URL, never the derived local paths (B4 —
+   BLOCKER).** Rules 1–4 govern the child *wrapper*'s environment; they do
+   NOT govern how `serve` itself is launched, and today both launcher paths
+   re-exec `agentchute serve` with the DERIVED config rather than the
+   locator that produced it: `buildDispatchRunArgs` emits
+   `--control-repo <cfg.ControlRepo> --loop-dir <cfg.LoopDir>`
+   (`internal/cli/dispatch.go:247-258 @ 1244ae4`, called at
+   `dispatch.go:241`) and the legacy shim path emits the same pair
+   (`cmdShimsExec`, `internal/cli/shims.go:300-310`, inside
+   `shims.go:259-312 @ 1244ae4`). Note what that second launcher is: the
+   single `ac` dispatcher is the only launcher installed today
+   (`installDispatcher`, `shims.go:208-231 @ 1244ae4`), and install/setup
+   **deletes** the generated per-wrapper `ac-*` shims that reach
+   `cmdShimsExec` (`removeLegacyWrapperShims`, `shims.go:233-257`) — so that
+   path is reachable only from a shim surviving an older install. It is live
+   code carrying the same defect, so it stays in scope, and the §10.3 row has
+   to CONSTRUCT such a shim to reach it. Under rule 2 a remote
+   `Config` has `ControlRepo` = the LOCAL repo root and `LoopDir` = the
+   shadow — both perfectly valid local paths. So the re-exec'd child hits
+   the **flag arm** of the discovery cascade, which outranks the pointer
+   (`internal/loop/config.go:209-216` precedes the pointer arm at
+   `config.go:228-246 @ 1244ae4`) and passes `validateExplicitControlRepo`
+   (`config.go:264-273`) because the local root really does contain
+   `AGENTCHUTE.md`. Result: `Remote` is nil, the lane runs **LOCAL against
+   the mail-free shadow** — no hub, no mail, no lease on the hub, and **no
+   error anywhere**. Every `ac serve <wrapper>` and every surviving legacy
+   `ac-*` shim in a joined checkout silently de-remotes itself. Normative fix, in both
+   launchers: when the discovered config is remote, forward
+   `--control-repo` with the canonical `ssh://` URL carried on
+   `cfg.Remote` — not `cfg.ControlRepo` — and
+   **omit `--loop-dir` entirely** — the child then re-derives the shadow
+   through the same ssh arm its parent used, one authority, no second
+   spelling. Forwarding the URL *and* the shadow would additionally trip
+   rule 4's hard error, which is the same rule saying the same thing. A
+   caller-supplied `--loop-dir` peeled off the dispatcher's global flags
+   (`extractGlobalFlag`, `dispatch.go:220-221`) against a remote config is
+   that same rule-4 refusal, raised in the dispatcher before the exec.
+   `internal/cli/dispatch.go` and `internal/cli/shims.go` are therefore
+   **in scope for M4** (§11), which is where the `ssh://` discovery arm
+   lands: the arm and its launchers must ship together, because either one
+   without the other produces a silently local lane.
+6. Integration tests pin the contract (§10.3): a hook-context `guard` call
+   in a joined checkout resolves the shadow latch with networking blocked; a
+   child `send` under remote serve lands in the hub pool; and `ac serve` /
+   a purpose-built legacy `ac-*` shim in a joined checkout produces a child
+   whose discovered config has `Remote != nil` (the B4 row).
+
+### 6.9 Lease pid-proof after a hub reboot (targeted `lease.go` change)
+
+`serve.claim` survives a hub reboot, and reclaim requires stale ≥10 s
+**and** a same-host pid-proof failure (`internal/loop/lease.go:236-244
+@ 1244ae4`). After a reboot, OS pid reuse can make the recorded pid read
+"alive" again — wedging the id behind `ErrLeaseHeld` until a human deletes
+the claim file, with no self-heal. `lease.go` already documents pid-only
+liveness as a known limitation ("vulnerable to OS PID REUSE",
+`lease.go:236-241`). The fix is scoped to that one decision point and
+flagged in the spec merge M2 (§9.1).
+
+**Recorded boot reference, compared for EQUALITY — never wall-clock
+ordering (B6).** An earlier draft of this section derived the host's boot
+*time* and treated a claim whose `StartedAt` predates it as provably dead.
+That rule is unsafe and is withdrawn: every portable boot-time source is
+computed as `wall_now − uptime`, so a wall-clock step moves the derived
+boot time by exactly the size of the step (`/proc/stat`'s `btime` is
+recomputed from the stepped calendar; Darwin's `kern.boottime` is
+re-anchored by the kernel on calendar adjustment for the same reason). A
+laptop or hub that boots with a wrong RTC and is then stepped FORWARD by
+NTP therefore lands in the worst case simultaneously: the live lane's
+`LastSeen` suddenly reads hours stale (so branch (c)'s freshness refusal no
+longer protects it), and its `StartedAt` suddenly reads pre-boot — so the
+ordering rule would declare a LIVE lane dead and steal its lease, when
+branch (d)'s `existing.Host == host && pidAlive(...)` (`lease.go:242-244
+@ 1244ae4`) was the only thing still protecting it. Stealing a live lane's
+lease is strictly worse than the wedge this section exists to fix.
+
+The replacement records the boot reference **in the claim, at acquire**,
+and compares refs for equality:
+
+- **New field**: `ServeClaim` gains a `BootRef` string, JSON-tagged
+  `boot_ref,omitempty` (the struct at `internal/loop/lease.go:55-62
+  @ 1244ae4`), populated by `AcquireServeLease` when it builds the claim
+  (`lease.go:159-167`).
+- **Sources** (both are per-boot identifiers with **no wall-clock
+  component**, so a clock step cannot move them):
+  - Linux: the contents of `/proc/sys/kernel/random/boot_id` — a UUID the
+    kernel mints at boot.
+  - Darwin: the `kern.bootsessionuuid` sysctl — likewise a per-boot UUID
+    (`golang.org/x/sys/unix.Sysctl`; `golang.org/x/sys` is already a
+    direct requirement, `go.mod`, so this adds no module — or an exec'd
+    `sysctl -n kern.bootsessionuuid`, same value). Deliberately **not**
+    `kern.boottime`: that is the wall-clock-derived value the paragraph
+    above rules out.
+  - Anything else (other OS, unreadable file/sysctl, permission denied):
+    the empty string.
+  - **Both sources are HOST-scoped, and the scope of this fix is exactly
+    that.** They change on a host **reboot** and on nothing else: a
+    container or VM guest restart, a service restart, or a pid-namespace
+    re-create on a host that did not reboot leaves the ref identical, so
+    such a claim takes the unchanged stale+pid-alive refusal and behaves
+    exactly as today — no better, no worse. This section fixes the
+    post-reboot wedge; it does not solve pid reuse in general, and the
+    §7.5 manual remediation remains the answer everywhere else. The M2
+    spec text must carry this clause (§9.1).
+- **Reclaim rule, branch (d) only**: the stale-claim pid-proof still
+  refuses (`ErrLeaseHeld`) when `existing.Host == host && pidAlive(pid)`,
+  EXCEPT when the claim carries a boot ref, this host reports one, and the
+  two **differ** — in which case the recorded process belongs to a previous
+  boot of this host, is provably dead whatever the recycled pid says, and
+  the claim falls through to branch (e)'s reclaim CAS. Equality/inequality
+  only; the refs are never ordered, compared for age, or parsed.
+- **Absent ref ⇒ exactly today's behavior**, which is also the upgrade
+  path: a claim written by a pre-upgrade binary has no `boot_ref`, so it
+  takes the unchanged stale+pid-alive refusal and the §7.5 manual
+  remediation. The same holds when the current host's ref is unreadable.
+  No migration step, no fixup pass: the first `AcquireServeLease` under the
+  new binary writes the field, and every claim is rewritten on every
+  acquire anyway.
+
+**Field preservation and mixed-version safety — verified, not assumed.**
+`RenewLease` round-trips the claim through the `ServeClaim` struct
+(`readClaim` → mutate `LastSeen` → `marshalClaim` → `atomicWriteFile`,
+`lease.go:317-340 @ 1244ae4`), so a field that is part of the struct
+survives every heartbeat, while a JSON key that is NOT part of the struct
+would be silently dropped on the first renew. `boot_ref` must therefore be a real
+struct field (it is, above) and must never be smuggled as an ad-hoc extra
+key. In the other direction, `readClaim` uses a plain `json.Unmarshal`
+with no `DisallowUnknownFields` (`lease.go:101-114 @ 1244ae4`), so an OLD
+binary reading a NEW claim ignores `boot_ref` and behaves exactly as today
+— an old and a new binary can share a pool through the upgrade window
+without either failing closed. Note precisely what that tolerance is and is
+not: an unknown key **parses**, it does not **persist** — an old binary that
+renews a new claim re-marshals its own struct and drops `boot_ref` entirely.
+That is safe by the absent-ref rule above (the claim simply reverts to
+today's stale+pid-alive behavior) and self-heals at the next
+`AcquireServeLease` under the new binary; it is also why the field must be
+part of the struct rather than an ad-hoc key, and why §10.3's mixed-version
+row asserts parse-tolerance and key-dropping separately, never "unknown keys
+survive".
+
+**Ordering (C8), unchanged and restated exactly**: `AcquireServeLease`
+refuses a claim that is not yet stale BEFORE any pid or boot reasoning
+(`lease.go:230-232` precedes the pid branch at `lease.go:242-244
+@ 1244ae4`). The boot-ref corroboration lives strictly inside the
+stale-claim pid-proof branch (d), under the same `withAgentLock(id)`. So a
+pre-boot claim whose `LastSeen` still reads fresh (a sub-10 s reboot
+window) is still refused until the 10 s staleness floor passes; nothing
+here is "immediately" reclaimable, and the §10.3 fixture makes its
+`LastSeen` explicitly STALE so the test exercises the branch that actually
+changed.
+
+Net effect on the clock-step case that killed the previous rule: the
+stepped clock still makes the live lane's `LastSeen` read stale, so the
+claim still reaches branch (d) — and there the pid is alive and the boot
+refs are EQUAL (no reboot happened; a clock step is not a boot), so the
+lease is refused to the would-be reclaimer and the live lane keeps it.
+Protection is strictly stronger than today's and never weaker: boot_ref can
+only ever turn a refusal into a reclaim when a *different boot* is proven,
+never the reverse. This also fixes the same (rarer) wedge for local pools
+after a host reboot; it is the only change this design makes inside
+`internal/loop`.
+
+---
+
+## 7. End-user experience
+
+### 7.1 Quickstart — hub operator
+
+The hub is your existing pool. **Setup: zero commands.** In the common case
+(§7.2) even authorization is driven from the joining machine and the hub
+operator runs nothing at all. When a joiner lacks SSH access and sends you
+the paste line instead, run it:
+
+```
+$ agentchute hub authorize --agent codex-tiny --pool /home/alex/code/agentchute \
+    --key "ssh-ed25519 AAAAC3Nz… agentchute:codex-tiny"
+authorized: codex-tiny -> pool /home/alex/code/agentchute (canonical; marker agentchute:codex-tiny:9c4e12ab77f0)
+key ed25519 SHA256:Yk3n… — 1 line appended to ~/.ssh/authorized_keys
+```
+
+`authorize` refuses to write a bad line: the pool path must resolve to a
+real pool (contains `AGENTCHUTE.md` + `.agentchute/loop/`) and the binary
+path must be executable (§5.1) — a typo'd join URL dies here, loudly, not as
+a remote's mystery failure later. It must be run as the SSH login user
+(the account whose `~/.ssh/authorized_keys` sshd reads); on a macOS hub,
+enable Remote Login for that user.
+
+First-time hub prerequisites (almost always already true — three lines,
+once per hub):
+
+```
+1. sshd is running and the joining user can SSH in  (macOS: enable Remote Login)
+2. agentchute is installed at a stable absolute path (e.g. /usr/local/bin/agentchute)
+3. that's it — the pool itself needs nothing
+```
+
+`hub authorize` also enforces the permissions sshd silently requires: it
+chmods `~/.ssh/authorized_keys` to 0600 and `~/.ssh` to 0700 on write
+(sshd's StrictModes *ignores* the file on group/world-writable paths with no
+error to the joiner — the failure would otherwise surface only as a remote's
+inexplicable `E_UNAUTHORIZED`), and `--list`/hub-side `doctor` FAIL on wrong
+permissions. `agentchute hub authorize --list` prints every
+`agentchute:`-marked line with a **PASS/FAIL health verdict** (binary exists
+and is executable; pool resolves; perms correct) so a broken line is visible
+on the hub, not just as a remote's `E_UNAUTHORIZED`. `--revoke <agent>`
+removes that pool's line and — when that agent's
+`serve.claim` in the pinned pool is fresh with a live pid — prints the
+`kill <pid>` command for an immediate cut (sshd re-checks keys only at the
+next authentication, §8 row 10).
+
+### 7.2 Quickstart — joining machine
+
+Prerequisites: `agentchute` installed (same installer as the hub) and a
+working checkout of the repo cloned. The join URL's path is the pool's
+**absolute path on the hub** — run `pwd` there if unsure.
+
+```
+$ cd ~/code/agentchute        # your working checkout of the same repo
+$ agentchute hub join ssh://alex@hub.tail1234.ts.net/home/alex/code/agentchute --name codex
+generated key: ~/.agentchute/hub/3fa8c21b90de/keys/codex-tiny_ed25519.v1
+hub key recorded: ED25519 SHA256:xxxx…
+authorizing via your own SSH access… ok
+joined: codex-tiny (local name: codex) @ ssh://alex@hub.tail1234.ts.net/home/alex/code/agentchute (agentchute-hub v1, rtt 18ms)
+wrote pointer: .agentchute-control-repo (ignored via .git/info/exclude)
+$ agentchute serve codex      # local name — resolves to codex-tiny; `ac serve codex` after a new shell
+```
+
+**Naming: local names for the operator, hostname-suffixed pool ids
+(Alex-directed, post-SHIP delta).** With `--as` omitted, join derives the
+pool-wide id as `<local-name>-<hostname>`:
+
+- `<local-name>` is `--name`'s value, canonicalized to the wrapper's agent
+  id (`claude` → `claude-code` — the same canonicalization `ac serve`
+  applies: `wrapperForToken`, `internal/cli/shims.go:51-64 @ 1244ae4`,
+  called from `internal/cli/dispatch.go:132-137`); `<hostname>` is the
+  first DNS label of the machine's `os.Hostname()`.
+- **`--name` MUST name a known wrapper token; a non-wrapper `--name` is
+  REFUSED at join, before keygen or authorize (S4).** The rule is forced by
+  both launch paths, neither of which can be taught a local alias for a
+  non-wrapper: `ac serve <token>` resolves the token through
+  `wrapperForToken` and hard-refuses an unknown one before any identity
+  work happens (`dispatch.go:132-137 @ 1244ae4`), and direct `agentchute
+  serve <token>` treats the positional as the **wrapper command to exec**,
+  not as a name (`opts.WrapperArgs = fs.Args()`, then
+  `wrapperSpecForName(filepath.Base(WrapperArgs[0]))`, `serve.go:117-129
+  @ 1244ae4`) — so `--name work` would mint `work-tiny`, record
+  `names["work"]`, authorize a key for it, and then have no launch form at
+  all: `ac serve work` says "unknown wrapper", and `agentchute serve work`
+  tries to exec a binary called `work`. Accepting it produces an
+  unlaunchable lane whose failure appears long after join reported success.
+  The rejected alternative — teaching the dispatcher the `names` map —
+  was declined: it would put a per-hub, per-machine map into the argv
+  parser that runs *before* discovery, make `ac` behave differently in
+  different directories, and still leave the direct-`serve` path broken,
+  since there the positional is genuinely a command. Refusal text in §7.5;
+  an arbitrary pool id remains available through `--as`, whose lanes launch
+  with an explicit wrapper (`ac --as work-tiny serve claude`).
+- Each component is sanitized to the id grammar `[a-z0-9][a-z0-9-]*`
+  (`agentIDPattern`, `internal/loop/inbox.go:40 @ 1244ae4`, enforced by
+  `ValidateAgentID`, `inbox.go:496-504`) — **exactly**: lowercase; every
+  character outside `[a-z0-9-]` replaced with `-`; runs of `-` collapsed to
+  one; leading and trailing `-` trimmed; an empty result is an error.
+  (`Alexs-MacBook.local` → label `Alexs-MacBook` → `alexs-macbook`;
+  `tiny` → `tiny` → id `codex-tiny`.)
+- At **join time**, `--as` remains the explicit override, minted **verbatim**
+  — never suffixed. (Runtime identity resolution is a separate rule, below:
+  there, a value that happens to be a recorded local name maps to its
+  joined id.)
+- The mapping is minted **once, at join**, and recorded in `config.json`'s
+  `names` map (`{"codex":"codex-tiny"}`, §7.4); a later hostname change
+  never re-derives it — the recorded id wins.
+- **Runtime resolution (the rule that actually has to survive the real
+  launch path).** The real path is NOT "no id set": enrollment exports
+  `AGENTCHUTE_AGENT_ID=codex` as standing practice, and the dispatcher
+  injects `--as <wrapper-canonical>` when nothing else is set
+  (`ensureDispatchIdentity`, `internal/cli/dispatch.go:269-278 @ 1244ae4`)
+  — so a naive "explicit values win verbatim" rule would hello as `codex`
+  against a key pinned to `codex-tiny` and hand every joined lane
+  `E_IDENTITY` on its first launch. The rule, applied at the single
+  identity choke point (`resolveAgentID`, `internal/cli/identity.go:13
+  @ 1244ae4`) whenever the discovered config is remote: take the candidate
+  id from `--as` / `AGENTCHUTE_AGENT_ID` / the wrapper default as today,
+  then **if the candidate is a LOCAL NAME present in the `names` map,
+  resolve it to the joined id; treat it as a pool id only when it is not
+  in the map or already equals the joined id.** The lookup lives **inside
+  `resolveAgentID` itself** (`identity.go:13-38`), which — verified — BOTH
+  launch paths reach: direct `agentchute serve` calls it after discovery
+  (`cmdServe`, `internal/cli/serve.go:135,145 @ 1244ae4` — a path that
+  never touches the dispatcher), and `ac serve` merely injects `--as
+  <canonical>` (`ensureDispatchIdentity`, `dispatch.go:269-278`) before
+  exec-ing that same serve, so the injected value is resolved identically.
+  The wrapper-default candidate needs one explicit wire-up on the DIRECT
+  path (round 10 blocker): today `cmdServe` computes the wrapper's
+  canonical id but keeps it only in `launchedWrapper`
+  (`serve.go:122-129 @ 1244ae4`), and `resolveAgentIDRaw` has exactly two
+  sources — flag, then env, then error (`identity.go:27-38`) — so a bare
+  `agentchute serve codex` in a fresh shell with env unset (precisely the
+  two-command quickstart above: `hub join` cannot export into its parent
+  shell) would have NO candidate at all. Fix: direct `cmdServe` supplies
+  `launchedWrapper` as the fallback candidate when both flag and env are
+  absent; that candidate then resolves through the `names` map like any
+  other.
+  Every other consumer — the one-shot ops, hook invocations, the spool
+  path — already resolves through the same function. One exception is
+  named rather than assumed: `guard`'s hook evaluation resolves its id
+  inline today (`evaluateGuardInvocation`, `internal/cli/guard.go:169-189
+  @ 1244ae4`, deliberately not via `resolveAgentID`); M4 routes that
+  lookup through the same map so the latch path can never disagree with
+  the lane's resolved id. `doctor` and `hub join` warn when `AGENTCHUTE_AGENT_ID`
+  is set and resolves to something other than what it names (the same
+  pattern as the existing `AGENTCHUTE_CONTROL_REPO`-vs-pointer mismatch
+  warning, §7.6). **No send-side peer aliasing, explicitly**: the map
+  resolves SELF-identity on this machine only — `--to` is never mapped,
+  and peers everywhere address the full `codex-tiny`.
+- **`agentchute identity`** in a joined checkout lists this machine's
+  local-name → joined-id map and what the current env/flags resolve to
+  (a `config.json` read; no network, no new command — `identity` is
+  already the id-resolution command).
+
+Rationale (recorded per Alex's direction): the operator thinks in LOCAL
+names — "codex on this laptop" — so the machine-qualified pool id should be
+automatic, never typed; the hostname suffix makes pool-wide uniqueness
+automatic as machines join; and it makes message traffic **human-legible**
+— every inbox filename, roster row, and archive entry then carries the
+origin machine in the sender slug
+(`20260815T101503123456Z_from-codex-tiny_r….md`), so an operator reading
+the pool sees who talks to whom, and from where, with no lookup.
+
+Edge cases: two machines sharing a hostname mint the same auto id — the
+duplicate-id refusal at authorize catches it, and its text now names the
+hostname-collision case with the `--as` remedy (§7.5). An explicit `--as`
+on one machine colliding with an auto-derived name elsewhere is the same
+normal refusal. A hostname change after join changes nothing (minted once,
+above).
+
+**Local-name/pool-id shadowing is REFUSED at join, before keygen or
+authorize (round 10).** The two namespaces share one spelling space on a
+machine, and the runtime resolver gives local names precedence — so a pool
+id that equals a recorded local name would be unselectable here (`--as
+codex` would remap to `codex-tiny` forever). Both join orders are refused
+with the existing mapping named and the way out:
+
+- `names["codex"]="codex-tiny"` exists, then `hub join <url> --as codex`:
+  `hub join: "codex" is already this machine's local name for
+  "codex-tiny" — a pool id "codex" would be unselectable here (runtime
+  --as codex resolves to codex-tiny). Pick a different --as, or use the
+  existing codex lane.`
+- joined as pool id `codex` (verbatim `--as`), then `hub join <url>
+  --name codex` on the same machine:
+  `hub join: this machine already joined as pool id "codex"; recording
+  "codex" as a local name for "codex-tiny" would shadow it (runtime --as
+  codex would stop selecting it). Pick a different --name, or --as an
+  explicit id.`
+
+**One command on the joining machine** in the common case: §7.1 already
+presupposes the joining human can SSH to the hub, so `hub join` performs the
+authorize step itself — an interactive
+`ssh alex@hub.tail1234.ts.net agentchute hub authorize --agent codex-tiny
+--pool /home/alex/code/agentchute --key '<pubkey>'` under the operator's
+normal credentials (agent or password prompt allowed — this is a human-run
+command, not BatchMode). Remote arguments are single-quoted per argument;
+every value is already validated by grammars that exclude `'` (§5.1, §7.4).
+When that ssh fails (no direct access; a different admin owns the hub), join
+falls back to printing the complete ready-to-paste authorize line and exits
+0; after the hub operator runs it, re-running `agentchute hub join`
+(idempotent) completes and verifies the join. So: one command and zero
+pastes normally; one paste when an admin sits in the middle.
+
+Key handling is **normatively idempotent** (G-B1 — §7.3 recommends bare
+re-runs, so a re-run must never invalidate the live key): if
+`keys/<id>_ed25519` already exists, join **reuses it** — never a second
+keygen, never a surprise `--replace-key`. Generation happens only when the
+file is absent, with this exact argv (G-B2 — the default interactive
+passphrase prompt would hang a scripted join, and a passphrase-protected key
+would fail every BatchMode operation as `E_UNAUTHORIZED`):
+
+```
+ssh-keygen -q -t ed25519 -N "" -C agentchute:<id> -f ~/.agentchute/hub/<hub-id>/keys/<id>_ed25519.v1
+```
+
+followed by creating the active-pointer symlink `keys/<id>_ed25519 -> <id>_ed25519.v1`
+(the stable path §4.2's `-i` uses; versioning + the symlink are the
+rotation substrate, D4b/F3). A crash in the gap between those two steps is
+covered by the version-state recovery's no-pointer branch (H3a, below):
+a rerun NEVER re-runs `ssh-keygen` onto an existing versioned path —
+`-q` still prompts "Overwrite?" on an existing file, which hangs a
+scripted join — it adopts or retires the orphan instead.
+
+(The key's own comment carries only the client-known `agentchute:<id>`; the
+authoritative `agentchute:<id>:<pool12>` marker is computed and written by
+`hub authorize` on the hub — the client never derives pool identity from
+URL text, D3.)
+
+Join additionally refuses a pre-existing passphrase-protected key (probe:
+`ssh-keygen -y -P "" -f <key>` must succeed) with the remediation "remove
+the passphrase or rotate". Tested: join-twice ⇒ same pubkey, exactly one
+authorized_keys line (§10.3).
+
+**Per-hub-dir mutual exclusion (G2).** `hub join`, `hub join --rotate-key`,
+and the migration below all read-modify-write the same
+`~/.agentchute/hub/<hub-id>/` tree (config, key versions, the active
+symlink, the whole directory in migration's case), and two of them
+interleaving would produce exactly the half-states the recovery narration
+is supposed to be the LAST line of defense against — two concurrent joins
+both minting `v<N+1>`, a rotate promoting a symlink a migration is copying,
+a migration deleting a dir a rotate is writing into. All three therefore
+run inside an exclusive advisory lock, taken before any probe and held to
+the end of the run:
+
+- **Lock path**: `~/.agentchute/hub/.locks/<hub-id>.lock` — a sibling
+  directory, deliberately NOT a file inside `<hub-id>/`, because migration
+  renames and deletes the very directory it is protecting; a lock file that
+  travels (or vanishes) with its subject stops excluding anyone the moment
+  it matters, while every waiter's `flock` on the unlinked inode keeps
+  succeeding. `.locks/` is created 0700 on demand.
+- **Idiom**: the shipped one, unchanged — `syscall.Flock(fd,
+  LOCK_EX|LOCK_NB)` in a deadline-bounded poll loop, i.e. `withAgentLock`'s
+  mechanism (`internal/loop/filelock_unix.go:46-67 @ 1244ae4`;
+  `agentLockTimeout` 5 s at `filelock_unix.go:20`,
+  `agentLockRetryInterval` 25 ms at `:23`), generalized to a
+  caller-supplied lock path rather than an agent state dir. Same
+  non-reentrancy discipline: one acquisition per run, never nested. The
+  wait stays SHORT and deliberately does not cover a slow run: an
+  interactive auto-authorize can sit on a password prompt for minutes, and
+  a second operator should be told to come back, not blocked silently.
+- **Timeout ⇒ a named refusal**, never a silent wait: `hub join: another
+  agentchute hub join/rotate is already running for this hub (lock
+  ~/.agentchute/hub/.locks/3fa8c21b90de.lock). Wait for it to finish and
+  re-run.`
+- **Migration holds TWO locks** (old hub-id and new hub-id). To make
+  deadlock structurally impossible they are acquired in ascending
+  lexicographic hub-id order, always — never "old then new".
+- The lock is machine-local and says nothing about lanes: a live lane is
+  still refused by the liveness check below, which is a separate, stronger
+  gate.
+
+**Same-hub URL migration (D4a).** A join whose URL hashes to a hub-id with
+no local dir is NOT automatically a new hub — the same hub reached through a
+different spelling (ssh-config alias, MagicDNS vs IP) must never mint a
+second key and then die on the duplicate-id refusal. Before any keygen,
+join: (1) connects and obtains the host-key fingerprint (available
+pre-auth); (2) scans `~/.agentchute/hub/` for dirs whose recorded
+fingerprint matches — considering **only** entries whose name is exactly 12
+lowercase hex characters, so scratch (`<id>.partial`) and infrastructure
+(`.locks/`) can never be mistaken for a joined hub (G1, G2); (3) for each
+match, attempts a hello using that dir's
+existing key for this `--as` id — if it succeeds and `hello-ok.pool12`
+equals that dir's recorded pool12, this IS the same hub: join **migrates**.
+**Migration REFUSES while any lane of the old hub dir is live (E2)** — a
+running remote serve's child carries `AGENTCHUTE_CONTROL_REPO=<old URL>` in
+its immutable environment (§6.8), so moving the state dir out from under it
+would send every child op to `E_NOT_JOINED` and strand its latch/spool in a
+dir nothing resolves anymore; no reconciliation can fix a live child whose
+env cannot change, so the lane must relaunch regardless — refusing first
+merely makes that explicit instead of letting it wedge. (The rejected
+alternative — a durable old-hub-id alias dir kept until reconciliation —
+would leave two names for one hub's latch/spool/cache/mux state, exactly
+the double-source drift this design deletes everywhere else.) Liveness
+check is local and uses the codebase's existing **runner attribution**
+discipline, not a bare pid probe (F2 — a live NUMBER from a stale
+`runner.json` can be an unrelated process after OS pid reuse): for each id
+in the old dir's `joined_as`, read its shadow `runner.json`
+(`loop.RunnerStatePath`, `internal/loop/config.go:149-151 @ 1244ae4`),
+require the recorded host to be this host and the pid alive, then read the
+process's command line and attribute it — the shape `stopSetupRunner` and
+`scanWipeLiveSignals` already use (`internal/cli/setup_reset.go:196-224`,
+`internal/cli/setup_wipe.go:553-570 @ 1244ae4`: state file binds pid→id,
+cmdline proves the pool, ambiguity fails closed).
+
+**The attribution predicate is REMOTE-SPECIFIC and must not reuse
+`setupCommandMatchesPool` unchanged (B5).** That function's pool proof is
+an EXACT filesystem-path match of argv's `--control-repo`/`--loop-dir`
+against `cfg.ControlRepo`/`cfg.LoopDir`, via `setupPathsEquivalent`
+(`internal/cli/setup_reset.go:308-344`, path comparison at
+`setup_reset.go:402-415 @ 1244ae4`). In remote mode neither string can
+match: the argv carries the canonical `ssh://` URL (§6.8 rule 5), the
+config's `ControlRepo` is the local repo root, and its `LoopDir` is the
+shadow — and `setupPathsEquivalent` applies `filepath` semantics that are
+meaningless on a URL anyway. Reusing it verbatim would send EVERY live
+lane, in the normal case, down the "alive but unattributed" branch: the
+good refusal below (stop the lane, then re-run) would never fire, and every
+ordinary migration would instead print the pid-reuse text with its
+"remove runner.json" advice, which for a genuinely live lane is both wrong
+and destructive. The predicate, stated in full — for old hub dir `H` with
+recorded canonical URL `U` (from `H/config.json`) and shadow loop dir `S`:
+
+1. **Subcommand match, unchanged**: the cmdline must read as an
+   `agentchute serve` (including the pre-v0.9.1 `agentchute run` alias
+   kept for upgrade cleanup, `setup_reset.go:315-329 @ 1244ae4`). Anything
+   else — any non-agentchute process — is NOT this lane; the pid is alive
+   and unexplained ⇒ **ambiguous**.
+2. **Pool proof**, on the argv values extracted by `setupCommandFlagValue`
+   (which already stops at `--`, so a wrapper's own flags can never be
+   mistaken for ours, `setup_reset.go:352-369 @ 1244ae4`):
+   - argv has `--control-repo`: canonicalize it with §7.4's **URL**
+     canonicalizer (lowercase host, port elided at 22, no trailing slash)
+     and require equality with `U` ⇒ **attributed**. A different `ssh://`
+     URL, or any local path, is a serve for some other pool ⇒
+     **ambiguous** (a recycled pid over a stale `runner.json`).
+   - else argv has `--loop-dir`: require `setupPathsEquivalent` against
+     `S` ⇒ **attributed**; a mismatch ⇒ **ambiguous**. This arm exists
+     only for lanes launched by a pre-§6.8 binary or by hand — after §6.8
+     rule 5 no launcher emits `--loop-dir` for a remote lane at all.
+   - else (**neither flag** — the direct `agentchute serve <wrapper>` form
+     the quickstart itself prints, which resolves through the pointer file
+     and therefore carries no locator on its argv) ⇒ **attributed**. The
+     pid→(id, hub) binding here is the *location* of the `runner.json`
+     that named this pid: it lives under `H`'s own shadow state dir, and
+     nothing but a serve for `H` writes there. The residual this arm
+     accepts is a recycled pid belonging to a DIFFERENT flagless
+     `agentchute serve`; the consequence is that migration refuses when it
+     could have proceeded, which is the fail-closed direction this whole
+     check is built to prefer. It is deliberately not folded into
+     "ambiguous", because in the normal case it is not ambiguous at all —
+     it is the ordinary live lane, and it deserves the ordinary message.
+
+Note the interlock with §6.8 rule 5: the URL arm only works because the
+launchers forward the URL. The two changes ship together (M4/M5) and a
+review of either must check the other. Three outcomes:
+
+- **Attributed live lane** ⇒ refuse:
+  `hub join: lane "codex" is still running against the old URL (serve pid
+  41210). Stop that session first (Ctrl-C in its terminal, or end the
+  serve process from its own supervisor), then re-run this join; the lane
+  relaunches under the new URL afterwards.` — never a `kill` command.
+- **Pid alive but cmdline does NOT attribute** ⇒ fail closed, ambiguous:
+  `hub join: pid 41210 is alive but is recorded as lane "codex"'s runner
+  while its command line does not match this hub — possibly OS pid reuse
+  over a stale runner.json. Refusing to migrate. Inspect with ps -p 41210;
+  if it is unrelated, remove <old-hubdir>/.agentchute/loop/state/codex/
+  runner.json and re-run this join.` — inspection guidance only, no kill
+  suggestion for a process that may be anything.
+- **Pid dead or no runner.json** ⇒ no live lane; proceed.
+
+With no live lane, migration proceeds. **The completion boundary is a
+single `rename()`, not "durably complete" (G1).** An earlier draft said a
+crash mid-migration "is healed by re-running join, which finds either dir
+usable" — but a half-copied `<new-id>/` is *not* usable, and worse, it
+matches the fingerprint scan exactly as well as the intact old dir does, so
+a re-run cannot tell which one is authoritative. The sequence is therefore
+pinned, and no step is optional:
+
+1. Copy key material + config (latch/spool residue included) into
+   `~/.agentchute/hub/<new-id>.partial/`. `mux/` is deliberately NOT
+   copied — a ControlPath socket is bound to a path that no longer exists
+   after the move.
+2. Write the new `config.json` (recorded URL updated, `joined_as`/`names`/
+   `pool`/`pool12` carried over) inside `.partial`, then fsync every
+   written file and fsync the `.partial` directory itself.
+3. `rename("<new-id>.partial", "<new-id>")` — **this is the commit
+   point**, atomic on every supported filesystem. Fsync the parent
+   `~/.agentchute/hub/` afterwards.
+4. Rewrite the checkout's pointer file to the new URL.
+5. Delete the old hub dir.
+
+**The fingerprint scan only ever considers directories whose name is
+exactly 12 lowercase hex characters**, so `<new-id>.partial` (and
+`.locks/`) is never a scan candidate and can never be mistaken for a
+joined hub. Recovery is then deterministic at every crash point: before
+step 3 the only complete dir is the old one, and the leftover `.partial`
+is removed and redone from scratch on the next run (it is scratch, never
+adopted); after step 3 both dirs are complete and consistent, and the
+next run — which resolves the *new* URL to `<new-id>`, finds a complete
+config there recording that URL, and so never reaches the fingerprint scan
+at all — takes the ordinary joined-verify path, which sweeps for exactly
+this leftover (a sibling hub dir with the SAME recorded host-key
+fingerprint but a stale recorded URL) and finishes steps 4–5. Migration is
+thus idempotent from any interruption, with exactly one authoritative dir
+at every instant.
+
+**Mux masters outlive the old dir by design; reap them (G4).** A one-shot
+op's `ControlPersist=60s` master (§4.2) can still be running against
+`<old-id>/mux/%C` when the dir is deleted. Step 5 first sends a
+best-effort `ssh -O exit` for the old URL (one call, failure ignored); an
+unreaped master is harmless — it holds an unlinked socket inode, exits at
+its own ControlPersist deadline, and no new one-shot can ever attach to it
+because the ControlPath it would look for no longer exists.
+
+A fingerprint match with a different pool12 is a different pool on
+the same host — a normal fresh join (G-M2 markers keep them apart). No
+match ⇒ genuinely new hub ⇒ fresh join. Tested: same-hub-alias rejoin ⇒
+zero new keys, one authorized_keys line; alias rejoin under a LIVE latched
+lane ⇒ refused, state untouched, and after stopping the lane the rejoin
+migrates with latch/spool residue intact (§10.3).
+
+**Staged key rotation (D4b/F3): versioned keypairs + one atomic active
+pointer.** Keys are versioned files — `keys/<id>_ed25519.v<N>` (+`.pub`) —
+and `keys/<id>_ed25519` is a SYMLINK to the active version. That symlink is
+the stable path §4.2's `-i` already names (ssh follows it), so no
+invocation changes; and every local state transition below is ONE atomic
+step, so no rename boundary needs its own recovery narration (round-4's
+active→prev / staged→active / marker-rewrite triple had crash interleavings
+that contradicted its own recovery rule — F3). There is no `rotate.json`
+either: **a version file newer than the symlink's target IS the staged
+state** — the filesystem is the marker.
+
+**Version-file grammar (G3) — normative, because "newer" and "the current
+pubkey" are both load-bearing:**
+
+- **`.v<N>` is parsed as a NUMBER, and ordering is numeric.** `<N>` must
+  match `^[1-9][0-9]*$`; comparison is by integer value, so `v10` is newer
+  than `v2`. (String ordering would silently promote `v2` over `v10` on
+  the eleventh rotation of a long-lived lane — a stale key adopted as
+  "newest", with the real active key pruned as "residue".) Minting always
+  uses `max(existing N) + 1`.
+- **A non-numeric suffix is NOT a version file and is never guessed at.**
+  Any `keys/<id>_ed25519.v<S>` whose `<S>` fails that pattern (`v01`,
+  `v2b`, `vold`, `v`) is excluded from the version scan and is neither
+  adopted as newest nor pruned as residue; join/rotate refuses the run and
+  names the file — `hub join: keys/codex-tiny_ed25519.vold is not a valid
+  key version (expected .v<N>, N a positive decimal integer). Move it out
+  of the keys directory and re-run.` Silently deleting an operator's
+  hand-made file, or silently trusting it as a key, are both worse than
+  stopping.
+- **The scan's other exclusions**: `*.pub` (the public half of a version)
+  and `*.invalid.*` (retired files, below) are never version candidates.
+- **`.invalid.<ts>` is `<original-file-name>.invalid.<stamp>`**, where
+  `<stamp>` is the codebase's existing UTC filename stamp — `YYYYMMDDT`
+  `HHMMSS` + 6 digits of microseconds + `Z`, e.g.
+  `codex-tiny_ed25519.v3.invalid.20260815T101503123456Z` — the same
+  spelling message filenames use (`tsStampLayout`,
+  `internal/loop/tsid.go:22,51 @ 1244ae4`). Microsecond resolution makes
+  repeated retirements within one second collide-free; the `.pub` half is
+  retired alongside its private half, under the same stamp. Retired files
+  are inert forever: nothing scans them, nothing prunes them, and the
+  operator can delete them at leisure.
+- **There is deliberately NO `.pub` symlink; the current pubkey is
+  DERIVED.** `keys/<id>_ed25519` is the one and only pointer, and the
+  public half of whatever it names is that target's path plus `.pub`:
+  resolve the symlink (`readlink`) → `<id>_ed25519.v<N>` → the current
+  pubkey is `keys/<id>_ed25519.v<N>.pub` (which `ssh-keygen -f` wrote next
+  to the private key by construction). This is what keeps promotion ONE
+  atomic step — a second symlink would need a second `rename()` and
+  reintroduce exactly the multi-boundary crash interleavings F3 deleted —
+  and it makes a `.pub` that disagrees with the active key structurally
+  impossible. Both paste lines that need a "current pubkey" resolve it
+  this way: `E_UNAUTHORIZED` (§7.5) prints the pubkey of the **active**
+  target, and the rotation-recovery branches print the pubkey of the
+  version that branch selected (the STAGED `v<N+1>.pub` while resuming a
+  rotation, the ACTIVE `v<N>.pub` in the post-promotion residue branch).
+
+`hub join --rotate-key`:
+
+1. Mint `v<N+1>` directly at its versioned path (keygen, then dir fsync).
+2. Remote replace: `hub authorize --replace-key` with the v<N+1> pubkey —
+   **only** via the operator's own unrestricted SSH access (interactive
+   auto-authorize) or the printed paste line, the same two paths as join's
+   authorize. Never over the agent's pinned key: its forced command can
+   only ever run `hub session` (§5.1), so "authorize over the old key" is
+   structurally impossible (E3). Idempotent.
+3. Promote: swap the symlink to v<N+1> — write a temp symlink, one
+   `rename()` over the active path.
+4. Verify: hello with the (new) active key.
+5. Cleanup: delete the v<N> files — retained until this point.
+
+Recovery (E3/F3/H3 — executable from ANY crash point without assuming a
+credential still works). Every join/rotate run classifies the version state
+and handles all three abnormal shapes, in this order:
+
+- **Version files with no pointer symlink (H3a — the first-join gap).**
+  Probe the newest version with the passphrase-free check
+  (`ssh-keygen -y -P ""`); if it passes, ADOPT it: create the initial
+  symlink to it and continue the normal flow (the key may or may not be
+  authorized yet — the ordinary join probe decides what happens next). If
+  the probe fails (corrupt or passphrase-protected), move the file aside
+  (`.invalid.<ts>` rename) and mint fresh. `ssh-keygen` is never re-run
+  onto an existing path.
+- **A version NEWER than the symlink's target (staged rotation).** Probe
+  hello with that staged key FIRST. Success proves the remote replacement
+  landed — promote (if not already) then fall through to the residue
+  branch below, never re-driving step 2 over a now-revoked key. Staged-key
+  failure: if the active key still answers hello, resume at step 2 through
+  the operator path; if neither answers, print the complete paste line
+  with the staged pubkey for the hub operator — no self-rotation op exists
+  or is needed.
+- **Older versions beside the active target (H3b — post-promotion
+  residue, otherwise indistinguishable from a completed rotation).**
+  VERIFY first, prune second: probe hello with the ACTIVE key; only on
+  success delete the older version files. On ANY failure, prune nothing —
+  the older versions stay as evidence and fallback — and the response then
+  splits by error class (J2): **only the auth-refusal class
+  (`E_UNAUTHORIZED`) means the key itself needs authorizing**, so only
+  there does recovery print the paste line for the ACTIVE pubkey
+  (finishing the intended rotation — late revoke or half-landed replace
+  both converge on it). Every other failure class says nothing about the
+  key and gets its own existing §7.5 remediation, propagated unchanged:
+  `E_CONNECT` (hub down — retry later; pruning simply waits for a later
+  successful verify), `E_HOSTKEY_CHANGED` (security stop — never overlaid
+  with rotation advice), `E_VERSION`, `E_IDENTITY`, `E_POOL_MISMATCH`,
+  `E_HUB_NO_BINARY` likewise. A reauthorize hint on a mere network failure
+  would send an operator to the hub to "fix" a key that was never broken.
+
+A leftover temp symlink (crash mid-step-3, before the rename) is inert and
+removed on the next run; the real symlink at that point still names v<N>,
+so the staged branch applies unchanged. Tested with failure injection at
+EVERY transition — between first keygen and the initial symlink (orphan
+adoption; and the probe-fail retire path), after mint, before and after
+the remote replace, mid-promote (temp symlink present, rename not yet),
+after promote before verify (asserting verify-then-prune runs and old
+versions survive an active-key hello failure), after verify before cleanup
+(asserting the residue branch completes the prune) — the post-replace
+cases asserting recovery succeeds with the old key already revoked
+(§10.3).
+
+Join also **proves the lane can actually work** before declaring success
+(G-M5): the verification hello checks `hello-ok.writable` (§3.6), and a
+false verdict fails the join naming the three things to look at —
+`joined but the hub session cannot WRITE the pool: check that user "alex"
+owns /home/alex/code/agentchute (ls -ld), that the .agentchute/loop tree is
+writable by it, and that the pool was not authorized against another user's
+checkout.` — instead of letting the first real `send` die as `E_HUB_IO`.
+
+Join is **probe-before-pointer** (§7.4): a typo'd URL never poisons the
+checkout. Re-running join with a different URL first runs the same-hub
+migration check above; only a URL that probes as a genuinely different hub
+replaces the pointer as a fresh join, printing
+`pointer replaced: <old> -> <new>`. Un-join = delete
+`.agentchute-control-repo` (and, whenever no lane still uses that hub, the
+`~/.agentchute/hub/<hub-id>/` dir can be removed too).
+
+`hub join` also installs the `ac` dispatcher/shims if absent (reusing
+setup's shim machinery; the PATH change needs a new shell, which join
+reminds you of), so the joining machine never needs `agentchute setup`;
+wrapper hooks are refreshed by `serve` at launch as today
+(`internal/cli/serve.go:159 @ 1244ae4`). After join, **every existing
+command works unchanged** — `send`, `check`, `ack`, `boot`, `status`,
+`gate`, `pending`, `doctor` — the remoteness lives entirely in discovery.
+
+Incremental adoption is trivially safe: a fresh clone contains a tracked
+`.agentchute/loop/agents/README.md`, so the cwd-walk would find a
+plausible-looking empty local pool — but the pointer file outranks the cwd
+walk in the discovery cascade (flag > env > pointer > walk,
+`internal/loop/config.go:208-258 @ 1244ae4`), so a joined checkout always
+resolves to the hub. One thing DOES outrank the pointer: a set
+`AGENTCHUTE_CONTROL_REPO` env var (`config.go:218-225`) — env leakage has
+bitten this project before, so `hub join` and `doctor` both warn loudly
+whenever that variable is set and disagrees with the pointer.
+
+### 7.3 New command surface (subtract-default audit)
+
+**One new command family (three subcommands), one new `serve` flag, zero
+new flags on any other existing command:**
+
+| addition | justification |
+|---|---|
+| `agentchute hub join <url> (--name <local> \| --as <id>)` (flags: `--reset-hostkey`, `--rotate-key`) | the entire remote-side join: keygen (idempotent — an existing key is reused; rotation only via the explicit `--rotate-key`, §7.2), auto-authorize, probe, pointer, shims. `--name` mints the hostname-suffixed pool id (§7.2 naming) and must be a known wrapper token (S4 — it is also the launch name); `--as` is the verbatim override. A bare re-run verifies, so a separate `--verify` flag was cut as redundant. Folding join into `setup` would entangle pool-mutating setup with machine-local join and double both help texts. |
+| `agentchute hub authorize --agent <id> --pool <abs> --key "<pubkey>"` (flags: `--list`, `--revoke <id>`, `--replace-key`) | the entire hub-side story; writes and validates the forced-command line so no human ever hand-edits authorized_keys grammar; `--list` doubles as the hub-side health audit (§7.1). |
+| `agentchute hub session --agent <id> --pool <path>` | the forced-command entry point. Never typed by a human; exists because a forced command must be a real command. Hidden from `ac` help. |
+| `agentchute serve --relaunch` (boolean; **default true for remote lanes**, `--relaunch=false` to opt out; error on local lanes) | supervised full-lane relaunch (§6.7) — removes the one recurring manual-recovery event (laptop sleep, hub reboot/update) this design would otherwise create daily. `--relaunch-args` was cut from v1 (C9/G-m3). |
+| `ssh://` form of the existing control-repo locator (pointer file / `AGENTCHUTE_CONTROL_REPO` / `--control-repo`) | a grammar extension to an existing knob, not a new knob. |
+
+Explicitly **not** added: `hub ping` (folded into `doctor` and a bare
+re-join), `hub status` (plain `status` works), any per-command
+`--remote`/`--hub` flags (remoteness is discovered, never spelled per-call),
+any hub-side daemon (sshd is the daemon), any config beyond the pointer +
+`config.json`. Subtractions delivered alongside: joining machines no longer
+run `setup` at all, and the spec merge M2 (§9) retires the network-mounted-loop-dir
+guidance as the multi-host story in favor of the hub.
+
+### 7.4 Config / pointer-file format
+
+Pointer file (`.agentchute-control-repo`, existing discovery step 3,
+`internal/loop/pointer.go:14 @ 1244ae4`) — one line, now also accepting:
+
+```
+ssh://[user@]host[:port]/absolute/path/to/control-repo
+```
+
+Grammar: `user`,`host` match `[A-Za-z0-9._-]+` and must not start with `-`
+(argv-option-injection guard); `host` may be a `~/.ssh/config` Host alias
+(ProxyJump etc. work for free); `port` 1–65535, omitted = ssh default; path
+absolute. The same form is accepted by `AGENTCHUTE_CONTROL_REPO` and
+`--control-repo`. Canonical form for hashing: lowercase host, port elided when
+22, no trailing slash; `hub-id = hex(sha256(canonical))[:12]`.
+
+Local per-hub state (never in the repo, survives multiple checkouts):
+
+```
+~/.agentchute/hub/.locks/<hub-id>.lock     join/rotate/migrate exclusion (§7.2, G2)
+                                           — a SIBLING of the dirs it guards,
+                                           since migration renames/deletes them
+~/.agentchute/hub/<hub-id>/
+  config.json          {"url":"ssh://alex@hub…/home/alex/code/agentchute",
+                        "joined_as":["codex-tiny"],"names":{"codex":"codex-tiny"},
+                        "pool":"/home/alex/code/agentchute","pool12":"9c4e12ab77f0"}
+                       (pool identity RECORDED from hello-ok at join — hub-side
+                        canonical, never derived from URL text; §4.3, D3)
+  known_hosts          per-hub TOFU store (§5.6)
+  keys/<agent>_ed25519.v<N>[.pub]   versioned keypairs (D4b/F3; N numeric, §7.2 G3)
+  keys/<agent>_ed25519              SYMLINK -> the active version (the -i path;
+                                    the ONLY pointer — the current pubkey is
+                                    derived as <target>.pub, never a 2nd symlink)
+  mux/                 ControlPath sockets (%C) — the PREFERRED location; a
+                       path too long for sun_path falls back to an owned 0700
+                       per-user temp dir, else mux is disabled (§4.2 rule)
+  spool/               preserved send bodies (§4.5.3) — deliberately OUTSIDE
+                       the shadow loop tree so the --body-file retry command
+                       is never refused by the state-tree guard
+                       (send.go:600-633)
+  .agentchute/loop/    LOCAL SHADOW loop dir: state/<agent>/{guard.latch,
+                       runner.json, runner.log} — dotdir parent kept so the
+                       loop-dir shape invariant holds (§6.8) — never mail
+```
+
+Remote-mode `Discover` follows the §6.8 contract: every control-repo arm
+branches on the `ssh://` prefix and returns `Config{Remote:
+&RemoteConfig{…}, LoopDir: <shadow>, ControlRepo: <local repo root>}` by
+pure local derivation.
+Everything that reads local state through `cfg.AgentStateDir`
+(`internal/loop/config.go:142 @ 1244ae4`) — guard latch, runner state —
+lands in the shadow automatically, with no per-callsite changes.
+
+**Who picks the transport — the dependency direction, pinned (B2).** An
+earlier draft said "`internal/op` picks the transport on `Remote != nil`",
+which cannot be built: `internal/op` owns the request/response structs, the
+wire codec package must import them to marshal them, and the ssh client
+must import both — so an `op` that reached back for a transport would close
+the cycle `op → hubclient → hubwire → op`. The direction is one-way and
+normative:
+
+```
+internal/loop  ←  internal/op  ←  internal/hubwire  ←  internal/hubclient  ←  internal/cli
+```
+
+- `internal/op` is a **leaf over `internal/loop`**. It executes operations
+  against a local filesystem pool and knows nothing about transports,
+  sessions, sockets, or `Remote`. It MUST NOT import `hubwire`,
+  `hubclient`, or `internal/cli` (§7.4's companion rule to B1's
+  `op`-must-not-import-`cli`), and a dependency-direction test asserts it.
+- `internal/hubwire` imports `internal/op` for the payload structs (the
+  seam structs ARE the wire schema, §3) and adds framing, codes, and the
+  handshake.
+- `internal/hubclient` imports both, and owns the `ssh` invocation, the
+  channel, and the one-shot sessions.
+- **`internal/cli` selects.** It is the only layer that has both the
+  discovered `Config` and every implementation in scope: on `cfg.Remote ==
+  nil` it calls `internal/op` in-process; otherwise it drives
+  `internal/hubclient`. Equivalently — and this is the permitted
+  refinement, not a different design — `internal/op` may DECLARE a
+  `Transport` interface over its own request/response types, with the
+  in-process implementation living in `op` and the ssh implementation in
+  `hubclient`; the CLI still constructs and injects it. Either way the
+  arrow from an implementation to `op` points inward, never out.
+- `hub session` (hub-side) sits beside the CLI in the same direction: it
+  imports `hubwire` + `op` and dispatches frames to seam calls.
+
+Pointer lifecycle (all normative):
+
+- **Probe before pointer.** `hub join` writes `.agentchute-control-repo`
+  only after a probe proves the hub is real: a successful hello, or an SSH
+  auth refusal (which proves host + sshd + reachability; only the key is
+  pending). Connect/DNS/host-key failures write **nothing** — a typo'd URL
+  never poisons the checkout.
+- **Never committable by accident.** Join appends the pointer filename to
+  `.git/info/exclude` (machine-local; no repo file is mutated, so nothing
+  shows up in `git status` or a PR). If the pointer is already *tracked* —
+  someone committed one previously — join warns loudly instead of hiding it.
+- **Unjoined machines refuse cleanly — including the hub itself (C3).** An
+  earlier draft refused whenever the URL's *path* resolved to a local pool;
+  that falsely rejects the common valid case of a laptop and hub sharing the
+  same absolute layout (same username, same checkout path), and no
+  offline-safe host-identity proof exists (DNS in the discovery path would
+  break the §6.8 guard contract). The refusal is instead keyed on **join
+  state**, which is purely local and machine-specific: when the `ssh://` arm
+  activates but `~/.agentchute/hub/<hub-id>/config.json` does not exist —
+  true on a hub (or any third machine) that pulled a committed pointer, and
+  never true on a machine that actually joined — discovery refuses with
+  `E_NOT_JOINED` (§7.5), whose text covers both "this is the hub; delete the
+  committed pointer" and "this machine should join; run hub join". A
+  genuinely-joined machine with an identical path is untouched (its config
+  exists), and the guard cannot be wedged by this: an unjoined machine has
+  no serve session, so `resolveGuardSession` is already "" there
+  (`internal/cli/guard.go:109-115 @ 1244ae4`). Both cases are tested
+  (§10.3): identical-paths-two-hosts joins and operates; a true self-URL
+  committed-pointer pull gets `E_NOT_JOINED`.
+- **Env still wins.** A set `AGENTCHUTE_CONTROL_REPO` outranks the pointer
+  (`config.go:218-225 @ 1244ae4`); `hub join` and `doctor` warn when it is
+  set and disagrees (§7.2, §7.6).
+
+### 7.5 Error-message catalog (exact text)
+
+Transport / client-side:
+
+| code | exact message |
+|---|---|
+| `E_CONNECT` | `hub: cannot reach hub.tail1234.ts.net:22 (connect failed after 5s). Check network/VPN/tailnet, then retry; `agentchute doctor` runs this same probe. (If this machine should no longer be joined to this hub, delete .agentchute-control-repo.)` |
+| `E_UNAUTHORIZED` | `hub: hub refused this key for alex@hub.tail1234.ts.net. Either it was never authorized or it was revoked. Run this ON THE HUB, then retry here:`<br>`  agentchute hub authorize --agent codex --pool /home/alex/code/agentchute --key "ssh-ed25519 AAAAC3Nz… agentchute:codex"`<br>(the client composes the complete ready-to-paste line from its own pubkey and the joined URL; authorize canonicalizes the pool and writes the authoritative `agentchute:codex:<pool12>` marker itself, D3) |
+| `E_HOSTKEY_CHANGED` | `hub: HOST KEY CHANGED for hub.tail1234.ts.net — refusing to connect. If the hub was reinstalled, confirm with its operator, then run: agentchute hub join --reset-hostkey. If not, treat this as a possible interception.` |
+| `E_HUB_NO_BINARY` | `hub: connected, but the hub could not run agentchute (remote exit 127 — command not found at /usr/local/bin/agentchute). Reinstall agentchute on the hub, or re-authorize this key so its line points at the current binary path.` (mapped immediately from the ssh child's exit status — never burns the 10 s hello timeout) |
+| `E_HELLO_TIMEOUT` | `hub: connected but no protocol answer in 10s. The hub-side agentchute may be hung or broken; on the hub run: agentchute doctor` |
+| `E_VERSION` | `hub: hub speaks agentchute-hub v1; this CLI needs v2. The hub always upgrades first — run `agentchute update` on the hub, then retry. This machine is not misconfigured and re-running `agentchute hub join` will NOT fix it: wait for the hub upgrade.` (P8 — the operator instinct on any hub error is to re-join; here that burns a key rotation and changes nothing, so the text forecloses it) |
+| `E_IDENTITY` | `hub: this key is authorized as "codex" but you are acting as "grok". Fix --as/AGENTCHUTE_AGENT_ID, or join this machine as grok: agentchute hub join <url> --as grok` |
+| `E_POOL_MISMATCH` (client arm, §4.4.2) | `hub: this key now serves pool /home/alex/other-pool (id 41d2…) on the hub, but this machine joined pool id 9c4e12ab77f0 (/home/alex/code/agentchute). The key line was re-pointed or the hub moved the pool. Re-join if the move is intended (agentchute hub join <url> --as codex), or re-authorize the key with the right --pool on the hub.` (compared against the pool id RECORDED at join, never raw URL text — a symlinked spelling of the same pool never trips this, D3) |
+| `E_NOT_JOINED` | `hub: .agentchute-control-repo points at ssh://alex@hub…/home/alex/code/agentchute, but this machine never joined that hub (no ~/.agentchute/hub/3fa8c21b90de/config.json). If this machine IS the hub, a joined machine probably committed its pointer file — delete .agentchute-control-repo here (and `git rm` it if tracked). If this machine should be joined, run: agentchute hub join <that-url> --as <id>` |
+| `E_CHANNEL_LOST` | `hub: channel to the hub was lost; the wrapper was stopped (fenced). Relaunch with: <the exact command line this serve was started with, echoed from its own argv — never a hard-coded example>. (This lane was started with --relaunch=false; the default relaunches automatically, §6.7.)` |
+| `E_NO_SSH` | `hub: the `ssh` binary was not found on this machine. Install the OpenSSH client (macOS: preinstalled — check PATH; Debian/Ubuntu: apt install openssh-client), then retry.` |
+| `E_SEND_UNKNOWN` | `hub: connection lost after the send was transmitted — DELIVERY UNKNOWN. Do NOT resend blindly: a copy may already be in claude-code's inbox (check `agentchute status`, or ask them). Body preserved at <spool-path>; if you confirm it did not arrive, retry with: agentchute send --to claude-code --body-file <spool-path>` |
+
+Hub-reported (wire `error` frames, rendered with context):
+
+| code | exact message |
+|---|---|
+| `E_LEASE_HELD` (fresh claim) | `runner for codex is already active (serve lease held by hub pid 48122, fresh 2s ago). A second machine serving the same id must pick a distinct --as; if a connection just dropped, this clears within ~20s.` |
+| `E_LEASE_HELD` (stale claim, pid reads alive — §6.9; reachable when the claim carries no `boot_ref` (written by a pre-upgrade binary), when this host's boot ref is unreadable, or when the two refs MATCH — i.e. same boot, so a genuinely frozen-but-alive holder is protected, exactly as today) | `runner for codex looks DEAD (lease stale 3h) but hub pid 48122 still reads alive on the same boot as this claim — either that process is frozen but real, or this is OS pid reuse within one boot. On the hub: inspect `ps -p 48122`; if it is unrelated, delete /home/alex/code/agentchute/.agentchute/loop/state/codex/serve.claim and relaunch.` |
+| `E_POOL_MISMATCH` (hub arm, §4.4.2 / §5.1) | `hub: this key is authorized for pool id 9c4e12ab77f0, but /home/alex/code/agentchute on the hub reports pool id 41d2c8ab0917 (or has no state/pool.id at all). The authorized_keys line's --pool was edited without its --pool-id, or the pool directory was replaced. On the hub, re-run: agentchute hub authorize --agent codex --replace-key --pool <the pool this key should serve> --key "<key>".` (refused at session start, before any op — the client never sees a hello-ok) |
+| `E_FENCED` | `serve: this lane was fenced out (lease reclaimed — likely a newer serve for codex, or a hub update). Restart this lane: ac serve codex` (identical framing to today's `serve.go:618 @ 1244ae4`; under `--relaunch` this triggers the single automatic relaunch attempt, §6.7) |
+| `E_POOL_NOT_FOUND` | `hub: the authorized pool path /home/alex/code/agentchute no longer resolves on the hub. The hub operator should re-run hub authorize from the pool's current location (agentchute hub authorize --agent codex --replace-key --pool <new-path> --key "<key>").` |
+| `E_NOT_REGISTERED` | (unchanged texts — **two of them**, one per caller path; the code travels on the wire and the CLIENT renders the text its own call site renders today, so "sender" never becomes "agent" on a remote lane)<br>**sender path** — `send` (`internal/cli/send.go:145 @ 1244ae4`): `sender "codex" is not registered. Run `agentchute boot --as codex --vendor <vendor>` first (AGENTCHUTE.md §5.3)`<br>**agent path** — `check` (`internal/cli/check.go:120`) and `status` (`internal/cli/status.go:62 @ 1244ae4`), byte-identical to each other: `agent "codex" is not registered. Run `agentchute boot --as codex --vendor <vendor>` first (AGENTCHUTE.md §5.3)`<br>The two differ only in their first word; an earlier draft of this catalog listed the agent-path text alone, which would have made a remote `send` print "agent" where a local `send` prints "sender" — a behavior change inside a "zero behavior change" refactor. |
+| `E_RECIPIENT_*` | the four C29 texts, verbatim from `internal/cli/send.go:347-416 @ 1244ae4` (unknown / stale / racing / unreadable) — single-sourced client-side, as the seam mandates (`seq.go:250-252`). |
+| `E_HUB_IO` | `hub: the hub could not write pool state: <os error, e.g. "no space left on device">. This is a hub-side problem; nothing was partially delivered unless the message text says otherwise.` |
+| `E_ORDER` | `hub: protocol order violation (tick before register on this channel). This is a client bug, not an operator problem — please report it.` |
+
+CLI-surface refusals (not wire codes; exact text):
+
+| surface | exact message |
+|---|---|
+| `hub authorize`, duplicate id | `hub authorize: "codex-tiny" already has an authorized key (SHA256:Yk3n…, added 2026-08-01). One key = one agent id. If this machine REPLACES the old one, re-run with --replace-key. If both machines should run, join the new one under its own id — ids are cheap, and a shared id would collide on the serve lease anyway. (Auto-derived names collide when two machines share a hostname; pick an explicit id on one of them: agentchute hub join <url> --as codex-tiny2.)` |
+| `hub authorize`, unsafe pool/binary path (`E_POOL_PATH_UNSAFE`, §5.1) | `hub authorize: pool path contains characters outside the safe set [A-Za-z0-9._/+-] (spaces, quotes, and shell metacharacters are refused rather than escaped): "/home/al ex/pool". Move or symlink the pool to a plain path and re-run.` |
+| `hub authorize`, malformed pool identity (`E_POOL_ID_INVALID`, §5.1 J1) | `hub authorize: /home/alex/code/agentchute/.agentchute/loop/state/pool.id is not a valid pool identity (must be a regular 0600 file containing exactly 12 lowercase hex characters). Nothing was written to authorized_keys. Inspect the file; if it is corrupt, delete it and re-run authorize to mint a fresh identity (existing key lines for this pool will then need re-authorizing).` |
+| `turn-end`, hub unreachable (§8 row 21) | `turn-end: could not reach the hub to commit claimed mail (connect failed after 5s). Nothing is lost: the claim is held on the hub and the guard latch stays armed; turn-end retries at the next turn boundary. If this persists, check the network and run agentchute doctor.` |
+| `hub join`, non-wrapper `--name` (§7.2, S4) | `hub join: --name work does not name a wrapper this machine can launch (known: claude, codex, gemini, grok). --name is the LOCAL name you launch the lane with (ac serve <name>), so it must be a wrapper token — a lane named "work" would have no launch form at all. For an arbitrary pool id, use --as instead and launch with an explicit wrapper: agentchute hub join <url> --as work-tiny, then ac --as work-tiny serve claude.` (refused before keygen and before any authorize call) |
+| `hub join`/`--rotate-key`, hub dir busy (§7.2, G2) | `hub join: another agentchute hub join/rotate is already running for this hub (lock ~/.agentchute/hub/.locks/3fa8c21b90de.lock). Wait for it to finish and re-run.` (bounded wait, then this refusal — never a silent block) |
+| `hub join`/`--rotate-key`, unparseable key version (§7.2, G3) | `hub join: keys/codex-tiny_ed25519.vold is not a valid key version (expected .v<N>, N a positive decimal integer). Move it out of the keys directory and re-run.` (never adopted as newest, never pruned as residue) |
+| bare `agentchute hub join` | `usage: agentchute hub join ssh://[user@]host[:port]/abs/path/to/pool (--name <local-name> \| --as <agent-id>)`<br>`  --name mints the pool id <local-name>-<hostname> (e.g. --name codex on host tiny -> codex-tiny) and must be a known wrapper token; --as uses your id verbatim.`<br>`  The path is the pool's absolute path ON THE HUB (run `pwd` there).` |
+
+Hook-context degradation rule (seamlessness invariant): commands that run
+from hooks (`pending`, `self-check`, `guard`, `boot` context emitters) must
+**never wedge the wrapper on network failure** — `guard` is fully local
+(§6.6); `pending`/`self-check` print one stderr warning
+(`hub unreachable; skipping (will retry next event)`) and exit 0. `turn-end`
+is the exception by design: it reports the failure (text above) and leaves
+the latch armed (§6.6). Worst-case added delay while the hub is down is
+bounded by a **30 s negative cache** (G-M3): any `E_CONNECT` writes
+`~/.agentchute/hub/<hub-id>/hub-down.json` `{"last_econnect":"<T>"}`; until
+`T+30s`, hook-context commands — `pending`, `self-check`, **and hook-mode
+`boot`** (`--context-only` / `--codex-hook SessionStart`,
+`internal/cli/boot.go:15-40 @ 1244ae4`; D6 — SessionStart dials too, so
+omitting it meant two 5 s stalls per offline session start) — skip the dial
+entirely and take the same warn-and-exit-0 path, and any successful
+connection deletes the file. Interactive `boot` bypasses the cache like
+every other human-typed command. So a fully offline turn pays ConnectTimeout
+(5 s) at most once per 30 s across all hooks, not once per invocation.
+`turn-end` deliberately ignores the cache (it is the commit path —
+correctness over latency), as does any human-typed command (a fresh attempt
+is what the human is asking for: `send`, `check`, `doctor` always dial).
+
+### 7.6 `doctor` integration
+
+`agentchute doctor` in a joined checkout adds one check group, `hub`,
+alongside the existing checks (`runDoctorChecks`,
+`internal/cli/doctor.go:197 @ 1244ae4`):
+
+```
+hub: config ok (ssh://alex@hub…/home/alex/code/agentchute, joined as codex-tiny [local name: codex])
+hub: key ok (~/.agentchute/hub/3fa8…/keys/codex-tiny_ed25519 -> .v1, 0600)
+hub: connect ok (rtt 18ms, host key ED25519 SHA256:xxxx…)
+hub: identity ok (key pinned to codex-tiny; protocol agentchute-hub v1; hub binary 1.7.0)
+hub: pool ok (writable; hub time offset +0.4s)
+```
+
+Each line has a FAIL form that names the §7.5 error and its remediation
+verbatim. The probe is one one-shot session's `hello`/`hello-ok` (the `ping`
+op was cut into it, §3.6), total budget 10 s. Two further checks:
+
+- On joined machines, `doctor` (like `hub join`) warns loudly when
+  `AGENTCHUTE_CONTROL_REPO` is set in the environment and disagrees with the
+  pointer file — env outranks the pointer (`config.go:218-225 @ 1244ae4`)
+  and env leakage has bitten this project before. `doctor` also reports the
+  negative-cache state (`hub-down.json` age, §7.5) so "why are my hooks
+  quiet" has a one-line answer, and FAILs with `E_NO_SSH` when the local
+  `ssh` binary is missing.
+- The `AGENTCHUTE_AGENT_ID` counterpart of that warning — the one §7.2's
+  resolver rule points at — is specified here (round 10; it existed only
+  by reference before). Emitted by `doctor` and `hub join` whenever the
+  env var is set and names a mapped local name, exact text:
+  `warning: AGENTCHUTE_AGENT_ID=codex is a local name on this machine;
+  every command resolves it to "codex-tiny" (this hub's names map). Unset
+  it, or export the full id, if that is not what you want.`
+- Run **on the hub**, `doctor` performs the authorize-line audit (the same
+  validation as `hub authorize --list`): every `agentchute:`-marked
+  authorized_keys line gets PASS/FAIL for "binary exists and is executable"
+  and "pool resolves to a real pool" — surfacing hub-side the breakage that
+  otherwise appears only as a remote's opaque
+  `E_UNAUTHORIZED`/`E_HUB_NO_BINARY`.
+
+### 7.7 Tailscale recipe (documented recipe — never a dependency)
+
+The blessed deployment shape, shipped as a README/docs section:
+
+1. Hub and every remote on one tailnet (`tailscale up`). Port 22 never faces
+   the public internet; Tailscale ACLs say which machines may reach the hub's
+   22 at all.
+2. Join with the MagicDNS name:
+   `agentchute hub join ssh://alex@hub.tail1234.ts.net/home/alex/code/agentchute --name codex`.
+3. Everything else is the standard flow — **standard sshd + authorized_keys
+   on top of the tailnet**, keys and forced commands exactly as in §5.
+
+**Do not use `tailscale ssh` for the hub** (explicit, verified): Tailscale SSH
+performs its own authentication and *does not read `~/.ssh/authorized_keys`*
+("Your SSH configuration and keys files will not be modified"; Tailscale's own
+docs flag machines that use authorized_keys to limit commands as a poor fit) —
+so forced-command identity pinning, the day-one security requirement, would
+silently not exist. The recipe uses Tailscale as the network layer only, which
+already delivers its whole value here: no public exposure, stable names, no
+firewall wrangling. Key management stays (that's the cost of keeping pinning);
+`hub join` reduces it to the one join command per machine (§7.2 — zero
+pastes when you can SSH to the hub yourself).
+
+---
+
+## 8. Failure-mode matrix
+
+| # | fault | detected by | behavior | user-visible message |
+|---|---|---|---|---|
+| 1 | hub down at op start | ConnectTimeout 5 s | op fails; `send` spools body (safe-retry class) | `E_CONNECT` |
+| 2 | hub dies under a live channel | ServerAlive (≤15 s) or tick deadline (10 s) | child fenced + stopped; then §6.7: relaunch loop (default) or exit (`--relaunch=false`) | relaunch status lines / `E_CHANNEL_LOST` |
+| 3 | TCP half-open, client side | same as 2 | same as 2 | `E_CHANNEL_LOST` |
+| 4 | TCP half-open, hub side | hub read deadline 20 s | session exits, releases lease; relaunch may see `E_LEASE_HELD` ≤20 s | `E_LEASE_HELD` (with the "clears within ~20s" line) |
+| 5 | ssh helper process crashes | serve's child-wait | same as 2 (fence + stop + exit) | `E_CHANNEL_LOST` |
+| 6 | wrapper (child) crashes | serve's `done` channel (`serve.go:469`) | serve sends `lease-release`, exits; hub releases | normal exit + wrapper error, as today |
+| 7 | whole serve process crashes | ssh child gets stdin EOF → exits → hub session EOF | hub releases lease; child wrapper dies with the PTY | none (next launch is clean) |
+| 8 | version skew (a remote updated before the hub) | handshake | fail closed before any op; the remote WAITS for the hub upgrade — re-running `hub join` is explicitly not the fix (P8) | `E_VERSION` ("hub upgrades first"; text names the do-not-re-join rule) |
+| 9 | clock skew (either side) | n/a — hub clock owns all protocol state (§2); display ages corrected via `hub_time` offset | no protocol effect; spool/local log stamps may skew (cosmetic) | none |
+| 9b | hub wall clock STEPPED forward under a live lane (wrong RTC at boot, then an NTP step) | the live lane's `LastSeen` suddenly reads stale, so a would-be acquirer reaches the stale-claim branch | lease is **NOT stolen**: branch (d)'s same-host pid-proof holds, and the claim's `boot_ref` equals this host's (a clock step is not a boot), so the boot-ref rule never fires — equality, never ordering (§6.9, B6) | `E_LEASE_HELD` to the would-be acquirer; the live lane is unaffected |
+| 10 | key revoked while a session is up | sshd checks keys at auth only | live session survives until its connection ends; no *new* session can start | doctor/status show the still-live lease; docs: kill the `hub session --agent <id>` pid for immediate cut |
+| 11 | disk full on hub | any loop write fails | op fails loudly; a live channel's heartbeat/sweep failures ride back as `tick-ok.warnings` (§3.4) and are re-logged into the runner log, never fatal; delivery never partial (link is atomic) | `E_HUB_IO` with the ENOSPC text |
+| 12 | duplicate id join (2nd machine, same id) | `hub authorize` refuses a 2nd key for a marked id; if forced via `--replace-key`, the old machine's next auth fails; two live serves collide on the lease | fail closed at authorize time, else at lease time | duplicate-id refusal text (§7.5, spells the `codex-laptop` fork) / `E_LEASE_HELD` |
+| 13 | disconnect after `check` claimed, before display | client sees dead channel/deadline | mail sits in hub `.claimed/`; next `check` REDELIVERS with banner (`check.go:180-193`); local latch set on that next check | `E_CHANNEL_LOST`, then normal REDELIVERED flow |
+| 14 | disconnect after `send` transmitted, before `send-ok` | response deadline / EOF inside the ambiguity window (§4.5.3) | fail closed, spool, never auto-replay | `E_SEND_UNKNOWN` |
+| 15 | lease reclaimed mid-session (zombie resume) | next `tick` → `E_FENCED`; next fenced one-shot `send` → `E_FENCED` | fence path: stop child, exit | `E_FENCED` |
+| 16 | malformed/oversized frame (either direction) | codec | error frame, session closes (no resync) | `E_MALFORMED_FRAME` / `E_TOO_LARGE` |
+| 17 | hub pool path gone/moved | session start validation of `--pool` | error frame then exit | `E_POOL_NOT_FOUND` |
+| 18 | hub host key rotated | ssh + per-hub known_hosts | hard refusal until explicit reset | `E_HOSTKEY_CHANGED` |
+| 19 | authorized_keys line hand-mangled | sshd auth failure | as key-revoked | `E_UNAUTHORIZED` |
+| 20 | hub unreachable during a hook (`pending`/`self-check`) | ConnectTimeout | warn to stderr, exit 0 — never wedge the wrapper (§7.5) | one stderr warning line |
+| 21 | hub unreachable during `turn-end` | ConnectTimeout | commit not performed; latch stays armed; retried next turn-end | exact text in §7.5 ("could not reach the hub to commit claimed mail …") |
+| 22 | remote laptop sleeps, later wakes | on wake, ServerAlive/tick deadline kill the dead channel ≤15 s | child fenced + stopped during sleep-detection; the lane relaunches within one backoff step of waking (relaunch default-on); hub side released at its 20 s read deadline back when the laptop slept | relaunch status line; with `--relaunch=false`, `E_CHANNEL_LOST` |
+| 23 | hub reboots (N remote lanes) | all channels drop at reboot; sshd returns minutes later | every remote serve (relaunch default-on) retries with capped backoff (≤60 s interval) and relaunches when sshd answers — zero human action on any machine; pre-reboot `serve.claim` files are long stale by then and reclaimable because their recorded `boot_ref` differs from the rebooted host's (§6.9; freshness floor still applies first, C8) | relaunch status lines; with `--relaunch=false`, N × `E_CHANNEL_LOST` |
+| 24 | hub `agentchute update`/`setup` invalidates all serve leases (`lease.go:371-376 @ 1244ae4`) | every channel's next `tick` → `E_FENCED` | fleet-wide fence by design (the update forcing function); lanes perform their single `E_FENCED` relaunch attempt (default-on) and come back under the new binary; note: a live hub session keeps executing its already-open old binary inode until it exits | `E_FENCED` text |
+| 25 | `<hubdir>/mux/%C` too long for `sun_path` (deep `$HOME`; ~104 B macOS / 108 B linux) | the ControlPath length budget in the ssh-invocation builder (§4.2), before ssh is spawned | one-shots move to the owned-0700 per-user temp mux dir; if that does not fit either, multiplexing is disabled for this hub (one extra authentication per op, correctness unaffected). Never a refusal; the channel never multiplexes anyway | none in the fallback arm; exactly one `warn` note naming both attempted paths in the mux-disabled arm |
+
+---
+
+## 9. Compatibility & spec delta
+
+Ordering (C6, decided): the seam refactor (merge M1, §11) makes **no** spec
+claim and tags **v1.6.0 before any spec change**; the spec merge (M2) then
+lands before any hub code; **no further tag exists until v1.7.0** ships the
+complete capability. So the spec never describes a transport no released
+binary has, and no released binary carries an unspecified transport —
+Working rule 1 (spec before code) holds for every hub-code merge.
+
+### 9.1 AGENTCHUTE.md amendments (exact sections)
+
+- **A normative "Hub wire & lifecycle" section (C7)** — not amendment notes
+  but binding spec text, added by M2 to AGENTCHUTE.md (or a normative
+  `HUB.md` incorporated by reference from it): the frame grammar and the
+  64 KiB / 4 MiB limits (§4.3), the message vocabulary and per-session
+  serial ordering (§4.4), the version handshake + hub-upgrades-first policy
+  (§4.3), the never-auto-replay rule for ambiguous sends (§4.5.3) **and the
+  mandatory `send-ok.committed` flag it is written against** (§4.4.1, F11 —
+  the spec copy of that example carries `"committed":true`; a `send-ok`
+  without the field is malformed, not a defaulted `false`) **and the
+  always-present `tick-ok.warnings` list** (§3.4/§4.4.1 — `[]` when the tick
+  was clean; the fenced case is the tick's only hard error, every other step
+  failure is a warning entry) **and `note.level`'s two-value vocabulary with
+  its pinned routing** (§4.3 — exactly `warn`/`info`; `warn` → stderr with a
+  rendered `warning: ` prefix, `info` → stdout with none; the `info` arm is
+  not decorative, it is what keeps `check`'s in-stream status lines in
+  position), the
+  disconnect-after-claim redelivery rule (§4.5.2), remote turn-end ordering
+  (§6.6), the timeout/size table (§4.6), the per-key identity-pinning
+  model (§5), and **the error-code registry with each code's emitter side**
+  (§4.4.2, F9/X1 — hub-emitted, client-emitted, or both; `E_POOL_MISMATCH`
+  is the one code with two emitters and two exact texts, and the spec must
+  say so rather than classifying it as client-only). After M2, when this
+  proposal and that spec text disagree, the spec wins — the same supremacy
+  rule the conformance suite already has.
+- **Enrollment surface (G-M4)**: AGENTS.md and the wrapper enrollment
+  templates (CLAUDE.md / CODEX.md / GEMINI.md / GROK.md + `examples/`) gain
+  four lane-facing rules: remoteness is *discovered* (commands are
+  identical on hub and remote; never a `--hub`/`--remote` spelling); NEVER
+  re-send after `E_SEND_UNKNOWN` without confirming non-delivery first; run
+  `agentchute doctor` immediately after a join and after any hub move; and
+  **on `E_VERSION`, WAIT for the hub to upgrade — never "fix" it by
+  re-running `hub join`** (P8: the hub upgrades first, §4.3; a remote that
+  updated ahead of its hub is correctly configured and simply early, and
+  re-joining rotates a key for no reason). The same line belongs on the
+  release checklist for any tag that bumps the wire version.
+- **`setup --wipe-state` surface (H1)**: the layout/§3 amendment names
+  `state/pool.id` as preserved, non-runtime scaffold — alongside
+  `setup.json` — in the wipe plan, the post-wipe rescan, and the
+  dry-run/preserved output (today's wipe deletes every other `state/`
+  entry and its rescan flags survivors, `setup_wipe.go:295-316,519-536
+  @ 1244ae4`; wiping the pool's identity would silently invalidate every
+  key binding). Spec text in M2; behavior lands in M5 with `authorize`.
+
+- **§1 Reference implementation**: add the hub as the reference *transport*
+  for multi-host pools: "Transport: … or, for a remote lane, framed
+  operations over SSH to the pool host (the hub); the substrate is unchanged."
+- **§2 Scope / Tested targets**: add "hub pool (one pool host + SSH remote
+  lanes)" as a supported, CI-tested configuration; rewrite the cross-host
+  network-mount paragraph to point new multi-host deployments at the hub
+  (mount-based cross-host remains tolerated-but-unverified compatibility, one
+  notch further deprecated).
+- **§4 Discovery**: document the `ssh://` locator form in the §4.1 cascade
+  arms (flag/env/pointer).
+- **§5.4 Serve lease**: one paragraph — for a remote lane, the lease holder
+  is the hub-side session process; pid-proof is therefore same-host again;
+  channel loss releases the lease token-checked. Additionally the same-host
+  pid-proof gains **boot-reference corroboration** (§6.9, B6): the claim
+  records a per-boot identifier (`boot_ref`) at acquire, and a stale claim
+  whose recorded ref DIFFERS from the host's current one is provably dead
+  whatever its pid says. Spec text must state the three properties that
+  bound it — the comparison is **equality only, never ordering**; the
+  reference has **no wall-clock component** (so a clock step cannot forge a
+  difference); and the reference is **host-scoped**, changing on a host
+  reboot and on nothing else, so a container/VM/service restart on an
+  unrebooted host is unchanged from today's behavior and pid reuse is NOT
+  solved generally (§6.9) — and that an absent ref means unchanged,
+  pre-existing behavior. This is the one behavioral amendment to existing lease
+  semantics, called out explicitly since it also affects local pools. (An
+  earlier draft of this design proposed a `StartedAt`-predates-boot-time
+  rule; it is withdrawn as unsafe — see §6.9 — and must not reach the
+  spec.)
+- **§8 Wake/supervision**: note that for a remote lane the runner's poll is
+  the tick over the channel; injection is unchanged and local.
+- **§12 Non-goals**: amend "No non-filesystem transport in the reference
+  CLI" → "No non-filesystem **state substrate** in the reference CLI; the
+  hub's SSH channel forwards *operations* to the one filesystem pool and is
+  part of the reference implementation. Sync/replication of loop state
+  remains excluded." Also drop "no handshake" phrasing in favor of "no
+  *dynamic capability* negotiation beyond the versioned hub handshake".
+- **§15 Security**: add the per-key pinning model (§5 here, condensed): remote
+  sender identity is transport-enforced; cooperative trust still governs
+  co-tenants on the hub itself; bodies remain untrusted data.
+
+### 9.2 EXTENSIONS.md
+
+Keeps: the substrate sketches (queue, object store, HTTP endpoint, git),
+bridges, and the "not extension space" list — all still true and still
+non-shipping. Changes: the HTTP sketch gains one line ("planned phase-2 behind
+`internal/op` — see the hub design"), and any wording implying every
+non-filesystem *transport* is out of the reference CLI is aligned with the
+amended §12.
+
+### 9.3 Conformance-suite additions
+
+`conformance.Binding` (`conformance/binding.go:52 @ 1244ae4`) has **no
+lease/fencing surface** — passing it alone was already flagged insufficient by
+the consensus. Additions:
+
+- New vector set **L (lease/fencing)**, driven in-process against the seam:
+  `L1` a second acquire while fresh fails closed; `L2` a fenced holder's
+  mint/heartbeat writes nothing (zombie-resume); `L3` release is token-checked
+  (never deletes a successor's claim); `L4` stale + pid-dead reclaim succeeds
+  and old token is dead. These encode `lease.go`'s existing behavior as
+  executable spec for *any* future backend (S3's CAS story must pass L2 —
+  the veto's "executable proof" hook).
+- New vector set **W (wire)**, driven against a fake transport (§10.2):
+  `W1` disconnect-after-claim redelivers; `W2` disconnect-after-send is
+  reported unknown and not replayed; `W3` reclaim-during-send fails fenced;
+  `W4` identity mismatch closes at handshake; `W5` version mismatch closes at
+  handshake.
+
+Timing (C7): these vectors are **not** a post-release merge. The L set and
+the fake-transport W set land inside M3 (with the code they test); the
+sshd-backed W runs land inside M6 — all of it **gating** the v1.7.0 tag,
+never after it (§11).
+
+---
+
+## 10. Test plan
+
+### 10.1 Operation-seam tests (M1; in-process, no network)
+
+Port the behavioral assertions of the existing CLI tests to the seam:
+send preflight ordering (A5), C29 classification, fresh-suffix collision
+retry (C4), claim/ack idempotence, redelivery, quarantine, owed
+record/discharge, lease acquire/renew/release/fence, heartbeat self-heal,
+sweep back-off. Plus, per the reshaped seam: every actor-scoped op driven
+through **both** `op.Context` constructors (CLI-resolved and pinned-id,
+§3 conventions — C1), and the streaming emitters (`Claim`/`Ack`/`Pending`)
+asserted to hold at most one item in memory and to surface an emit-error
+abort cleanly (C4). Plus a byte-for-byte stdout/stderr golden for the two
+note levels' routing (§4.3): the three `info` status lines land on **stdout**
+in their production positions — the limit line between two message renders,
+the CLAIMED line before the expired-obligation lines — and `warn` notes on
+**stderr** with the `warning: ` prefix the renderer (never `Msg`) supplies.
+Position, not merely presence, is the assertion: a renderer driven from the
+terminal summary passes a `Contains` check and still reorders the output.
+Success criterion for the merge: the **existing** CLI
+test files (`send_test.go`, `check_*.go`, `ack_test.go`,
+`consume_boundary_test.go`, `b1_convergence_test.go`, …) pass unmodified —
+the refactor is invisible, including the local child-then-register serve
+startup order (§6.1, C10).
+
+### 10.2 Framing tests with a fake transport (M3)
+
+The codec reads/writes an `io.ReadWriter`; tests drive it over `net.Pipe`:
+round-trip every frame type; body trailers byte-exact at 0 B, 1 B, 4 MiB, and
+4 MiB+1 (`E_TOO_LARGE`); truncated frame/trailer at every boundary; unknown
+`t`; unknown fields ignored; oversize line; interleaved `note` frames at both
+levels, with `warn`→stderr / `info`→stdout routing asserted end-to-end (§4.3);
+a `register-ok` whose `reg.body` exceeds 64 KiB round-tripping through the
+trailer (§4.4.3); the **`status-ok` two-budget rows** (§4.4.3) — 64 small rows
+in ⇒ 64 out, `truncated:false`; 65 in ⇒ the first 64 in sort order,
+`truncated:true`; **one valid registration whose `host` alone exceeds 64 KiB**
+⇒ that row is excluded even though the pool holds far fewer than 64 agents,
+`truncated:true`, and the emitted line is ≤ 64 KiB when measured whole; the
+same oversized row placed FIRST in sort order ⇒ `agents:[]` with
+`truncated:true` and every later row dropped (prefix, never skip-and-continue);
+and a pool sized so the encoded line lands exactly at the budget boundary
+(largest frame that fits ⇒ `truncated:false`; one byte more ⇒ the last row
+drops), asserted on the **encoded line length including the LF**, so a
+rows-only budget fails the row;
+handshake version matrix (v1/v1, v1/v2 both directions); a fuzz target on the
+frame parser (`go test -fuzz`, checked in as a regular seed-corpus test —
+the hub-side parser is the §5.4 attack surface); typed-event-stream tests
+(C4/D2): a `check` over many maximum-size (4 MiB) messages with peak-memory
+assertion; a `check` producing many interleaved `note`/`owed-item` frames
+with order preserved end-to-end; a `pending` with many owed entries and one
+4 MiB `show_body` body as a trailer; transport failure injected after the
+first emitted item AND after a mid-stream `note` (claim durable, no partial
+frame, clean abort, no note silently lost before the failure point).
+
+### 10.3 Real-sshd integration matrix (M6)
+
+Harness: generate throwaway host + client keys in a temp dir; start
+`/usr/sbin/sshd -D -f <generated sshd_config>` on a random high port with
+`AuthorizedKeysFile` pointing at a generated file containing the §5.1 forced-
+command line (absolute path to the freshly built test binary); pool in a temp
+dir. Build-tagged `//go:build sshd_integration`, gated on
+`AGENTCHUTE_SSHD_TEST=1` (env-strip discipline per the destructive-test rule —
+the harness refuses to run if `AGENTCHUTE_LOOP_DIR`/`AGENTCHUTE_CONTROL_REPO`
+point at a real pool).
+
+Matrix (each row asserts both sides' end state):
+
+| test | method |
+|---|---|
+| join→authorize→verify happy path | drive `hub join`/`hub authorize` against the harness |
+| identity mismatch | hello with wrong `agent` → `E_IDENTITY`, no op executed |
+| version mismatch | client forced to v2-min → `E_VERSION` |
+| disconnect-after-claim | SIGKILL the client ssh after `msg` frames start; assert `.claimed/` residue; next check redelivers |
+| disconnect-after-send | SIGKILL between body flush and `send-ok` (test seam in the client transport); assert spool + `E_SEND_UNKNOWN`; assert at most one inbox file |
+| reclaim-during-send | acquire lease as A, release/reacquire as A′ (new token), then one-shot send with A's token → `E_FENCED`, nothing linked |
+| channel drop fences child | kill sshd mid-channel; assert wrapper (a script child) got SIGTERM within 15 s; assert hub lease released |
+| half-open hub side | SIGSTOP the client; assert hub session exits at the 20 s read deadline and releases |
+| lease-held refusal | two serves same id; second gets `E_LEASE_HELD` |
+| host-key change | swap host key; assert `E_HOSTKEY_CHANGED` refusal |
+| mux reuse | 3 sequential one-shots; assert 1 sshd auth log entry (ControlMaster hit) |
+| ControlPath length rule (§4.2) | drive the invocation builder with an **injected** hub-dir length (deterministic — no real deep `$HOME`, no OS dependence; no CI runner has a home deep enough to trigger this naturally): within budget ⇒ `-o ControlPath=<hubdir>/mux/%C`; over budget ⇒ the owned-0700 per-user temp path (assert the dir is 0700 and uid-owned, and that a symlinked or foreign-owned temp dir is refused, `runner_socketdir_unix.go:24-49`); over budget with every temp root also over budget/unwritable ⇒ `-o ControlMaster=no -o ControlPath=none` plus exactly one `warn` note naming both attempted paths, and the op still succeeds. Re-run the mux-reuse row through the fallback arm (still 1 auth entry) and the disabled arm (3 auth entries) |
+| child env contract (§6.8) | launch remote serve in the harness; assert child env carries `AGENTCHUTE_CONTROL_REPO=<ssh URL>` and no `AGENTCHUTE_LOOP_DIR`; with networking blocked, run `guard --pre-tool-use` in hook context and assert it resolves the SHADOW latch (denies while armed — never fail-open); child `send` lands in the hub pool |
+| supervised relaunch — default path (§6.7, D5) | launch a remote lane with a BARE `agentchute serve` (no flag — this is the load-bearing default); kill sshd; restart sshd; assert the lane re-acquires with a NEW token and NEW child pid, exactly one lane instance, old child SIGTERM'd first. An implementation that kept relaunch opt-in fails this row |
+| relaunch opted out (`--relaunch=false`) | same drop; assert the old child is stopped, NO new child appears, and serve exits with `E_CHANNEL_LOST` echoing its own argv |
+| hub-reboot pid reuse (§6.9, C8, B6) | fabricate a `serve.claim` with an explicitly **stale** `LastSeen`, a `boot_ref` DIFFERENT from the injected current one, and a live decoy pid → assert acquire reclaims; same claim with a MATCHING `boot_ref` → assert `ErrLeaseHeld` (a frozen-but-alive same-boot holder keeps its id); with `boot_ref` ABSENT (a pre-upgrade claim) → assert `ErrLeaseHeld` (today's behavior preserved = the upgrade path); with the host's current ref unreadable → assert `ErrLeaseHeld`; with a FRESH `LastSeen` and a differing ref → assert `ErrLeaseHeld` (the freshness refusal still precedes the pid/boot branch) |
+| clock step does not steal a live lease (§6.9, B6 — the row the withdrawn rule failed) | hold a live lease, then step the injected wall clock FORWARD by hours so the claim's `LastSeen` reads stale while the process stays alive and the boot ref is unchanged → assert a competing `AcquireServeLease` gets `ErrLeaseHeld` and the claim file is byte-unchanged (same `serve_token`), i.e. the live lane keeps its lease; assert the same for a step BACKWARD |
+| `boot_ref` survives the heartbeat (§6.9, B6) | acquire, assert `boot_ref` is present in `serve.claim`, run `RenewLease` repeatedly, assert `boot_ref` is still present and identical after each renew (guards the `readClaim`→`marshalClaim` round-trip, `lease.go:317-340`) — it survives **because it is a real struct field**, which is the property under test. Separately assert the mixed-version property, which is TOLERANCE and not preservation: a claim JSON carrying an unknown extra key still unmarshals cleanly and every known field is read correctly (`readClaim`'s plain `json.Unmarshal`, no `DisallowUnknownFields`, `lease.go:101-114`) — and assert the other half explicitly, that the unknown key is **DROPPED** by the first `RenewLease`, so no test and no caller may treat an off-struct key as durable |
+| launcher preserves remoteness (§6.8 rule 5, B4) | in a joined checkout, launch through BOTH launcher paths and capture the re-exec'd `agentchute serve` argv. (1) The single `ac` dispatcher (`ac serve <wrapper>`) — the only launcher setup installs today. (2) `cmdShimsExec` (`shims.go:259-312 @ 1244ae4`), the LEGACY per-wrapper `ac-*` path: setup deletes those shims (`removeLegacyWrapperShims`, `shims.go:233-257`), so the test must CONSTRUCT one (or call `cmdShimsExec` directly) — a row that exercises only the dispatcher passes green while `shims.go:304-305` is still broken. For each: assert it carries `--control-repo ssh://…` (the canonical URL, not the local repo root) and NO `--loop-dir` at all, and that the child's discovered config has `Remote != nil` and `LoopDir` = the shadow. A launcher that forwards `cfg.ControlRepo`/`cfg.LoopDir` fails this row — today's code would pass discovery, run LOCAL against the shadow, and report no error, so the assertion must be on `Remote != nil`, never merely on "the command succeeded". Also assert an explicit `--loop-dir` passed to `ac` in a joined checkout is REFUSED (§6.8 rule 4) rather than forwarded |
+| live-lease self-check/turn-end (C2) | with a channel holding a fresh lease, run the child's one-shot `register` (self-check) and `turn-end` carrying the inherited token → accepted; with a missing/wrong token → refused as live-elsewhere (`register.go:189-195` semantics preserved over the wire) |
+| register field semantics (C2/D1) | wire register with `Bio:nil` preserves an existing bio; `Bio:&""` clears it; omitted host after a simulated machine move records the NEW remote hostname (never the hub's); omitted vendor (`Vendor:nil`) against an existing custom-id hub row resolves that row's vendor — every step-0 repair succeeds bare; `Announce:true` against a pool with one undeliverable peer renders the per-peer warning AND `sent to N of M peer(s)` byte-identically to a local `register --announce`, and a hub-side announce failure prints `warning: announce failed: …` with the register itself still exiting 0; `Sweep` is `true` on `boot` alone — a remote `boot` removes a stale lease-dead row from the HUB pool and leaves the shadow untouched (the local sweep is skipped, never duplicated), a hub-side sweep failure surfaces as `sweep stale registrations: …` in boot's warnings with boot still succeeding, and remote `register`/`self-check`/`turn-end` send `sweep:false` and remove nothing |
+| remote vendor resolution skipped client-side (S2) | in a joined checkout with a custom pool id whose vendor no canonical-prefix rule can name, drive each of the four sites bare (no `--vendor`) — `agentchute serve <wrapper>`, `register`, hook-mode `boot`, and `turn-end`'s step-0 self-check → assert each sends `Vendor:nil` on the wire (never a value resolved from the mail-free shadow) and each succeeds; **assert the rendered OUTPUT carries the hub-RESOLVED vendor, not the empty request value** — `register`'s `  vendor:        <resolved>` (text; the command has no `--json`), `boot`'s text `(<resolved>)` **and** `boot --json`'s `"vendor":"<resolved>"`, `self-check`'s text **and** `self-check --json`'s `"vendor":"<resolved>"`, each byte-identical to the same pool driven locally (a renderer printing the pre-wire `opts.Vendor` prints empty here and fails this row); assert `cmdServe` does NOT emit its `missing --vendor` refusal (`serve.go:153-155`) on a remote lane; assert an explicit `--vendor` still wins and is still validated |
+| remote `status` renders the HUB, header included (§3.6) | in a joined checkout, run `agentchute status` remotely against a hub pool of three agents and assert: the table's STATUS/INBOX columns and the AGE column come from the response (`StatusAgent.Status`, `.InboxDepth`, `StatusResp.Now`) and are byte-identical to the same pool driven locally with the clock pinned — a client that re-derives them locally renders `-`/`0` and fails; the header's `control_repo:` line prints the canonical `ssh://` URL (never the local repo root, never the shadow), `loop_dir:` prints the shadow WITH its marker line — asserted **byte-exact** against §3.6's pinned `  (local shadow: this process's own loop dir, not the hub's)`, two leading spaces included — `vendor:` matches the local run's string; the lenient-read `warning: …` lines land on stderr AHEAD of the table. Then plant a registration whose `host` alone exceeds 64 KiB and re-run. **The fixture pins where that row sorts: the oversized `host` belongs to the lexicographically LAST of the three agent ids** (e.g. `alpha`/`bravo`/`zulu`, huge host on `zulu`) — §4.4.3's rule emits a PREFIX of the sort order, so an oversized row sorting first or in the middle drops every row behind it and "every other agent still renders" would be false (that first-row case is the §10.2 producer row asserting `agents:[]`). With it sorting last: the listing still renders the other two agents, and the trailing truncation line is asserted **byte-exact** against §4.4.3's pinned `note: listing truncated by the hub at the first row that would exceed 64 rows or a 64 KiB response; later agent ids are missing.` (a notice naming only "64 rows" fails the row, since this pool has three) |
+| durable pool identity (D3/D9/E5/F1) | authorize the same pool via its realpath, a symlink spelling, a trailing-slash spelling, and — on the macOS runner — a CASE-alias spelling (`/Users/...` vs `/users/...`) → ONE marker (`pool.id` reuse), duplicate-id refusal fires across all spellings, `--list` shows one line, `--revoke` removes it |
+| `--pool`-only key-line edit (F1; `E_POOL_MISMATCH` **hub arm**, F9) | after a completed join, edit ONLY the forced command's `--pool` to another directory (leaving `--pool-id` intact) → session start reads that directory's `pool.id` and refuses → `E_POOL_MISMATCH` **error frame from the hub**, before any op and before `hello-ok`; assert the client never sees a `hello-ok` and renders the hub-arm text (§7.5). Repeat with the new directory having NO `state/pool.id` at all → same code, same arm |
+| mid-stream disconnect arms the latch (E1) | kill the connection after the first `msg` frame of a multi-message `check` → assert the LOCAL guard latch is armed, the displayed message's claim persists hub-side, and the undisplayed remainder redelivers on the next check. Repeat with the first frame being a **REDELIVERED** `msg` (hub-side `.claimed` residue, no fresh mail) → assert the latch is armed before that render too — the remote counterpart of the local `check.go:185` arming site (§3.2), and the one an emitter that only watches freshly claimed mail would miss |
+| same-hub alias rejoin (D4a) | re-join through a different Host alias for the same hub/pool → migration path: zero new keys, one authorized_keys line, pointer updated |
+| migration attribution, normal lane (B5) | launch a remote lane **exactly as the quickstart launches one** — `ac serve codex` in the joined checkout, and separately the direct `agentchute serve codex` form the quickstart prints — then attempt an alias rejoin: assert BOTH are attributed as live lanes and produce the **"still running against the old URL … stop that session first"** refusal, never the ambiguous-pid text; assert state is untouched; stop the lane and assert the rejoin then migrates. A predicate that exact-matched argv `--control-repo`/`--loop-dir` against `cfg` fails this row in the normal case |
+| migration vs pid reuse (F2, B5) | plant a stale `runner.json` whose pid is alive but belongs to (a) a non-agentchute process and (b) an `agentchute serve --control-repo ssh://<a-different-hub>/…` → alias rejoin fails CLOSED with the ambiguous-pid text in both (no kill suggestion, state untouched); after removing the stale file, the rejoin migrates |
+| migration completion is atomic (G1) | inject a crash BEFORE the `rename()` → assert `<new-id>.partial` exists, `<new-id>` does not, the old dir is intact and still authoritative, and a re-run discards the `.partial` and completes; inject a crash AFTER the rename but before the old dir is deleted → assert a re-run finishes steps 4–5 (pointer rewritten, old dir gone) with no second migration; assert the fingerprint scan never returns `<new-id>.partial` or `.locks/` (names that are not 12 lowercase hex) |
+| join/rotate/migrate mutual exclusion (G2) | run two `hub join` invocations for the same hub concurrently → exactly one proceeds, the other exits with the lock-busy refusal, and the key/version state is identical to a single run; assert the lock file lives at `~/.agentchute/hub/.locks/<hub-id>.lock` and SURVIVES a migration that deletes the old hub dir; assert migration takes both locks in ascending hub-id order (no deadlock under a reversed-pair concurrent run) |
+| key-version grammar (G3) | `.v2` vs `.v10` present → `.v10` is treated as newest (numeric, not lexicographic); a `.vold`/`.v01`/`.v2b` file → run refuses with the invalid-version text and neither adopts nor deletes it; a retired file is named `<file>.invalid.<YYYYMMDDTHHMMSSuuuuuuZ>` with its `.pub` retired under the same stamp, and two retirements within one second do not collide; the "current pubkey" every paste line prints is `readlink(keys/<id>_ed25519) + ".pub"` and there is NO `keys/<id>_ed25519.pub` symlink |
+| mux reaped across migration (G4) | run a one-shot to leave a live ControlPersist master, then migrate → assert the old dir is deleted, a best-effort `ssh -O exit` was issued, and a subsequent one-shot opens a fresh master under the NEW hub dir (never attaches to the orphan) |
+| staged rotation crash recovery (D4b/F3/H3) | inject failure at EVERY transition — between first keygen and the initial symlink (rerun adopts the orphan after the passphrase-free probe, never re-runs keygen onto it; a probe-failing orphan is retired `.invalid.<ts>` and reminted), after mint, before the remote replace, after the remote replace, mid-promote (temp symlink present, rename not done), after promote before verify (recovery verifies the ACTIVE key via hello THEN prunes; on any active-hello failure old versions survive, with the J2 class split below), after verify before cleanup (residue branch completes the prune) → re-running join/rotate converges from each; post-replace cases run with the old key already revoked |
+| wipe preserves pool identity (H1) | run `setup --reset --wipe-state` on a pool with `state/pool.id` → pool.id listed as Preserved in the dry-run and the wipe, survives, and the post-wipe rescan does NOT flag it; next session start still validates against `--pool-id` |
+| pool.id validation (J1) | plant each malformed `pool.id` in turn — oversized (>64 B), a symlink, embedded newline, quote, `` `$()` ``, whitespace, wrong length/charset → `hub authorize` (fresh-read AND loser-re-read paths) refuses `E_POOL_ID_INVALID` and authorized_keys is byte-identical before/after; `hub session` startup refuses the same before any op |
+| residue remediation by error class (J2) | post-promotion residue with the active key deauthorized → `E_UNAUTHORIZED` path prints the active-key paste line; same residue with the hub DOWN → `E_CONNECT` remediation only, no reauthorize hint; same residue with a rotated host key → `E_HOSTKEY_CHANGED` security stop only; all three preserve every version file |
+| concurrent alias first-authorize (H2) | two `hub authorize` runs racing on the same never-identified pool via different spellings → exactly one `pool.id` (exclusive create; loser adopts the winner's value), both key lines carry the SAME marker |
+| default naming (operator-directed) | `hub join --name codex` on two hosts (`tiny`, `alexs-macbook`) → distinct ids `codex-tiny` / `codex-alexs-macbook`, each machine's `agentchute identity` lists its own local-name map, `ac serve codex` resolves the joined id on each; same `--name` on two hosts SHARING a hostname → duplicate-id refusal with the hostname-collision `--as` hint; sanitization cases (`Alexs-MacBook.local`, unicode/underscore chars, empty-after-sanitize error) |
+| non-wrapper `--name` refused (S4) | `hub join <url> --name work` → refused with the §7.5 text BEFORE keygen and before any authorize call; assert no key file, no authorized_keys line, no `config.json` change. Then the supported form: `hub join <url> --as work-tiny` succeeds, and `ac --as work-tiny serve claude` launches and hellos as `work-tiny`. Also assert the negative that motivates the rule: with a hypothetically recorded `names["work"]`, `ac serve work` exits on `wrapperForToken`'s unknown-wrapper refusal (`dispatch.go:132-137`) and `agentchute serve work` tries to exec a wrapper command named `work` (`serve.go:117-129`) — neither path can ever launch that lane |
+| resolver, direct launch with env UNSET (round 10 — the quickstart's own path) | after `hub join --name codex`, in a fresh shell with NO `AGENTCHUTE_AGENT_ID`, run bare `agentchute serve codex` → `launchedWrapper` supplies the candidate, the `names` map resolves it → lane hellos clean as `codex-tiny` (this case must NOT export env — the earlier row false-greened by doing so) |
+| resolver with env exported (round 9/9b) | same join; launch BOTH ways — direct `agentchute serve codex` AND `ac serve codex` — each with `AGENTCHUTE_AGENT_ID=codex` exported (the enrollment default) → resolved to `codex-tiny` in both; guard latch, spool, and hello all use the resolved id; a candidate NOT in the map (`codex-tiny2`) passes verbatim; `send --to codex` is never remapped (no peer aliasing) |
+| hostname-change invariant (round 9b) | join as `codex-tiny`, then change the injected hostname (`tiny` → `renamed`), re-run `hub join`, `agentchute identity`, and `serve` → id, `names` map, and key files all remain `codex-tiny`; no newly derived id, key, or authorized_keys line appears |
+| name/pool-id shadowing refused, both orders (round 10) | (a) after `hub join --name codex` (⇒ `names["codex"]="codex-tiny"`), `hub join <url> --as codex` → refused before keygen/authorize with the mapping named; (b) after a verbatim `hub join --as codex`, `hub join <url> --name codex` on the same machine → refused likewise; in both cases no key, no authorize call, no config change |
+| env local-name warning (round 10) | with `AGENTCHUTE_AGENT_ID=codex` exported and `names["codex"]="codex-tiny"`, `doctor` and `hub join` each emit the §7.6 warning naming the resolution; with the env var set to an unmapped id, no warning |
+| negative cache covers SessionStart (D6) | with the hub down, hook-mode `boot` then `pending` inside 30 s ⇒ exactly one dial (one 5 s stall), both exit 0 |
+| join idempotence (G-B1) | run `hub join` twice → same pubkey fingerprint, exactly one authorized_keys line; `--rotate-key` → new key, old line replaced |
+| shell-safety refusals (C5) | authorize/join with values containing each metacharacter class (space, `'`, `"`, `` ` ``, `$()`, `;`, `\`, newline) in pool/binary paths → refused, never written; quoted-pubkey path round-trips |
+| same-path two-hosts vs true self-URL (C3) | harness "hub" and "remote" sharing one absolute pool path → join + ops work; a pointer to a hub-id with no local join config → `E_NOT_JOINED` |
+| `E_FENCED` single relaunch attempt | invalidate the lease under a bare (default-relaunch) lane → assert exactly one relaunch attempt succeeds; repeat with a rival holding the lease → assert the lane stops on `E_LEASE_HELD` |
+| pool mismatch, consistent re-point (§4.3, D3/F1; `E_POOL_MISMATCH` **client arm**, F9) | after a completed join, re-point the key line's `--pool` AND `--pool-id` together at another validly-authorized pool → session start passes (its pool.id matches) and a `hello-ok` IS returned, but the CLIENT fails closed on `hello-ok.pool12` ≠ the RECORDED pool12, rendering the client-arm text (§7.5), no op executed; a symlinked spelling of the joined pool does NOT trip either arm |
+| authorize validation (§7.1) | authorize with a non-pool path / non-executable binary path → loud refusal; `--list` shows FAIL for a hand-broken line |
+
+### 10.4 CI wiring
+
+New workflow job `hub-integration` on `ubuntu-latest` **and** `macos-latest`
+(both ship sshd; macOS uses `/usr/sbin/sshd` with a user-owned config — no
+system Remote Login needed since we run our own sshd on a high port).
+Runs 10.3 + 10.2; the seam/unit tests join the normal test job. The existing
+`gh pr checks`-before-SHIP gate applies (embedded-asset coupling rule).
+
+---
+
+## 11. Implementation plan (6 ordered merges)
+
+Collapsed from an earlier 10-PR plan (G-m7): the process weight shrinks, the
+code does not — every deliverable of the old plan appears below, and the
+conformance vectors moved INSIDE the merges they test (C7).
+
+| merge | contents | ~LOC (incl. tests) | reviewer gate | tag |
+|---|---|---|---|---|
+| M1 | **Operation seam** `internal/op`: extract §3 ops (op.Context + emitter shapes from day one); CLI calls seam in-process; zero behavior change — the existing CLI test files pass unmodified. `op` is a LEAF over `internal/loop` and imports neither `internal/cli` nor any transport package — the §7.4 dependency direction (B2), with a direction test landing here | 1,500 | deep-review (design) + codex | **v1.6.0** immediately after (seam-only; no hub claim anywhere) |
+| M2 | **Spec**: the normative Hub wire & lifecycle section + §9.1 amendments + §9.2 EXTENSIONS.md + enrollment-surface deltas (G-M4). Prose only | 350 | deep-review + codex (spec PRs always) | — |
+| M3 | **Wire codec + `hub session` + conformance**: frames/codes/handshake + fake-transport & fuzz tests (§10.2); forced-command entry, op dispatch, pinning, deadlines, streaming emitters; the §6.9 boot-**ref** pid-proof in `lease.go` (`ServeClaim.BootRef` + the two per-boot-UUID sources + the equality rule in branch (d)); **L vectors + fake-transport W vectors** | 2,450 | deep-review + codex (security-sensitive: conservative lane) | — |
+| M4 | **Client transport + remote discovery**: `ssh://` grammar, §6.8 env/discovery contract **including rule 5's launcher fix in `internal/cli/dispatch.go` + `internal/cli/shims.go`** (forward the URL, omit `--loop-dir` — B4; ships with the discovery arm, never after it), shadow dir, ssh invocation builder, one-shot ops (send/check/ack/status/gate/pending/boot/clean-owed) with the four remote `Vendor:nil` call sites (S2), spool + ambiguity handling, hook degradation + 30 s negative cache | 1,350 | codex | — |
+| M5 | **Remote serve channel + join UX**: lease lifecycle over the channel, tick, single-writer, fence-on-drop both sides, default-on relaunch (§6.7); `hub join`/`hub authorize`/doctor group/error catalog — the §7 UX exactly (auto-authorize, probe-before-pointer, key idempotence, `--list` validation, env warnings) | 2,400 | deep-review + codex (install surface → conservative lane) | — |
+| M6 | **Real-sshd integration matrix + CI (§10.3–10.4) + sshd-backed W vector runs + docs** (quickstarts, Tailscale recipe, README pointer) | 1,150 | codex | **v1.7.0** after green on ubuntu + macos |
+
+Total ≈ 9.2k LOC — larger than the synthesis's 300–600-line naive-hub sketch
+because the consensus itself priced the seam extraction at 1.5–3k and added
+the lifecycle/pinning/test release gates; this is the honest cost of "zero
+issues, very seamless". Order constraints: M1 tags v1.6.0 **before** M2 (C6
+— the spec must never describe a capability no release has); M2 before any
+hub code (Working rule 1); M3→M4→M5 sequential (each consumes the previous
+layer); M6 gates the v1.7.0 tag — no tag while any conformance vector or the
+sshd matrix is red. Reviewer-gate names follow the current team model
+(deep-review lane + mandatory codex backstop); the roster is dynamic — bind
+gates to roles at execution time, not to today's names.
+
+---
+
+## 12. Open questions
+
+Deliberately near-empty; everything the brief listed as "choose and specify"
+is decided above. Two items are recorded as *resolved-with-rationale* rather
+than open:
+
+1. **Offline hook behavior** — RESOLVED in v1 by the 30 s negative cache
+   (§7.5, G-M3): at most one 5 s ConnectTimeout per 30 s across all hooks
+   while the hub is down. The richer idea — caching pending *content*
+   (last-tick counts/entries) for offline display — stays deliberately
+   unbuilt (subtract-default: don't build a cache nobody has missed).
+2. **Windows remotes / Windows hubs** — out of scope, matching the spec's
+   existing tested-targets posture (AGENTCHUTE.md §2: native Windows is out
+   of scope for `serve`); the hub requires a Unix host for the same reasons
+   the pool already does (flock/PTY semantics).
+
+No other open questions.

--- a/proposal/ssh-hub/PLAN.md
+++ b/proposal/ssh-hub/PLAN.md
@@ -1,0 +1,3251 @@
+# SSH Hub — Implementation Plan
+
+Source of truth: [`proposal/ssh-hub/DESIGN.md`](DESIGN.md), designed against HEAD
+`1244ae4`. **Every `file:line` anchor below is `@ 1244ae4` and was re-opened and
+verified for this revision** — where a citation in round 1 was wrong, the
+corrected anchor is used and the correction is called out inline.
+
+Bar for this document: an agent assigned any single work item (WI) can finish it
+from this plan plus the named DESIGN.md sections, **without asking a question**.
+Where DESIGN.md deliberately left an implementation detail open (package/file
+names, test placement, contingencies), this plan pins it and says so (§7 lists
+every such pin).
+
+Round 2 of this plan applied the four review lanes' findings; dispositions are
+logged in [`plan-reviews-r1.md`](plan-reviews-r1.md) §"Revision log (plan round
+2)". **Round 3 applies R1–R14 of
+[`plan-reviews-r2.md`](plan-reviews-r2.md)**; dispositions are logged there
+under §"Revision log (plan round 3)".
+
+---
+
+## 1. Overview — six merges, two releases
+
+Per DESIGN.md §11 (M1–M6) and §9 (ordering, C6):
+
+```
+M1 seam ──tag v1.6.0──▶ M2 spec ──▶ M3 codec+session+vectors ──▶ M4 client ──▶ M5 channel+join ──▶ M6 sshd matrix+CI+docs ──tag v1.7.0──▶ fleet rollout
+```
+
+- **M1** (operation seam, **2,000–2,500 LOC** — re-priced from 1,500 because
+  every wrapped helper MOVES into `internal/op` rather than being called
+  in place, B1/X2) is an invisible refactor; **v1.6.0 tags immediately after it
+  and BEFORE M2** — the spec must never describe a capability no release has
+  (C6).
+- **M2** (spec, ~380 LOC prose) lands before any hub code (Working rule 1).
+  After M2, on any disagreement the spec wins over DESIGN.md.
+- **M3 → M4 → M5** are strictly sequential (each consumes the previous
+  layer). **No tag anywhere in M2–M5.**
+- **M6** gates **v1.7.0**: the real-sshd integration matrix green on
+  ubuntu-latest AND macos-latest, and every conformance L/W vector green
+  (§9.3: L + the hub-side W halves land in M3, the client-side W halves in M4,
+  the sshd-backed W runs in M6). No tag while any of those is red.
+- **45 work items, ≈ 10,700 LOC incl. tests.**
+
+Merge mechanics: every merge is one PR from an isolated worktree branch,
+gated per §3 (implementer + primary reviewer + codex always). claude-code
+(integrator) performs the merge/tag/release steps and owns the two
+release-notes items (WI-1.9, WI-6.6) only.
+
+---
+
+## 2. Work items per merge
+
+Format per item: **(a)** goal / **(b)** DESIGN.md pointers / **(c)** files /
+**(d)** fixed shapes / **(e)** tests / **(f)** done-when / **(g)** LOC.
+"Rows" = the named test rows in DESIGN.md §10.3 (or §10.1, §10.2 where stated).
+
+**Execution rules for every merge (stated once, binding everywhere):**
+
+1. **One implementer per merge.** One lane owns the merge and its PR. Where the
+   lane table (§4) names a specialist for a *specific* item (WI-3.4,
+   WI-5.3b, WI-5.3c), that item is handed over **inside** the same merge,
+   sequentially, and the merge owner integrates it. A merge is never split
+   across two concurrently-working lanes.
+2. **Items run in numeric order within a merge.** Where the ordering is
+   load-bearing it is restated on the item itself: WI-1.4 before WI-1.5 (gate
+   core before `op.Ack` — F7/X2), WI-1.6 before WI-1.7 (register before the
+   tick template), WI-4.1 before WI-4.2 (config format before discovery),
+   WI-4.2 and WI-4.3 in the SAME merge (§6.8 rule 5), WI-5.4 and WI-5.5 in the
+   SAME merge (pool.id writer + wipe preservation).
+3. **No two items run in parallel if they touch the same file.** Each item's
+   **(c)** file list is the authority; if two items you were about to start
+   share a file, run them in numeric order instead.
+
+### M1 — operation seam (`internal/op`), then tag v1.6.0
+
+Ground rules for every M1 item:
+
+- Zero behavior change. The existing CLI test files must pass **unmodified
+  EXCEPT the named list below** (§10.1) — and the list is closed: **three
+  files, three hunks, nothing else.**
+
+  | file | hunk | item | why no alias is possible |
+  |---|---|---|---|
+  | `internal/cli/send_a5_test.go` | `229-237` | WI-1.2 | the seam var moves package; a test that REASSIGNS it must name the new one |
+  | `internal/cli/send_b3_test.go` | `137-146` | WI-1.2 | same |
+  | `internal/cli/run_test.go` | `495-507` (`newPollTestRuntime`) | WI-1.7 | three `runnerRuntime` fields collapse into one `*op.Channel`; a struct literal cannot be aliased |
+
+  Everything else the move set removes from package `cli` keeps a thin
+  **alias or adapter**, pinned on its own item: `gateStatus` (type alias,
+  WI-1.4), `performRegister`/`registerOpts`/`registerResult` (adapter,
+  WI-1.6), `printStatus` (signature preserved, WI-1.4),
+  `refuseLiveRunnerCollision` (signature preserved, WI-1.7).
+- **Move-set rule (R1, widened by T2) — binding on every item in EVERY merge,
+  and the reason the list above is trustworthy.** The rule covers two
+  populations, and round 3 only ran it over the first:
+  1. every identifier an item **removes** from package `cli` — a type, a
+     function, a struct field;
+  2. every identifier an item **re-signatures** in package `cli` — same name,
+     same package, different parameters or results. A test that calls it
+     stops compiling just as surely as if it had moved, and no alias can
+     bridge a changed signature.
+
+  For each such identifier the item does ONE of two things before it may be
+  called done: leave a thin alias/adapter in `cli` (or preserve the
+  signature), or name the test file and its hunks — in the M1 table above for
+  an M1 item, or in the item's own (c) file list and (f) acceptance for a
+  later merge. The check is mechanical and is part of the item's done-when:
+  run `grep -n '\b<identifier>\b' internal/cli/*_test.go` for each moved OR
+  re-signatured identifier; a comment-only hit needs nothing, a **code** hit
+  needs an alias, an adapter, a preserved signature, or a named exception.
+
+  Run over both populations at `1244ae4`, the check yields exactly: the three
+  M1 exceptions in the table above, the four M1 aliases/adapters, and — from
+  population 2, which is where round 3's version stopped — **`resolveAgentID`
+  in M4**, whose five direct calls in `internal/cli/identity_test.go` are
+  named in WI-4.8(c). Nothing else in the plan re-signatures a `cli`
+  identifier that any `*_test.go` calls; `printStatus`
+  (`status_test.go:35,77,126,181`) and `refuseLiveRunnerCollision`
+  (`run_test.go:130,140,159,170`) are the two the plan keeps byte-identical
+  precisely so they stay off this list. **M1's own exception table is still
+  closed at three files and three hunks** — the `resolveAgentID` edit is
+  M4's, in a merge with no zero-test-edit criterion. An item that adds a new
+  move or a new signature change must re-run the check.
+- `internal/loop` signatures unchanged; `git diff --stat` shows no
+  `internal/loop` change anywhere in M1.
+- No wire code, no transport code.
+- **Every wrapped helper MOVES into `internal/op`** (B1/X2). There is no
+  "stays in cli as the loop-level worker the op wraps" option anywhere in M1 —
+  it does not compile: `internal/op` MUST NOT import `internal/cli` (§7.4
+  dependency direction, B2), so an op that called a CLI-resident helper would
+  close a cycle. The moving set, in full: `evaluateGate` (`gate.go:129-256`),
+  `finishGateClear` (`gate.go:262-268`), `gateStatus` (`gate.go:271-286`),
+  `archiveAllClaimed` (`ack.go:164-179`), `performRegister`
+  (`register.go:72-98`) with `publishRegistrationOnce` (`register.go:107-187`)
+  and `registrationLiveElsewhere` (`register.go:189-195`),
+  `hasPendingInboxMail` (`serve.go:757-763`), and the delivery seam var
+  `sendTsMessageWithCommit` (`send.go:21`).
+
+  What moves is the **implementation**; the move-set rule above still applies
+  on top of it, and neither survivor weakens B2: `gateStatus`'s declaration
+  moves and `cli` keeps a one-line **type alias** (an alias is not a second
+  type and not an import cycle), and `performRegister`'s **body** moves while
+  `cli` keeps a thin **adapter** of the same name (a caller of `internal/op`,
+  never a callee).
+- `internal/op` imports only the standard library and `internal/loop`. A
+  dependency-direction test lands in WI-1.8.
+
+**WI-1.1 — seam skeleton: context, events, errors.**
+
+(a) Create `internal/op` with the actor context, the typed event union, the
+typed error set, and the error→code function.
+
+(b) §3 conventions (all three bullets); §4.4.2 (the amended error-code registry
+— codes only, no wire yet).
+
+(c) NEW `internal/op/op.go`, `internal/op/event.go`, `internal/op/errors.go`.
+
+(d) Fixed shapes:
+
+- `type Context struct { ActorID string }`
+- `type Event struct { Message *MessageEvent; Note *NoteEvent; Owed *OwedEvent; Ack *AckItemEvent }`
+  — exactly one arm non-nil, emitted in production order.
+- `MessageEvent{Filename, Sender, Stamp string; Redelivered, ReplyRequired bool; ReplyRef string; Body []byte}`
+- `NoteEvent{Level, Msg string}` — **`Level` is one of exactly `"warn"` or
+  `"info"`** (F4). Routing, pinned: `warn` → **stderr**, rendered
+  `warning: <Msg>`; `info` → **stdout**, rendered `<Msg>`. `Msg` NEVER carries
+  its own level prefix — the renderer adds it, so the wire and the local path
+  cannot drift. The wire `note.level` field (§4.3) uses this same two-value
+  vocabulary. A third level is a spec change (M2), never an implementer's
+  choice. **DESIGN §4.3's "Hub→client `note` frames" bullet now carries BOTH
+  arms** — two example frames, the "the level IS the stream" rule, and the
+  three `check` `info` lines it is written against (a round-3 note said the
+  bullet showed only `warn`; DESIGN has since been amended and that note is
+  stale). The `info`→stdout arm is load-bearing (WI-1.3), so WI-2.1's spec
+  copy MUST reproduce both arms and their streams.
+- `OwedEvent{To, From string; Seq uint64; Stamp, Suffix string; By, RecordedAt time.Time; Ref string}`
+  — the full `loop.OwedEntry` fields per E4 (`internal/loop/owed.go:114-122`).
+- `AckItemEvent{Filename, ArchivePath string}`
+- **The M1 op-layer sentinel set — exactly eight, no more** (F6). Four are
+  **re-exports** (`var X = loop.X` aliases, NOT redeclared sentinels, so
+  `errors.Is` matches across both packages and a `loop` error travelling
+  through `op` still satisfies the CLI's existing checks); four are new:
+
+  | sentinel | origin | code |
+  |---|---|---|
+  | `op.ErrNotRegistered` | NEW | `E_NOT_REGISTERED` |
+  | `op.ErrRecipientUnknown` | re-export of `loop.ErrRecipientUnknown` (`seq.go:191`) | `E_RECIPIENT_UNKNOWN` |
+  | `op.ErrRecipientUnreadable` | re-export of `loop.ErrRecipientUnreadable` (`seq.go:206`) | `E_RECIPIENT_UNREADABLE` |
+  | `op.ErrRecipientStale` | NEW — the **preflight** arm (C29b, `seq.go:240`) | `E_RECIPIENT_STALE` |
+  | `op.ErrRecipientRacing` | NEW — the **under-lock** arm (C29c, `seq.go:253`) | `E_RECIPIENT_RACING` |
+  | `op.ErrFenced` | re-export of `loop.ErrFenced` (`lease.go:51`) | `E_FENCED` |
+  | `op.ErrLeaseHeld` | re-export of `loop.ErrLeaseHeld` (`lease.go:46`) | `E_LEASE_HELD` |
+  | `op.ErrOrder` | NEW — `Channel.Tick` before `Channel.Register` (§3.4/§6.1) | `E_ORDER` |
+
+  `ErrRecipientStale` and `ErrRecipientRacing` both **wrap** the underlying
+  `*loop.ErrRecipientStale` value, reachable via `errors.As`, because the CLI's
+  C29 renderer (`send.go:347-416`) needs its fields. The op sentinel records
+  only WHICH raise site produced it: today the CLI classifies the two by
+  position in `cmdSend`, but the hub must emit two distinct codes for them
+  (§4.4.2), so the distinction becomes explicit at the seam.
+- **`func CodeFor(err error) string`** — a FUNCTION, not a table (F6): an
+  `errors.Is` switch over the eight sentinels with a **default arm returning
+  `"E_HUB_IO"`**, and `CodeFor(nil) == ""`. `loop.ErrInboxMissing`
+  (`inbox.go:111`) has no code of its own and takes the default arm
+  deliberately.
+- **The three code sets, with the arithmetic pinned (R3).** §4.4.2's hub-side
+  registry is **17 rows**, partitioned with no gap and no duplicate:
+  - **op-owned outputs: 9** — the eight sentinels above **plus** the default
+    `E_HUB_IO`. `E_ORDER` is op-owned (it is a sentinel), so M3 must not
+    re-add it.
+  - **M3 session/codec: 8** — `E_VERSION`, `E_IDENTITY`, `E_POOL_NOT_FOUND`,
+    `E_POOL_ID_INVALID`, `E_POOL_MISMATCH` **hub arm**, `E_MALFORMED_FRAME`,
+    `E_TOO_LARGE`, `E_UNSUPPORTED`. **9 + 8 = 17.**
+  - **client-only: 9**, landing in M4 — `E_CONNECT`, `E_UNAUTHORIZED`,
+    `E_HOSTKEY_CHANGED`, `E_CHANNEL_LOST`, `E_SEND_UNKNOWN`,
+    `E_HELLO_TIMEOUT`, `E_HUB_NO_BINARY`, `E_NOT_JOINED`, `E_NO_SSH`. This
+    list is disjoint from the 17.
+  - **`E_POOL_MISMATCH` is the one code with TWO emitters** (§4.4.2 as
+    amended, F9/X1) and is **not** a client-only-list member: it is modelled
+    as an explicit **both-sides classification** — hub arm at session start
+    (M3, WI-3.3a), client arm after `hello-ok` (M4). Neither arm is an
+    op-layer sentinel. Requiring the client list to be disjoint from the hub
+    registry is only sound because this code is classified rather than
+    listed twice (WI-3.1a's completeness test asserts exactly that).
+- **Not-registered rendered text — CORRECTION to the round-1 finding.** The two
+  CLI sites are **not** byte-identical today: `send.go:145` reads
+  `sender %q is not registered. Run ...` and `check.go:120` reads
+  `agent %q is not registered. Run ...` (and `status.go:62` matches
+  `check.go`) — identical after the first word. So the rule is ONE sentinel,
+  TWO renderers: each CLI site keeps its own wording verbatim, formatted from
+  `Context.ActorID`, and neither string changes by a byte. DESIGN carries
+  both texts and this rule (§4.4.2's `E_NOT_REGISTERED` registry row — the one
+  naming `send.go:145`, `check.go:120` and `status.go:62` — plus its §7.5
+  catalog entry), so the remote `send` path renders "sender" too — there is no
+  local/remote divergence to flag.
+
+(e) Unit tests: event-union invariant (exactly one arm non-nil) for every
+constructor; **`CodeFor` completeness** — a table over all eight sentinels, a
+`fmt.Errorf("%w", …)`-wrapped sentinel, a bare I/O error (⇒ `E_HUB_IO`), and
+`nil` (⇒ `""`); plus a list test asserting the exported sentinel names equal a
+literal expected list, so adding a ninth sentinel without a code arm FAILS.
+
+(f) Done-when: the package compiles standalone against only stdlib +
+`internal/loop`; `CodeFor` has no reachable path returning `""` for a non-nil
+error; the completeness test enumerates all eight plus the default.
+
+(g) ~190 LOC.
+
+**WI-1.2 — `op.Send` (and the delivery test seam).**
+
+(a) Extract send's validate-and-mutate into
+`op.Send(cfg *loop.Config, ctx Context, req SendReq) (SendResp, error)`.
+
+(b) §3.1; §4.5.3 (the spool stays CLI-side).
+
+(c) NEW `internal/op/send.go`; MODIFY `internal/cli/send.go`.
+
+- **Moves out of `cli`**: the sender-enrollment stat (`send.go:141-148`), the
+  recipient preflight (`send.go:158-171`), the delivery call (`send.go:242`),
+  and the package-level seam var `sendTsMessageWithCommit` (`send.go:21`,
+  today's sole production call site is `send.go:242`).
+- **Stays in `cli`**: compose (`send.go:174-224`), the spool
+  (`send.go:418-477`), the C29 renderer (`send.go:347-416`),
+  `rejectLoopStateBodyFile` (`send.go:600-633`), `sendStdin` (`send.go:23`),
+  `afterSendPreflightHook` (`send.go:19`).
+
+(d) `SendReq{To string; Content []byte; Ask bool; ReplyBy time.Duration; ServeToken string}`
+— **no `From` field**; wraps `loop.CheckRecipientReachability`
+(`internal/loop/seq.go:226`), the delivery seam, and `loop.RecordOwed`
+(`internal/loop/owed.go:202`).
+`SendResp{Filename, Ref string; Committed bool; DurabilityNote string}`.
+
+**The test seam (F1), pinned.** `internal/op` declares an **exported**
+package-level var:
+
+```go
+var SendTsMessageWithCommit = loop.SendTsMessageWithCommit
+```
+
+(same signature, same single production call site), and
+`internal/cli/send.go:21`'s unexported var is deleted in the same commit. It is
+**exported** deliberately: two existing tests in package `cli` reassign the
+current var, and an unexported one in `op` would leave them nothing to patch.
+An exported var needs no test-only setter function and no test relocation.
+
+**Named exception to the zero-test-edit rule** (rows 1–2 of the M1 preamble's
+closed table). Exactly two existing test files may be edited **by this item**,
+and only to retarget that variable:
+
+- `internal/cli/send_a5_test.go:229-237` —
+  `TestSendPostLinkSyncFailureIsPartialSuccess` (decl `:227`): `:229` saves the
+  original, `:230-236` installs a wrapper that DELEGATES to the real
+  implementation and on success returns `id, true, errors.New("forced post-link
+  sync failure")`, `:237` restores by defer.
+- `internal/cli/send_b3_test.go:137-146` — `TestSendFreshButRacingText`
+  (decl `:136`): `:137` saves, `:138-145` installs a NON-delegating stub
+  returning `loop.TsID{}, false, &loop.ErrRecipientStale{…}`, `:146` restores.
+
+Both stay where they are, so their surrounding assertions keep exercising the
+real `cmdSend` rendering. **No other existing `*_test.go` may be touched in
+M1.**
+
+(e) §10.1: A5 preflight ordering, C29 classification, C4 collision retry,
+partial-success (linked-but-sync-failed) — ported to seam level, driven through
+BOTH `op.Context` constructors.
+
+(f) Done-when: `tools/test.sh` green; `git diff` on `send_a5_test.go` and
+`send_b3_test.go` shows ONLY the seam-retarget hunks named above (four lines
+each, no other hunk); every other `*_test.go` unmodified.
+
+(g) ~260 LOC.
+
+**WI-1.3 — `op.Claim` (streaming).**
+
+(a) Extract check's state half into
+`op.Claim(cfg, ctx, ClaimReq{Limit int; NoArchive bool}, emit func(Event) error) (ClaimSummary, error)`.
+
+(b) §3.2 (exact order: residue → quarantine → per-message validate/claim/emit →
+owed discharge → expired-owed events); §4.5.2.
+
+(c) NEW `internal/op/claim.go`; MODIFY `internal/cli/check.go`.
+
+- The loop body `check.go:125-283` becomes the local emit renderer.
+- **`displayConsumed` (`check.go:312-334`) SPLITS** (F5 — the round-1 item
+  contradicted itself here): the **ClearOwed half** (`check.go:321-331`, plus
+  its two `warning: failed to clear owed obligation` sites at `:324` and `:328`)
+  moves into `op.Claim` and is **suppressed under `NoArchive`**, matching
+  today's read-only variant `displayConsumedReadOnly` (`check.go:338-341`),
+  which never discharges; the **print half** (`printConsumedBody` call at
+  `:313`, `printReplyRefIfRequired` at `:333`) stays as the renderer.
+- **CORRECTION to the round-1 "stays" range**: it is not `335-408` (`:335` is
+  blank). What stays CLI-side unchanged is `displayConsumedReadOnly`
+  (`338-341`), `printConsumedBody` (`348-364`), `sanitizeControlBytes`
+  (`374-388`), and `printReplyRefIfRequired` (`393-408`).
+- Latch arming stays CLI-side and remains **per-first-message before display**
+  (E1): `latchArmed` (`check.go:168`), the `setLatch` closure (`169-175`), its
+  three call sites (`:185` redelivered residue, `:243` `--no-archive` path,
+  `:256` post-claim), and `maybeSetGuardLatch` (`292-300`).
+
+(d) `ClaimSummary{Claimed, Redelivered, Quarantined, OwedExpired int}` — counts
+only (D2), exactly DESIGN §3.2's four fields, **no additions**.
+
+**The three load-bearing stdout lines are `Level:"info"` NoteEvents emitted at
+their production points (R2 — this replaces round 2's `Listed`/`Remaining`
+summary fields).** A summary field is read *after* the stream ends, so a
+renderer driven from it prints these lines AFTER the expired-owed lines that
+`op.Claim` emits inside the op — a silent reordering inside the merge whose
+whole claim is zero behavior change, and one `check_age_owed_test.go:196-224`
+would not catch (it matches with `strings.Contains`). Emitted as notes, the
+order survives the local path and the wire alike. `Msg` carries the line
+verbatim, with no level prefix (the renderer adds none for `info`):
+
+| production point | guard, verbatim | `Msg` |
+|---|---|---|
+| after the redelivered-residue loop, **before** the claim loop (`check.go:200-202`) | `len(msgs) == 0 && len(redelivered) == 0` | `(inbox empty)` |
+| at the limit break **inside** the claim loop (`check.go:206-208`) | `limit > 0 && claimed >= limit` | `(reached limit of %d; %d more pending)` with `limit`, `len(msgs)-claimed` |
+| after the claim loop, **before** the owed/expired section (`check.go:261-263`) | `!noArchive && claimed > 0` | `check.go:262`'s string verbatim (`note: messages CLAIMED …`) |
+
+Note the second row is why a count cannot substitute: the line is produced
+mid-stream, between two `MessageEvent`s. The third row's text already begins
+with `note: ` — that is its own wording (`check.go:262`), not a level prefix,
+and it is emitted byte-for-byte.
+
+`NoteEvent`s: `op.Claim` emits `Level:"warn"` for every stderr warning site it
+now owns — `check.go:141`, `144-145`, `148`+`150`, `221-222`, `228`,
+`232-233`, `276`, and the two ClearOwed sites `324`/`328` — with `Msg` carrying
+the text WITHOUT the `warning: ` prefix. Its `Level:"info"` notes are **exactly
+the three rows above and nothing else**. `check.go:298` (`failed to set guard
+latch`) stays CLI-side: the latch is local (§6.6). The stale-obligation stdout
+print (`check.go:278-279`) and the `clean --owed` hint (`check.go:279-281`) are
+rendered from `OwedEvent`s + `OwedExpired`, not from notes.
+
+Wraps `inbox.go:121,388,58,328`, `message.go:105`, `owed.go:241,149,273`,
+`registration.go:34` (+ the 4 MiB cap `registration.go:19`).
+
+(e) §10.1: claim idempotence, redelivery, quarantine, owed discharge; the
+emitter memory test (≤1 body held); event ORDER test (a note lands between the
+messages it occurred between); **a byte-for-byte stdout/stderr golden test for
+the three `info` lines above**, in the empty, limited, and all-quarantined
+shapes — asserting **position, not just presence**: the limit line lands
+between two message renders, and the CLAIMED line lands BEFORE the
+stale-obligation lines (the ordering a summary-derived renderer inverts).
+
+(f) Done-when: `check_a6_test.go`, `check_age_owed_test.go`,
+`consume_boundary_test.go`, `n3_sanitize_test.go` green unmodified.
+
+(g) ~320 LOC.
+
+**WI-1.4 — `op.Status` / `op.Gate` / `op.Pending` / `op.CleanOwed` (the read
+side + the gate core).**
+
+> **Ordering (F7/X2): this item is a PREREQUISITE of WI-1.5.** `op.Ack` calls
+> `finishGateClear`; leaving `evaluateGate` in `internal/cli` while `op.Ack`
+> calls it is an import cycle, because `internal/op` must not import
+> `internal/cli`. The gate core moves here, first.
+
+(a) The read-side ops + the owed prune, with the gate evaluation core moved
+into `internal/op`.
+
+(b) §3.6 (Pending: `MessageEvent`s with `Body` only under `ShowBody`;
+`OwedEvent`s full-entry; `NeedsBoot` hub-derived, E4, `pending.go:77-97`);
+§4.4.3 (the `status-ok` framing cap — applied by the WIRE producer, never by
+this op; see (d)).
+
+(c) NEW `internal/op/status.go`, `gate.go`, `pending.go`, `cleanowed.go`;
+MODIFY `internal/cli/status.go`, `gate.go`, `pending.go`, `clean.go`.
+
+`internal/cli/gate.go` keeps the `gateStatus` **type alias** (see (d)) and only
+renderers over `op.GateResp`: `cmdGate` (`:42`), `evaluateGatePhase` (`:307`),
+`emitGateText` (`:346`), `emitGateJSON` (`:363`), and the
+codex-Stop/blocked-stderr emitters. `internal/cli/status.go` keeps
+`printStatus`, `registrationStatusLabel`, `countInbox` and the formatters
+unchanged; only `readRegistrations` (`status.go:84-95`) moves, since its
+`ReadRegistrationsLenient` wrap is the op's read half (the move-set grep is
+clean for it — no `*_test.go` names it). `internal/cli/clean.go` keeps
+`cleanOwedResult`,
+`emitCleanOwedText`, `emitCleanJSON` and the whole `--mailbox` half.
+`internal/cli/pending.go` keeps the boot hint (`pending.go:182`) and the
+`--fail-if-any` exit-2 rule (`pending.go:167-169`).
+
+(d) **Fixed shapes (F8 — the round-1 item had no fixed-shapes clause at all;
+M3 serializes these verbatim):**
+
+- `GateReq{Phase string; RequireConfirm, AckStaleReg bool}` — exactly
+  `evaluateGate`'s parameters (`gate.go:129`) minus `cfg`/`agentID`/`now`:
+  `cfg` is the op's first argument, `agentID` is `Context.ActorID`, and `now`
+  is HUB-minted (§2 hub clock) and is **never** a wire field.
+- `GateResp` = the `gateStatus` struct's fields verbatim (`gate.go:271-286`),
+  same field names, same JSON tags. `internal/cli` renders `op.GateResp`, and
+  `turnEndJSON` (`turn_end.go:197-200`) embeds it — so `gate --json` and
+  `turn-end --json` stay byte-identical.
+  - **Alias, not deletion (R1a).** `internal/cli` keeps a one-line
+    `type gateStatus = op.GateResp` — an **alias**, never a defined type, so
+    `var got gateStatus` + `json.Unmarshal` still compiles and still names the
+    same struct. Eleven existing code sites depend on it:
+    `consume_boundary_test.go:257`, `gate_test.go:207,221,372`,
+    `enforced_enrollment_test.go:106,128`,
+    `turn_end_test.go:38,87,126,236,494` (plus a comment at
+    `turn_end_test.go:249`, which needs nothing). Every field is exported, so
+    an alias bridges all eleven with zero test edits.
+- `StatusReq{}` — no fields; `status` is pool-wide and read-only.
+- **`op.Status` STREAMS its warnings**, so its signature matches `op.Claim`'s
+  and `op.Pending`'s:
+  `op.Status(cfg, ctx, StatusReq{}, emit func(Event) error) (StatusResp, error)`.
+- `StatusResp{Agents []StatusAgent; Truncated bool; Now time.Time}`:
+  - `Agents` carries **every** row the pool has, sorted exactly as today by
+    `loop.RegistrationsByAgentID` (`status.go:111`). **The op never truncates
+    and always returns `Truncated:false`.** BOTH framing budgets — the 64 KiB
+    encoded-line budget and the 64-row cap — are wire-FRAMING concerns and
+    live in the wire producer: it appends rows in sort order while both hold
+    and sets `truncated:true` when either excluded a row, as it writes
+    `status-ok` (dispatch in WI-3.3a, shape and full rule in WI-3.1a, source
+    of truth §4.4.3). The sort stays in the op, so truncation is
+    deterministic wherever it is applied.
+    **Why the cap moved out (T1a).** Round 3 put it inside the op "so local
+    and remote agree by construction". That reasoning inverts: §4.4.3 is a
+    FRAMING rule downstream of the 64 KiB line cap, and in local mode there is
+    no line — so the only thing capping in-op buys is a silent row drop in the
+    one mode that never needed one. `printStatus` renders no truncation notice
+    of any kind (`status.go:97-139`), so a >64-row pool would lose rows with
+    nothing on stdout or stderr saying so — a behavior change inside the merge
+    whose sole acceptance criterion is that it has none, and whose release
+    notes say "no behavior change" (WI-1.9(d)). Local and remote diverging
+    here is not a defect to prevent; it is the fact `truncated:true` exists to
+    report.
+  - **`Now time.Time`** — the hub's evaluation instant. The AGE column and the
+    STATUS label are both derived from one clock; on a remote lane that clock
+    must be the HUB's, or a skewed client renders a different age than the
+    pool's own truth. (Same reason `hello-ok` carries `hub_time`, §4.3.)
+  - **There is NO `Warnings []string` field (T1c).** R4 was right that
+    `ReadRegistrationsLenient`'s warnings need a channel (`cmdStatus` prints
+    each to stderr as `warning: %s` **before** the table, `status.go:67-70`,
+    each entry an `e.Error()` string, `status.go:91-92`); it picked the wrong
+    one. That list is **unbounded and the 64-row cap does not bound it**: the
+    lenient read appends one error per malformed `*.md` under the agents dir
+    (`registration.go:522-549`), and a malformed file is not a registration,
+    so the 2–~10-agent pool-scale assumption says nothing about how many there
+    can be — a directory holding a thousand junk `.md` files yields a thousand
+    strings, each carrying a path. That is exactly §4.4.3's "unbounded lists
+    never ride inside one control frame".
+    **So they stream as `note` frames**, which is where the plan already
+    routes notes (WI-1.3, §4.4.3): the op emits one
+    `NoteEvent{Level:"warn", Msg: e.Error()}` per read error, in
+    `ReadRegistrationsLenient`'s own order, **before** it returns. The pinned
+    `warn` routing (WI-1.1(d)) renders each as `warning: %s` on **stderr**,
+    and a note necessarily precedes the terminal response — so both the bytes
+    and their position (before the table) are today's, by construction, in
+    local and remote mode alike. A cap-and-truncate contract was the
+    alternative and is rejected: it would need its own second truncation flag,
+    and its failure mode is a corrupt row going silent, which is the precise
+    defect R4 opened.
+- `StatusAgent{AgentID string; LastSeen time.Time; Host string; ProtocolVersion int; InboxDepth int; Status string}`
+  — one entry per registration row, and a **status-specific view: the row IS
+  the view; there is no nested `Reg RegistrationView` (T1b)**. Round 3 put the
+  full eight-field `RegistrationView` here, which puts `Body` on a 64 KiB
+  control line — a bio bounded only by `loop.MaxRegistrationBytes` (1 MiB,
+  `registration.go:18`), so one long bio makes `status-ok` unframable — and
+  contradicts DESIGN §4.4.3, which already says status rows carry no body.
+  Dropping `Body` removes the 1 MiB field; it does **not** make the row a
+  bounded shape — `Host` is free-form and length-unbounded
+  (`registration.go:217-241`, `register.go:206`), which is why the wire
+  producer budgets ENCODED BYTES and not just rows (WI-3.1a(d), §4.4.3). The
+  field set is exactly what the `status` command renders, checked against
+  `printStatus` line by line:
+
+  | field | JSON | what renders it |
+  |---|---|---|
+  | `AgentID` | `agent_id` | the AGENT column (`status.go:115`); also the sort key (`:111`) and the protocol-warning subject (`:242-247`) |
+  | `LastSeen` | `last_seen` | LAST_SEEN via `formatMaybeTime` (`:118`) **and** AGE via `formatAge(now, …)` (`:119`) |
+  | `Host` | `host` | HOST via `formatDash` (`:120`) |
+  | `ProtocolVersion` | `v` | PROTO via `formatProtocolVersion` (`:121`) and the `PROTOCOL WARNINGS:` block (`:126-138`, `:242-247`) |
+  | `InboxDepth` | `inbox_depth` | INBOX = `countInbox(cfg.AgentInboxDir(id))` (`:113,165`) — hub-derived |
+  | `Status` | `status` | STATUS = `registrationStatusLabel`'s verdict (`:151-163`), `lease-held` / `stale-would-sweep` / `fresh` — hub-derived, because it reads the serve claim and the pool's `StaleAfter` |
+
+  The four registration-sourced fields keep the frontmatter's own key names
+  (`agent_id`, `last_seen`, `host`, `v`) — the same tags `RegistrationView`
+  uses for them (see WI-1.6(d)), so one field is never spelled two ways
+  across the two views.
+  **Nothing else is on the row.** `Vendor`, `ControlRepo`, `WorkingRepos` and
+  `Body` are never rendered by `status`: the header's `vendor:` line is
+  `cfg.Vendor`, the local config's, not any row's (`status.go:100`). Neither
+  is the claim: round 3 carried a
+  `Claim *StatusClaim{Host, PID, StartedAt, LastSeen, Stale}` and **no
+  renderer reads it** — `registrationStatusLabel` consumes the claim hub-side
+  (`status.go:152-154`) and the only fact that survives into the output is the
+  `Status` label above. It is cut for the same reason `ServeClaim.ServeToken`
+  (`lease.go:59`) is excluded: `status` is pool-visible to every member, so
+  the row carries what `status` prints and nothing more. Re-add it in the
+  merge that ships a renderer for it, never before.
+  - **`printStatus` keeps its exact signature**
+    (`printStatus(w io.Writer, cfg *loop.Config, regs map[string]*loop.Registration, now time.Time)`)
+    — four existing call sites depend on it (`status_test.go:35,77,126,181`).
+    M1 wires `cmdStatus` as: `op.Status` with an emitter that prints each
+    `warn` note as `warning: %s` to stderr → rebuild the
+    `map[string]*loop.Registration` from `Agents` → `printStatus` unchanged,
+    which re-derives the label and the depth locally exactly as today. The
+    rebuilt registrations are **partial by design** — only `AgentID`,
+    `LastSeen`, `Host`, `ProtocolVersion` are set — and that is sufficient by
+    inspection: those are the only fields `printStatus`,
+    `registrationStatusLabel` and `protocolVersionWarning` read
+    (`status.go:111-138,151-163,242-247`). A partially populated
+    `loop.Registration` never escapes `cmdStatus`.
+    `InboxDepth`/`Status`/`Now` exist for the WIRE consumer and are **not**
+    read by the local renderer in M1; **M4 (WI-4.5) is where the renderer
+    switches to them**, because a remote client can neither stat the hub's
+    inboxes nor read its claims. An M1 implementer who "helpfully" retargets
+    the renderer breaks four tests for no gain.
+- `PendingReq{ShowBody bool}` /
+  `PendingSummary{Unread, Owed, Malformed int; NeedsBoot bool}`.
+- **`CleanOwedReq{Apply bool}` / `CleanOwedResp{Agent string; Pruned []string; Applied bool}`
+  (R4)** — `cleanOwedResult` verbatim (`clean.go:99-103`), with its shipped
+  JSON tags `agent` / `pruned` / `applied`:
+  - The request field is `Apply`, mirroring the shipped `--yes` flag's polarity
+    exactly (`clean.go:41,87`). An inverted `DryRun` is a defect waiting to
+    happen. `--json` is a render flag and stays CLI-side; `--as`,
+    `--control-repo`, `--loop-dir` are resolution flags, not op inputs;
+    `--vendor` is accepted by `cmdClean` but unused on the `--owed` path.
+  - **Counts alone lose behavior**: the text output prints one line per ref
+    (`clean.go:189-192`) and `--json` emits the ref list
+    (`clean_test.go:391-412` decodes into `cleanOwedResult` and asserts
+    `Agent`, `len(Pruned)`, `Applied`). Returning `{Pruned, Remaining int}`
+    fails that test.
+  - `Pruned` is initialized to `[]string{}`, never nil (`clean.go:121`), so
+    `--json` renders `[]` and not `null` — load-bearing for byte-identical
+    JSON.
+  - `Applied` follows `clean.go:171`: `apply && len(Pruned) > 0`.
+  - `cleanOwedResult` itself **stays in `internal/cli`** as the render/JSON
+    struct (`clean_test.go:407` names it), populated from the response.
+    Nothing prints a "remaining" count today; the field is dropped.
+
+(e) §10.1 ports; Pending event-stream tests (many owed entries; `ShowBody` body
+present/absent); a golden test that `gate --json` and `turn-end --json` are
+byte-identical before and after the move; **a corrupt-row test asserting
+`status` still prints its `warning: …` line to stderr before the table** (now
+via the `warn` note stream added in (d) — assert the STREAM ORDER too: the
+note is emitted before `op.Status` returns, so the warning cannot land after
+the table); **a >64-row pool asserting the op returns every row with
+`Truncated:false` and that local `status` prints all of them** (the
+regression T1a exists to prevent — it must FAIL against an in-op cap);
+**a pool holding one valid registration whose `host` alone exceeds 64 KiB,
+asserting the op returns it intact with `Truncated:false` and that local
+`status` prints it** (the local mirror of the same rule: the byte budget is
+framing-only, so it must not leak into the op — the row that the wire
+producer will drop is the row local mode must still render); and
+**a `clean --owed --json` golden with one
+expired obligation and with none**, proving the ref list and the `[]`-not-`null`
+empty shape survive.
+
+(f) Done-when: `gate_test.go`, `status_test.go`, `pending_test.go`,
+`pending_stale_age_test.go`, `clean_test.go`, `turn_end_test.go` green
+unmodified.
+
+(g) ~280 LOC.
+
+**WI-1.5 — `op.Ack`.** *(Prerequisite: WI-1.4.)*
+
+(a) `op.Ack(cfg, ctx, AckReq{}, emit func(Event) error) (AckSummary, error)`.
+
+(b) §3.3.
+
+(c) NEW `internal/op/ack.go`; MODIFY `internal/cli/ack.go` (the
+`archiveAllClaimed` body MOVES from `ack.go:164-179`), `internal/cli/turn_end.go`
+(its call at `turn_end.go:154` routes through the op).
+
+Stays CLI-side: `--quiet`/exit-2 (`ack.go:20-55`), the guarded-session denial
+(`ack.go:105-109` — it reads the **local** latch), the `ackItem`/`ackResult`
+render structs (`ack.go:199-210`), `emitAckText` (`183-196`), `emitAckJSON`
+(`:212`).
+
+(d) `AckSummary{Acked int; GateClear bool; BlockReasons []string}`; wraps
+`loop.ArchiveMessage` (`inbox.go:257`, idempotent EEXIST/SameFile handling
+included) and `finishGateClear` — now `internal/op`'s, from WI-1.4.
+
+(e) §10.1: ack idempotence (re-ack benign, `inbox.go:269-292`); emit-error
+mid-stream leaves committed items committed.
+
+(f) Done-when: `ack_test.go`, `turn_end_test.go`, `b1_convergence_test.go`
+green unmodified.
+
+(g) ~180 LOC.
+
+**WI-1.6 — `op.Register`.**
+
+(a) Registration (+announce) behind the seam with the D1 field semantics.
+
+(b) §3.5 (the full three-shape contract).
+
+(c) NEW `internal/op/register.go`; MODIFY `internal/cli/register.go`,
+`internal/cli/boot.go`, `internal/cli/self_check.go`,
+`internal/cli/turn_end.go`.
+
+**The write path moves into `internal/op`** (B1 — no "implementer's choice"
+here): the body of `performRegister` (`register.go:72-98` — CORRECTION: the
+round-1 citation `35-189` conflated the struct with two other functions),
+`publishRegistrationOnce` (`register.go:107-187`), and
+`registrationLiveElsewhere` (`register.go:189-195`).
+
+**`performRegister` stays in `cli` as a thin ADAPTER (R1b), and so do
+`registerOpts`/`registerResult`.** Thirteen existing calls take the current
+signature — `register_test.go:34,58,100,131,165,234,243,270,279,306,336,365,369`
+— plus two bare `registerOpts` literals (`:33`, `:57`); and `:365` passes
+`Bio:"old", BioProvided:true`, fields the reshaped request does not have, so
+**no type alias can bridge it**. The adapter is:
+
+```go
+func performRegister(cfg *loop.Config, opts registerOpts, now time.Time) (*registerResult, error)
+```
+
+— unchanged signature, unchanged struct definitions at `register.go:35-44` and
+`54-61` — which (1) resolves the host when `!opts.HostProvided`
+(`register.go:80-87`'s `os.Hostname()` substitution and its warning text move
+HERE, client-side, verbatim), (2) maps `Bio`/`BioProvided` to the `*string`
+presence pointer, (3) calls `op.Register`, and (4) maps the response back into
+`*registerResult`. It is a **caller** of `internal/op`, never a callee, so no
+cycle. The four production call sites (`boot.go:89`, `register.go:262`,
+`self_check.go:128`, `serve.go:536`) keep calling it and are unchanged. Tests
+that only mention the name in a comment need nothing
+(`hooks_sessionstart_test.go:11`, `turn_end_test.go:512`, `clean_test.go:476`,
+`register_test.go:32,52`).
+
+`internal/cli/register.go` keeps `cmdRegister` (`197-296`) as flag parsing +
+rendering, including the `fs.Visit` presence capture (`226-233`).
+
+**S1 — `internal/cli/self_check.go` is in scope.** `selfRepairRegistration`
+(`self_check.go:117-133`) is the step-0 repair that `turn-end` drives
+(`turn_end.go:120`) and that `self-check` is (`self_check.go:71`). It routes
+through the op, and its "return a non-empty id even when the registration WRITE
+failed" contract (`self_check.go:129-131`) must survive verbatim, because
+`turn_end.go:121-123` aborts only on an EMPTY id and `turn_end.go:126` warns
+and continues otherwise.
+
+(d) `RegisterReq{Vendor *string; Host string; Bio *string; WorkingRepos []string; Announce bool; Sweep bool; ServeToken string}`
+— **exactly DESIGN §3.5's field list; there is no `HostProvided` (R5)**:
+
+- `Host` CLIENT-resolved (D1a), a plain string with **no presence flag**.
+  `register.go:80-87`'s `os.Hostname()` substitution must never run for a
+  remote actor — a nil/absent host resolved hub-side would record the HUB's
+  hostname for every remote self-check — so the resolution happens in the
+  caller (the `performRegister` adapter above; on the wire, the client) and
+  the hub maps what it receives to `HostProvided:true` unconditionally. This
+  is behavior-preserving in every arm: `--host` given ⇒ that value, explicit
+  empty stays empty; `--host` absent ⇒ the caller's own `os.Hostname()`, i.e.
+  today's value, and today's warning text on failure. Round 2 added a
+  `HostProvided` field, which DESIGN deliberately does not have; it is
+  removed, because carrying `false` over the wire is precisely the "hub
+  substitutes its own hostname" bug the flag was meant to prevent.
+- `Vendor` nil ⇒ hub-resolved (D1b). **`resolveAgentVendor` itself is
+  UNCHANGED in M1** — it lives at `internal/cli/identity.go:72-83`
+  (CORRECTION: the round-1 citation `57-82` was `vendorForAgentID`, which is
+  `identity.go:57-70`). Only its four call sites branch, and that branch lands
+  in **M4** (S2), not here.
+- `Bio` pointer presence (`register.go:144` merge-preserve, `147-149` override,
+  `226-233` capture).
+- **`Sweep` — the boot-only discriminator (T3).** Round 3 had the op wrap
+  boot's sweep with no request field to say when, which is not expressible:
+  the shipped sweep runs in exactly two places, `cmdBoot` right after its own
+  registration (`boot.go:99-101`, C11) and the runner's throttled tick
+  (`serve.go:640`, which is `op.Tick`'s, WI-1.7 — not this op's). Always
+  sweeping would add a pool-wide sweep to `register`, `self-check`,
+  `turn-end`'s step-0 repair and `serve`'s startup registration; never
+  sweeping would leave a remote `boot` with no hub-side trigger, because a
+  remote lane's local sweep walks the mail-free shadow. So:
+  - `Sweep:true` ⇒ the op runs `loop.SweepStaleRegistrations(cfg,
+    ctx.ActorID, now)` (`sweep.go:60`) **after** the registration write, in
+    boot's order, and on failure appends
+    `fmt.Sprintf("sweep stale registrations: %v", err)` to `RegisterResp.Warnings`
+    — `boot.go:100`'s string verbatim, with no `agentchute serve: ` prefix
+    (that prefix belongs to the tick's warning, WI-1.7(d)). Never an error.
+  - **`Sweep:false` from every other caller**, including the channel's
+    mandatory startup `register` (§6.1): that lane's sweeping is the tick's,
+    whose first pass is due immediately (`lastSweep`'s zero value,
+    `serve.go:635-644`), so sweeping here too would double it.
+  - **M1 has no `true` caller.** The `performRegister` adapter passes
+    `Sweep:false` — `registerOpts` has no such field and its signature is
+    fixed (R1b) — and `cmdBoot` keeps its own `loop.SweepStaleRegistrations`
+    call at `boot.go:99-101` untouched, so local behavior is unchanged by
+    construction. Same treatment as `Announce`: the field exists for M4/M5,
+    where it must already be on the wire. The remote arm (and the deletion of
+    the local call on a remote lane, so no arm sweeps twice) lands in
+    **WI-4.5**.
+- `ServeToken` vs `registrationLiveElsewhere` (`register.go:126-128,189-195`).
+
+`RegisterResp{Announce *AnnounceView; Pending int; Reg RegistrationView; InboxDir string; Refreshed, ExistingFound bool; ResolvedHost string; Warnings []string}`,
+with `AnnounceView{Sent, Total int; Warnings []string}` — the tagged mirror of
+`loop.AnnounceResult` (`internal/loop/message.go:37-41`), for the same reason
+`RegistrationView` is one (no JSON tags; `internal/loop` frozen in M1).
+
+**The six render fields are forced, not optional** (knock-on of R1b, same
+class as R4). Beyond the op's own two facts every consumer of today's
+`registerResult` reads more, and M1 must be invisible:
+`cmdRegister` prints `ResolvedHost` and `InboxDir` (`register.go:270,274`) and
+`Warnings` (`:276-278`); `cmdBoot` reads `InboxDir`, `Reg.LastSeen`,
+`Refreshed`, `ExistingFound`, `ResolvedHost` (`boot.go:104,111,137-142,200`);
+`selfRepairRegistration` reads `ResolvedHost` and `Reg.LastSeen`
+(`self_check.go:79-80`); `register_test.go` asserts `res.InboxDir` (`:144-145`),
+`result.ExistingFound` (`:344,373`) and `result.Reg.{AgentID,LastSeen,Body}`
+(`:347,376,379`).
+
+**`RegistrationView` is defined HERE** — `RegisterResp.Reg` is its only user
+(round 3 defined it under WI-1.4, whose status rows no longer carry it, T1b).
+It is an `internal/op` struct mirroring `loop.Registration`'s eight fields
+(`registration.go:58-68`) — `AgentID`, `ProtocolVersion`, `Vendor`,
+`ControlRepo`, `WorkingRepos`, `Host`, `LastSeen`, `Body` — with the
+frontmatter's own key names as JSON tags (`agent_id`, `v`, `vendor`,
+`control_repo`, `working_repos`, `host`, `last_seen`, `body`). A mirror is
+required, not a preference: `loop.Registration` carries **no JSON tags** (it is
+frontmatter-serialized) and `internal/loop` is frozen in M1. Two conversion
+funcs in `internal/op` (to/from `*loop.Registration`) are the single place that
+mapping lives, and `StatusAgent` (WI-1.4(d)) reuses four of these tag names
+verbatim so one field is never spelled two ways.
+`Refreshed` is `true` on every successful write (`register.go:183`);
+`ExistingFound` is the pre-write existence fact (`:184`); `Warnings` is empty
+today and stays a field so the hub can populate it.
+
+**`Announce` is a view, not a count** (same class, one layer out). `cmdRegister`
+renders three facts from `loop.AnnounceEnrollment`'s result — each per-peer
+warning (`register.go:285-287`), then `no peers to announce to` when `Total ==
+0` or `sent to %d of %d peer(s)` from `Sent` and `Total` (`:288-292`) — so an
+`AnnouncedTo int` carries one of the three and a remote lane, whose fan-out
+runs hub-side, could not reproduce the other two. Nil unless the request set
+`Announce`; a hub-side announce that failed outright leaves it nil and appends
+`announce failed: <err>` to `Warnings`, which the client prints through the
+same `warning: %s` loop (`:276-278`) — the same bytes in the same stderr
+position, since `performRegister` returns no warnings of its own
+(`:180-186`). In M1 the adapter passes `Announce:false` and `cmdRegister` keeps
+its own `loop.AnnounceEnrollment` call (`:280-294`), so nothing local changes;
+the field exists for M4/M5, where it must already be on the wire.
+
+**There is no `Created bool`.** An earlier draft carried one beside
+`ExistingFound`; it is exactly `!ExistingFound` in every returned response
+(`existingFound` comes from the pre-write read, `register.go:112,120-125`, and
+the exclusive-create arm is taken on precisely `!existingFound`, `:159-171`;
+the EEXIST re-read re-enters that same arm, `:90-97`), and `emitBootText`
+already derives the "Registered" verb that way (`boot.go:200`). Do not
+re-add it.
+
+**Both DESIGN gaps this item flagged are closed in DESIGN as it stands**:
+§3.5's Output line carries the full set (with `Announce`), and §4.4.3 puts
+`reg.body` (a bio bounded by `registration.go:18` — CORRECTION: the earlier
+`:19` citation was `MaxInboxMessageBytes`) in a body trailer, never the control
+line; §4.4.1 shows the `register-ok` frame. The two documents state one
+`RegisterResp`; a revision that moves one moves both.
+
+(e) §10.1 ports of the register/boot/self-check tests; local-mode equivalence
+(a nil `Vendor` behaves exactly as today's `resolveAgentVendor` result);
+**the adapter's host arm**: `--host` given / explicit `--host ""` / absent ⇒
+the value written matches today byte-for-byte, with the `os.Hostname()`-failed
+warning still emitted from the CLI side; and one direct `op.Register` call with
+`Announce:true` against a seeded multi-peer pool holding one undeliverable peer
+⇒ `Announce.Sent`/`.Total`/`.Warnings` match a direct `loop.AnnounceEnrollment`
+on the same pool — the only M1 coverage of a field no local caller reads yet.
+Same for the other such field: one direct `op.Register` with **`Sweep:true`**
+against a pool holding one stale, lease-dead peer row ⇒ that row is gone
+afterwards and the sweep ran AFTER the registration write (the caller's own row
+is present and fresh, never swept); the identical call with `Sweep:false` ⇒
+the stale row is still there — and a `Sweep:true` whose sweep fails ⇒ exactly
+one `Warnings` entry, `sweep stale registrations: <err>`, with the register
+itself still succeeding.
+
+(f) Done-when: `register_test.go`, `boot_test.go`, `self_check_test.go`,
+`enforced_enrollment_test.go` green unmodified — `register_test.go` in
+particular, since it is the file the adapter exists to keep untouched.
+
+(g) ~250 LOC.
+
+**WI-1.7 — the lease/tick handle: `op.NewChannel`.** *(Prerequisite: WI-1.6.)*
+
+(a) Lease lifecycle + the tick composite behind a **stateful handle**.
+
+(b) §3.4 (no `poll` op — cut); §6.1; §6.2.
+
+**Why a handle and not free functions (F2).** `op.Tick` cannot be stateless: it
+needs the registration heartbeat template (today `regTemplate`, `serve.go:237`,
+filled from `heartbeatTemplate(cfg, opts)`, `serve.go:554-563`, assigned at
+`serve.go:430`), the 10-minute sweep throttle (`lastSweep`, `serve.go:242`,
+`sweepInterval`, `serve.go:51`), and the lease token across calls. This shape is
+inherited verbatim by M3's hub session and M5's remote serve, so it is pinned
+once, here.
+
+(d) **Fixed shape:**
+
+```go
+type ChannelOpts struct {
+    HeartbeatTemplate *loop.Registration
+    Lease             *loop.ServeLease // local adoption arm; nil ⇒ the channel acquires
+}
+
+func NewChannel(cfg *loop.Config, ctx Context, opts ChannelOpts) *Channel
+
+func (c *Channel) AcquireLease(LeaseReq) (LeaseResp, error) // records the token
+func (c *Channel) Token() string                            // for AGENTCHUTE_SERVE_TOKEN
+func (c *Channel) Register(RegisterReq) (RegisterResp, error)
+func (c *Channel) Tick(TickReq) (TickResp, error)
+func (c *Channel) ReleaseLease() error
+```
+
+`ChannelOpts` is a **constructor input, not a wire struct** — the serialized
+lease shapes are `LeaseReq{}` / `LeaseResp{Token string}` (§3.4), unchanged.
+
+- `Lease` **non-nil** ⇒ the channel ADOPTS an already-held lease and
+  `Token()` returns `Lease.Token`. This is the LOCAL runner's arm, and it is
+  what keeps C10's pinned startup order literal: the runner still acquires
+  through `refuseLiveRunnerCollision` (`serve.go:571-580`), which stays
+  **byte-unchanged**, signature included. Without this arm the helper's return
+  type would change and four existing call sites break
+  (`run_test.go:130,140,159,170`, whose returned leases are passed straight to
+  `loop.ReleaseLease` at `:147`, `loop.RenewLease` at `:163`, and
+  `loop.ReleaseLease` again at `:166` and `:174` — CORRECTION, T5: round 3
+  wrote `:147,164,167,172`. The fifth lease call in that file, `:137`,
+  releases a lease this helper never returned — `loop.AcquireServeLease`'s own
+  from `:126`) — an exception nobody needs.
+- `Lease` **nil** ⇒ `AcquireLease` acquires and records the token. That is the
+  HUB session's arm (WI-3.3a) and the remote channel's (WI-5.1). M1 exercises
+  only the adoption arm; the two-arm shape is pinned NOW so M3 does not have
+  to reshape the seam — exactly as with `HeartbeatTemplate` below.
+- `HeartbeatTemplate` **non-nil** ⇒ used verbatim. The LOCAL runner passes
+  today's `heartbeatTemplate(cfg, opts)` value, so M1 changes no heartbeat
+  byte.
+- `HeartbeatTemplate` **nil** ⇒ `Register` derives and caches the template from
+  the `RegisterReq`, and a `Tick` before `Register` returns `op.ErrOrder`
+  (`E_ORDER`, §6.1 step 3). M1 exercises only the non-nil arm; the nil arm's
+  derivation lands with the hub session (WI-3.3a). The two-arm shape is pinned
+  NOW so M3 does not have to reshape the seam.
+- `Register` injects `c.Token()` into the request (§3.5 `ServeToken`).
+- The local runner (`runnerRuntime`) stores ONE `*op.Channel` **in place of
+  three fields**: `lease` (`serve.go:229`), `regTemplate` (`serve.go:237`),
+  and `lastSweep` (`serve.go:242`).
+
+  **Named exception, row 3 of the M1 preamble table (R1c).** One test helper
+  builds that literal: `newPollTestRuntime` (`run_test.go:481-509`), whose
+  `:495-507` acquires the lease and sets `lease:` (`:504`) and `regTemplate:`
+  (`:505`). It becomes `op.NewChannel(cfg, ctx, ChannelOpts{Lease: lease,
+  HeartbeatTemplate: &tmpl})` assigned to the single field. **One helper, one
+  hunk, one file**: its callers are unchanged (`b1_convergence_test.go:36`
+  and `run_test.go`'s own poll tests all go through the helper), and
+  `run_resize_unix_test.go:44` builds `&runnerRuntime{ptmx:…, stopCh:…}` —
+  fields this item does not touch, so that file is untouched too.
+- `LeaseResp{Token string}`.
+- **`TickResp{Pending, Skipped int; Swept []string; Warnings []string}`** (F3).
+  `Tick` returns a non-nil ERROR **only for the fenced case** (`op.ErrFenced` —
+  today's fatal branch, `serve.go:617-620`, which buffers the fatal message and
+  SIGTERMs the child). Every other step failure becomes ONE `Warnings` entry,
+  in production order, carrying the EXACT string today's `r.logf` receives
+  minus its trailing newline:
+
+  | source | anchor | warning text |
+  |---|---|---|
+  | renew, non-fenced | `serve.go:622` | `agentchute serve: renew serve lease: <err>` |
+  | heartbeat | `serve.go:631` | `agentchute serve: heartbeat registration: <err>` |
+  | sweep | `serve.go:641` | `agentchute serve: sweep stale registrations: <err>` |
+
+  The CLI renders each as `r.logf("%s\n", w)`, so the runner log is
+  byte-identical. `lastSweep` is advanced even when the sweep failed
+  (`serve.go:643`) — the throttle keeps that behavior. The runner-state write
+  failure (`serve.go:675`) is NOT a tick concern and stays in `pollOnce`.
+  **Wire note:** DESIGN §4.4.1's `tick-ok` example carries `warnings` (both in
+  the clean and the step-failure shape), and the paragraph under it — "`warnings`
+  is `[]string` and, like `durability_note` on `send-ok`, is **always
+  present**" — states the always-present rule; the M2 spec copy MUST reproduce
+  both (WI-2.1) and the codec's fixed shape lists it (WI-3.1a).
+- Tick composition, in `pollOnce`'s order: `loop.RenewLease` (`lease.go:317`) +
+  `loop.HeartbeatRegistration` (`registration.go:192`) with the cached template
+  + the 10-min-throttled `loop.SweepStaleRegistrations` (`sweep.go:60`) +
+  pending counts (the seam version of `hasPendingInboxMail`,
+  `serve.go:757-763`, which **fails OPEN** on a non-`ErrInboxMissing` error —
+  preserve that).
+
+(c) NEW `internal/op/channel.go`; MODIFY `internal/cli/serve.go` (`pollOnce`
+`609-677` calls `Tick`; `runWrapper` constructs the channel with the lease
+`refuseLiveRunnerCollision` already returned). **`refuseLiveRunnerCollision`
+(`571-580`) is byte-unchanged** — see the `Lease` adoption arm in (d).
+
+(e) §10.1: lease acquire/renew/release/fence, heartbeat self-heal, sweep
+back-off; **the local serve startup order is PINNED and UNCHANGED** (C10):
+lease (`serve.go:374`) → child (`serve.go:379-385`) → register
+(`serve.go:393`), including the rollback at `serve.go:394-399`.
+
+(f) Done-when: `m4_inject_recheck_test.go`, `b1_convergence_test.go`,
+`run_resize_unix_test.go` and every lease/sweep test green **unmodified**, and
+`run_test.go` green with its diff limited to the `newPollTestRuntime` hunk
+named in (d) — no other hunk in that file; a new order-pin test asserts the
+local sequence.
+
+(g) ~240 LOC.
+
+**WI-1.8 — M1 acceptance sweep + dependency-direction test.**
+
+(a) Prove the refactor invisible, the seam dual-callable, and the dependency
+direction enforced.
+
+(b) §10.1 in full; §7.4 (dependency direction, B2).
+
+(c) NEW `internal/op/*_test.go` additions only.
+
+(d) Both-Context-constructor matrix: every actor-scoped op executed with a
+CLI-resolved ctx AND a directly-constructed pinned ctx, asserting identical
+state effects. PLUS the **dependency-direction test** (B1/B2): a test that
+fails if `internal/op` imports `internal/cli`, `internal/hubwire`, or
+`internal/hubclient` — implemented with `go/build`'s import scan over the
+package's own files (stdlib only, no new dependency), asserting the import set
+is a subset of {stdlib, `github.com/agentchute/agentchute/internal/loop`}. The
+same file asserts `internal/loop` imports no `internal/op`.
+
+(e) = (d) plus the §10.1 list.
+
+(f) Done-when: `tools/test.sh` fully green with **zero** edits under any
+existing `*_test.go` EXCEPT the closed table in the M1 preamble — three files
+(`send_a5_test.go`, `send_b3_test.go`, `run_test.go`), three hunks, and each
+diff limited to the hunk named there; `git diff --stat` shows no
+`internal/loop` change. This item also **re-runs the move-set grep** over
+every identifier M1 removed from package `cli` and fails if any code-level hit
+outside that table survives — the check that keeps the criterion honest rather
+than aspirational.
+
+(g) ~300 LOC (tests).
+
+**WI-1.9 — v1.6.0 release notes + CHANGELOG. (Integrator-owned; lands in the
+M1 PR, before the tag.)**
+
+(a) The tag literally cannot release without this file: `release.yaml:110` runs
+`test -s "docs/releases/${tag}.md"` and `release.yaml:168` passes it as
+`--notes-file`. A missing file fails the release job **after** the tag is
+already pushed.
+
+(c) NEW `docs/releases/v1.6.0.md`; MODIFY `CHANGELOG.md` (a new
+`## v1.6.0 (<date>) — <headline>` section in the same shape as v1.5.7).
+
+(d) The notes state explicitly: **internal refactor only; no behavior change;
+no hub capability is claimed or shipped; nothing to do on any lane.** No fleet
+cutover, no forced update.
+
+(f) Done-when: `docs/releases/v1.6.0.md` exists and is non-empty at the M1 PR
+head; `tools/fact-sweep.sh` PASS (CHANGELOG.md is check 3's surface).
+
+(g) ~40 LOC prose.
+
+→ **Integrator: tag v1.6.0** (checklist §5.1).
+
+### M2 — spec merge (prose only; no Go changes)
+
+**WI-2.1 — normative "Hub wire & lifecycle" spec section.**
+
+(a) Add the binding hub section to `AGENTCHUTE.md`.
+
+(b) §9.1 first bullet (C7).
+
+(c) MODIFY `AGENTCHUTE.md`. **Pin: it lands as §13**, which is a genuinely
+VACANT number today — the file runs §12 → §14 → §15, so nothing renumbers. The
+`HUB.md`-by-reference option DESIGN §9.1 allows remains available if length
+forces it; codex gates either way.
+
+(d) Content, all literal values byte-for-byte from DESIGN §4:
+
+- frame grammar + the 64 KiB / 4 MiB limits (§4.3);
+- vocabulary + per-session serial order (§4.4), including
+  **`tick-ok.warnings`** (F3) and **`note.level`'s two-value vocabulary with
+  its routing** — `warn` → stderr, `info` → stdout (F4/R2; DESIGN §4.3's
+  `note` bullet states both arms, and the spec copy must too);
+- version handshake + hub-upgrades-first (§4.3);
+- never-auto-replay (§4.5.3) **and the mandatory `send-ok.committed` flag it is
+  written against** (§4.4.1, F11) — the spec's copy of that example carries
+  `"committed":true`, and a `send-ok` without the field is **malformed**, not a
+  defaulted `false`;
+- disconnect-after-claim redelivery (§4.5.2);
+- remote turn-end order (§6.6);
+- the timeout table (§4.6);
+- the pinning model (§5);
+- **the error-code registry WITH each code's emitter side** (§4.4.2 as amended,
+  F9/X1): hub-emitted, client-emitted, or **both** — `E_POOL_MISMATCH` is the
+  one code with two emitters and two exact §7.5 texts, and the spec must say so
+  rather than classifying it client-only.
+
+(f) Done-when: every literal value (timeouts, caps, frame names, codes) matches
+DESIGN.md §4 byte-for-byte; codex spec-gate SHIP.
+
+(g) ~190 LOC prose.
+
+**WI-2.2 — section amendments.**
+
+(a) The §9.1 amendment list: §1 (reference transport), §2 (hub as a supported,
+CI-tested config; network-mount demoted), §4 (`ssh://` locator), §5.4 (hub-side
+session pid; token-checked release; **§6.9 boot-REFERENCE corroboration**), §8
+(tick as the remote poll), §12 (non-goals rewording), §15 (pinning), plus the
+`setup --wipe-state` surface: `state/pool.id` as preserved non-runtime scaffold
+(H1).
+
+(b) §9.1.
+
+(c) MODIFY `AGENTCHUTE.md`.
+
+(d) The §5.4 amendment is the ONE behavioral change to existing lease semantics
+and must state the three properties that bound it: the comparison is
+**equality only, never ordering**; the reference has **no wall-clock
+component**, so a clock step cannot forge a difference; and the reference is
+**HOST-scoped** (R12) — `/proc/sys/kernel/random/boot_id` and
+`kern.bootsessionuuid` change on a host **reboot** and on nothing else, so a
+container/VM restart, a service restart, or a namespace re-create on a host
+that did NOT reboot leaves the ref identical and the claim behaves exactly as
+today. The spec text must carry that clause rather than let a reader conclude
+pid reuse is solved generally: the fix is scoped to reboots, and every other
+pid-reuse wedge keeps the §7.5 manual remediation. An **absent ref means
+unchanged, pre-existing behavior**. The withdrawn
+`StartedAt`-predates-boot-*time* rule must **not** reach the spec (§6.9, B6).
+For the wipe surface, name the three places behavior changes (wipe plan,
+post-wipe rescan, dry-run/preserved output) so the M5 implementer and the spec
+agree.
+
+(f) Done-when: §12 no longer forbids what M3+ ships; the boot-ref wording says
+"equality", "no wall-clock component" **and** "host-scoped (a restart without a
+reboot is unchanged from today)" explicitly; wipe/pool.id wording present;
+codex SHIP.
+
+(g) ~130 LOC prose.
+
+**WI-2.3 — EXTENSIONS.md alignment.** (b) §9.2. (c) MODIFY `EXTENSIONS.md`
+(the HTTP sketch gains the phase-2-behind-`internal/op` line; any wording
+implying every non-filesystem *transport* is out of the reference CLI is
+aligned with the amended §12). (f) codex SHIP. (g) ~20 LOC.
+
+**WI-2.4 — enrollment surface.**
+
+(a) **FOUR** lane-facing rules (G-M4 as amended — the round-1 item said three
+and predates P8): remoteness is *discovered* (never a `--hub`/`--remote`
+spelling); NEVER re-send after `E_SEND_UNKNOWN` without confirming
+non-delivery; run `doctor` immediately after a join and after any hub move; and
+**on `E_VERSION`, WAIT for the hub to upgrade — never "fix" it by re-running
+`hub join`** (P8: the hub upgrades first; re-joining rotates a key for no
+reason).
+
+(b) §9.1 second bullet; §7.5's `E_VERSION` text.
+
+(c) MODIFY `AGENTS.md`, `CLAUDE.md`, `CODEX.md`, `GEMINI.md`, `GROK.md`,
+`examples/hooks/` templates — the enrollment prose blocks only.
+
+(d) **The enrollment prose blocks are MARKER-VERSIONED** (CHANGELOG records
+"marker v30" for v1.5.7). This edit bumps the marker, and the embedded copies
+must be regenerated in the same commit or `templates_drift_test.go` /
+`assets_test.go` fail — the `//go:embed` coupling rule: a zero-`.go`-diff is
+not a zero-behavior-change here.
+
+(f) Done-when: grep finds all four rules in every wrapper file; the marker is
+bumped; `templates_drift_test.go` and `assets_test.go` green; codex SHIP.
+
+(g) ~40 LOC prose.
+
+### M3 — wire codec + `hub session` + conformance vectors
+
+**WI-3.1a — codec: frames, codes, round-trip.**
+
+(a) NDJSON control frames + raw body trailers, both directions.
+
+(b) §4.3 (framing bullets), §4.4 (vocabulary), §4.4.2 (registry), §4.4.3
+(producer rules).
+
+(c) NEW `internal/hubwire/frame.go`, `codec.go`, `codes.go`.
+
+(d) Fixed: LF-terminated UTF-8 JSON objects; 64 KiB line cap; `body_len`
+trailers ≤ 4 MiB (absent = no trailer); client `id` / response `re`; one
+request in flight; unknown fields ignored; unknown `t` → `E_UNSUPPORTED`
+(session survives); a framing violation → error frame + close, **received
+frames only**; the hub MUST NOT compose a >64 KiB line (streamed aggregates:
+`msg`/`note`/`owed-item`/`ack-item`; `status-ok` two budgets + `truncated`).
+Full vocabulary exactly as §4.4 (no `ping`/`poll`/`pending-item`). Plus:
+
+- **The `status-ok` budgets live HERE, in the wire producer — never in
+  `op.Status` (T1a).** This package owns the `status-ok` encoder. It takes
+  the op's fully-sorted `Agents` slice and appends rows **in order**, keeping
+  a row only while BOTH hold:
+  1. **wire budget** — the complete encoded control line, counting every
+     non-row field (`t`, `re`, `now`, `truncated`), the `agents` array's own
+     punctuation and the terminating LF, stays ≤ 64 KiB;
+  2. **row cap** — the kept-row count stays ≤ 64.
+
+  The first row that fails either check ends the append (prefix semantics —
+  never skip-and-continue, which would omit a middle row while showing later
+  ones), and `"truncated":true` is written whenever **either** budget
+  excluded a row. `StatusResp.Truncated` from the op is always `false`
+  (WI-1.4(d)); the producer is the only writer of the `true` value. Budgets
+  applied one layer in would silently drop rows in local mode, where there is
+  no line to overflow.
+  - **A row count alone does not bound the line.** `Host` is free-form:
+    `ReadRegistration` copies frontmatter `host` through verbatim under only
+    the 1 MiB whole-file cap (`registration.go:72,88`),
+    `Registration.Validate` imposes no length bound
+    (`registration.go:217-241`), and `register --host` is an unconstrained
+    string flag (`register.go:206`) — so one otherwise-valid row with a 70 KiB
+    host exceeds the cap before row count matters. `AgentID` is
+    charset-constrained but also length-unbounded (`agentIDPattern`,
+    `internal/loop/inbox.go:40`); only `NAME_MAX` on `<id>.md` bounds it in
+    practice. **Implement against no bounded-field assumption.**
+  - **Non-row fields COUNT against the byte budget.** §4.4.3's normative rule
+    is that the hub never emits a control line over 64 KiB; a rows-only
+    budget balances its own books and still emits an over-cap line. Cost: one
+    integer.
+  - **Measure with `"truncated":false` encoded.** `true` is one byte shorter
+    than `false`, so a frame that fit before the flip still fits after it —
+    no second encoding pass, no re-measure.
+  - **First row alone too big ⇒ `agents:[]` with `truncated:true`.** A valid
+    response, not an error: `status` is read-only and pool-wide, and refusing
+    the whole listing over one pathological row would lose every other
+    agent's row. The client notice (WI-4.5) names the wire limit, not only
+    the row cap.
+
+- **`send-ok.committed` is MANDATORY** (F11): decode it as `*bool` and treat
+  absence as `E_MALFORMED_FRAME` — never as a defaulted `false`. This is the
+  field the never-replay rule is written against.
+- **`tick-ok.warnings` is `[]string`, always present** (F3), `[]` when empty,
+  never omitted.
+- **`note.level` is one of exactly `"warn"` / `"info"`** (WI-1.1).
+- `codes.go` re-exports `op.CodeFor`'s mapping and ADDS **exactly eight**
+  session/codec codes: `E_VERSION`, `E_IDENTITY`, `E_POOL_NOT_FOUND`,
+  `E_POOL_ID_INVALID`, `E_POOL_MISMATCH` (**hub arm**), `E_MALFORMED_FRAME`,
+  `E_TOO_LARGE`, `E_UNSUPPORTED`. **`E_ORDER` is NOT re-added here (R3)** — it
+  is an op sentinel (WI-1.1) and adding it makes the union double-count.
+- `codes.go` also carries the **emitter classification table**, one row per
+  code: `hub` / `client` / `both`. Exactly one row is `both`
+  (`E_POOL_MISMATCH`); it is what lets the client-only list be asserted
+  disjoint without lying about that code.
+
+(e) §10.2: round-trip every frame type; trailer boundaries byte-exact at
+0 B / 1 B / 4 MiB / 4 MiB+1 (`E_TOO_LARGE`); truncated frame and truncated
+trailer at every boundary; unknown `t`; unknown fields ignored; oversize line;
+interleaved `note` frames. Plus **the `status-ok` budget rows**, a
+`StatusResp` whose own `Truncated` is `false` being the input to every one of
+them (the producer, not the op, sets the flag):
+
+- **row cap** — 64 small rows in ⇒ 64 out with `truncated:false`; 65 in ⇒ the
+  first 64 in the op's sort order with `truncated:true`.
+- **wire budget, the row the row-cap misses** — a THREE-row pool in which one
+  otherwise-valid registration's `host` alone exceeds 64 KiB: that row is
+  excluded, `truncated:true`, and the emitted line measures ≤ 64 KiB **as a
+  whole line, LF included**. This row fails against a producer that only
+  counts rows, and fails against one that budgets rows without their frame.
+- **prefix, not skip** — the same oversized row placed FIRST in sort order ⇒
+  `agents:[]`, `truncated:true`, and the two later small rows dropped as
+  well; placed LAST ⇒ the two earlier rows survive. A skip-and-continue
+  producer passes the first shape and fails this pair.
+- **boundary, byte-exact** — a synthetic pool sized so the encoded line lands
+  exactly on the budget: the largest frame that fits ⇒ all rows,
+  `truncated:false`, length exactly 64 KiB; one byte more ⇒ the last row
+  drops with `truncated:true`. Assert the ENCODED length, never a row count.
+- **flag flip is free** — the same pool with ONE more row appended: the kept
+  rows still measure exactly 64 KiB under `"truncated":false`, the extra row
+  is excluded, and the frame actually emitted (`"truncated":true`, one byte
+  shorter) is still ≤ 64 KiB. That is the measure-with-`false` rule's
+  no-second-pass claim, asserted rather than assumed.
+
+Plus a
+**registry completeness test, with the arithmetic that actually holds (R3)**:
+
+- `op.CodeFor`'s output set is **9** — the eight sentinels plus the `E_HUB_IO`
+  default arm (WI-1.1(d)).
+- this package's own set is **8** (above; no `E_ORDER`).
+- the two sets are **disjoint**, and their union is **17** = §4.4.2's hub-side
+  registry **exactly** — no duplicate, no gap. Assert the union against a
+  literal list, so a code added to either side without a registry row fails.
+- the **client-only** list is **9** (`E_CONNECT`, `E_UNAUTHORIZED`,
+  `E_HOSTKEY_CHANGED`, `E_CHANNEL_LOST`, `E_SEND_UNKNOWN`, `E_HELLO_TIMEOUT`,
+  `E_HUB_NO_BINARY`, `E_NOT_JOINED`, `E_NO_SSH`) and is disjoint from that
+  17-row union.
+- `E_POOL_MISMATCH` is asserted to be classified `both` — present in the
+  hub-side union AND emitted client-side — and is **not** a member of the
+  client-only list. Requiring it in both lists is the contradiction round 2
+  shipped; this replaces it.
+
+(f) Done-when: the §10.2 round-trip suite green over `net.Pipe`.
+
+(g) ~350 LOC + ~250 test.
+
+**WI-3.1b — fuzz target + streaming/typed-event-stream tests.**
+
+(a) Harden the parser (the §5.4 attack surface) and prove the streaming
+contract end-to-end.
+
+(b) §4.3, §4.4.3 (streaming reaches all the way down, C4), §10.2.
+
+(c) NEW `internal/hubwire/fuzz_test.go`, `stream_test.go`, and a checked-in
+seed corpus under `internal/hubwire/testdata/fuzz/`.
+
+(e) A `go test -fuzz` target on the frame parser whose **seed corpus runs as an
+ordinary test** in the normal (non-fuzzing) run — so it lands in CI's existing
+`go` job with no CI change at all. Typed-event-stream tests: a `check` over many
+maximum-size (4 MiB) messages with a peak-memory assertion (≤1 body held); a
+`check` producing many interleaved `note`/`owed-item` frames with order
+preserved end-to-end; a `pending` with many owed entries and one 4 MiB
+`show_body` body as a trailer; transport failure injected **after the first
+emitted item** AND **after a mid-stream `note`** (claim durable, no partial
+frame, clean abort, no note silently lost before the failure point).
+
+(f) Done-when: the seed corpus is green under `tools/test.sh` (not only under
+`-fuzz`); the peak-memory assertion holds with 32 × 4 MiB messages.
+
+(g) ~250 LOC (tests).
+
+**WI-3.2 — handshake.**
+
+(a) `hello`/`hello-ok` with version + identity + pool checks.
+
+(b) §4.3 (handshake block, pool-check bullet, `hub_time` offset).
+
+(c) NEW `internal/hubwire/handshake.go`.
+
+(d) `hello{proto:"agentchute-hub", v:1, min_v:1, agent, bin}`;
+`hello-ok{v, agent, pool, pool12, writable, hub_bin, hub_time}`; version rule
+`use = min(hub_max, client_v)`, reject below either min → `E_VERSION`;
+`E_IDENTITY` on `agent` ≠ pinned; `pool12` **read from `state/pool.id`, never
+an argv echo** (F1); `writable` = a temp-file create/remove probe under the
+pool's `state/` (G-M5).
+
+**`E_POOL_MISMATCH` scope for this item** (F9/X1): the handshake carries
+`hello-ok.pool12` = the value READ FROM THE POOL, and nothing else. The **hub
+arm** (session start, `pool.id` absent or ≠ `--pool-id`) is WI-3.3a's; the
+**client arm** (recorded-vs-`hello-ok`) is M4's. Do not implement either here.
+
+**P3 — pool.id has no production writer until M5.** Every M3 test that needs a
+`state/pool.id` **mints its own fixture**:
+`os.OpenFile(path, O_WRONLY|O_CREAT|O_EXCL, 0600)` writing exactly 12 lowercase
+hex characters + LF, matching the J1 contract (§5.1) byte-for-byte. Pin the
+helper once — `writeFixturePoolID(t *testing.T, poolDir string) string` in the
+M3 test-helper file — and reuse it in WI-3.3a/3.3b. The sole PRODUCTION writer
+is WI-5.4; an M3 test that assumes one exists will not pass.
+
+(e) §10.2 handshake matrix (v1/v1, v1/v2 in both directions); `hello-ok.pool12`
+carries the value read from the pool's `state/pool.id` and never an argv echo.
+**No `pool.id` absent/malformed/valid-but-different rows here (R13)**: this
+item deliberately implements neither `E_POOL_MISMATCH` arm and does no J1
+validation, so those rows would assert against code that is not here. They live
+on WI-3.3a's (e), which owns the startup validation and the hub arm.
+
+(f) Done-when: the matrix is green and the hello deadline (10 s, both sides) is
+enforced in the fake-transport harness.
+
+(g) ~200 LOC.
+
+**WI-3.3a — `hub session`: dispatcher, state machine, release-on-EOF.**
+
+(a) The forced-command entry point: a framed dispatcher from wire ops to
+`internal/op` under one pinned `Context`.
+
+(b) §4.1 (carriage), §4.4 (dispatch), §5.1 (config direct from `--pool`, never
+Discover), §5.3 (actor-free dispatch), §3.4/§6.1 (`register` caches the tick
+template; early `tick` → `E_ORDER`), §6.4-hub (release on every exit path).
+
+(c) NEW `internal/cli/hub_session.go`, NEW `internal/cli/hub.go` (the `hub`
+subcommand family dispatcher); MODIFY `internal/cli/dispatch.go` —
+`commandHandlers` is declared at `dispatch.go:20` and **populated in `init()` at
+`dispatch.go:22-46`** (map keys `24-44`; CORRECTION to the round-1 `23-45`
+citation): add `"hub"`, and keep it out of `ac` help per §7.3.
+
+(d) - Config is built **directly** from `--pool`
+  (`ControlRepo=<pool>`, `LoopDir=<pool>/.agentchute/loop`) and the discovery
+  cascade is never called: a stray `AGENTCHUTE_CONTROL_REPO`/`AGENTCHUTE_LOOP_DIR`
+  in the hub user's rc-sourced environment would otherwise outrank the pinned
+  pool (`config.go:218-225` env arm, `config.go:299-329` loop-dir arms).
+- **At startup, before any op and before `hello-ok`**, in this order: validate
+  `state/pool.id` against the J1 contract (regular, non-symlink, 0600, content
+  exactly `^[0-9a-f]{12}\n$`, read through `loop.ReadFileLimit`,
+  `registration.go:34-48`, with a 64-byte cap) → `E_POOL_ID_INVALID` on
+  failure; then compare it to `--pool-id` → **`E_POOL_MISMATCH` (hub arm)** when
+  absent or unequal. Both are `error` frames followed by close.
+- `SSH_ORIGINAL_COMMAND` is logged for audit **only after** C0/C1 control-byte
+  stripping via the shipped `sanitizeControlBytes` (`check.go:374-388`).
+- **The `status` dispatch is where both budgets bind (T1a)**: it passes the
+  op an emitter that writes each `warn` note as a `note` frame (so the
+  lenient-read warnings stream and never ride inline, WI-1.4(d)), then hands
+  the response to WI-3.1a's `status-ok` encoder, which appends rows in sort
+  order while the encoded line stays ≤ 64 KiB **and** the count stays ≤ 64,
+  and sets `truncated:true` when either budget excluded a row. The op returns
+  every row with `Truncated:false`; the budgets exist only on this path. The
+  dispatcher itself performs no capping — one implementation of the rule,
+  in the encoder.
+- One `op.Context{ActorID: <pinned --agent>}` built once and reused for every
+  dispatch; one `op.NewChannel(cfg, ctx, ChannelOpts{HeartbeatTemplate: nil})`
+  — the **nil arm** from WI-1.7, so `Register` derives and caches the template
+  and a `tick` before `register` is `E_ORDER`.
+- **State machine**: `pre-hello → serving → (channel: leased) → closing`. EVERY
+  exit path calls `Channel.ReleaseLease()` — token-checked, so a
+  already-reclaimed lane is a safe `ErrFenced` no-op that never deletes the new
+  owner's claim (`lease.go:345-366`). Exit paths that must be covered: stdin
+  EOF, read-deadline expiry, `SIGTERM`/`SIGHUP`, a framing violation, and a
+  panic recovery.
+
+(e) In-process session tests over the fake transport: `E_ORDER`; `pool.id`
+absent / mismatched (`E_POOL_MISMATCH` hub arm, before `hello-ok`);
+`E_POOL_ID_INVALID` (the J1 malformed set); **release-on-EOF asserted for every
+one of the five exit paths above** (the claim file is gone, or belongs to the
+successor).
+
+(f) Done-when: a fake-transport client completes hello → register →
+lease-acquire → tick → lease-release against a temp pool with a fixture
+`pool.id`, and every exit path releases.
+
+(g) ~400 LOC + ~200 test.
+
+**WI-3.3b — deadlines + every-op end-to-end.**
+
+(a) Enforce §4.6's hub-side timers and drive every §4.4 op through the
+dispatcher.
+
+(b) §4.6 (hello 10 s; read 20 s channel / 30 s idle one-shot; write 30 s;
+one-shot lifetime 10 min); §4.4 (full vocabulary).
+
+(c) MODIFY `internal/cli/hub_session.go`.
+
+(d) Deadlines are enforced with `os.Stdin.SetReadDeadline` / the write
+equivalent; expiry closes the session through the same release path as EOF
+(WI-3.3a). The one-shot 10-minute lifetime is a safety net, independent of the
+idle deadline.
+
+(e) Every op in §4.4 driven end-to-end over the fake transport against a temp
+pool: `send`, `check`, `ack`, `register`, `status`, `gate`, `pending`,
+`clean-owed`, `lease-acquire`, `tick`, `lease-release` — each asserting both
+the response frame and the resulting pool state. Deadline tests: a silent
+channel dies at 20 s; a silent one-shot at 30 s; a one-shot alive at 10 min is
+closed.
+
+(f) Done-when: every §4.4 op has an end-to-end test and every §4.6 hub-side
+timer has an expiry test.
+
+(g) ~200 LOC + ~150 test.
+
+**WI-3.4 — lease boot-REFERENCE pid-proof (the ONE `internal/loop` change).**
+
+(a) Corroborate the same-host pid-proof with a **per-boot identifier recorded
+in the claim**, compared for EQUALITY.
+
+(b) §6.9 in full (as amended, B6 — the wall-clock boot-*time* rule is
+**withdrawn**; do not implement it), §4.6's last row, and §10.3's **three**
+boot rows (CORRECTION, R10: the rows named `hub-reboot pid reuse`, `clock step
+does not steal a live lease`, and ``boot_ref` survives the heartbeat` — round 2
+said four). The seven cases this item must cover are (e)'s, which is the
+authority; those three rows are where they land in the M6 matrix.
+
+(c) MODIFY `internal/loop/lease.go`:
+
+- add `BootRef string \`json:"boot_ref,omitempty"\`` to `ServeClaim`
+  (`lease.go:55-62`);
+- populate it in `AcquireServeLease` where the claim is built
+  (`lease.go:160-167`);
+- change **branch (d) only** (`lease.go:242-244`).
+
+NEW `internal/loop/bootref_linux.go` (`//go:build linux`),
+`internal/loop/bootref_darwin.go` (`//go:build darwin`),
+`internal/loop/bootref_other.go` (`//go:build !linux && !darwin`).
+
+**Build-tag shape (S6), decided.** `internal/loop` already partitions platforms
+totally with tagged pairs and no third file — `filelock_{unix,windows}.go`,
+`lease_pid_{unix,windows}.go`, `readfile_{unix,windows}.go`,
+`runner_socketdir_{unix,windows}.go`, each `!windows` / `windows`. Boot ref needs
+a THREE-way split, so the minimal total partition is `linux` / `darwin` /
+`!linux && !darwin` — the third file covers Windows **and** every other GOOS and
+returns `""` (= today's unchanged behavior). A separate `bootref_windows.go`
+would be byte-for-byte identical to `bootref_other.go`; it is deliberately not
+created.
+
+(d) - **Linux**: read `/proc/sys/kernel/random/boot_id` through
+  `loop.ReadFileLimit` with a small cap (a per-boot UUID, ≤64 B) and trim
+  whitespace.
+- **Darwin**: `golang.org/x/sys/unix.Sysctl("kern.bootsessionuuid")` — NOT an
+  exec'd `/usr/sbin/sysctl`. The boot ref is read inside `AcquireServeLease`'s
+  `withAgentLock` critical section, and forking a process while holding a flock
+  is exactly the latency and failure surface this codebase avoids elsewhere.
+  `golang.org/x/sys` is **already a direct requirement** (`go.mod:7`, v0.30.0)
+  and is currently imported only from `filelock_windows.go`, so adding
+  `x/sys/unix` on the unix side changes no `go.mod`/`go.sum` line — which
+  `release.yaml:28-30` (`go mod tidy` + `git diff --exit-code go.mod go.sum`)
+  proves.
+- Deliberately **not** `kern.boottime`: that is the wall-clock-derived value
+  §6.9 rules out.
+- Any error, absence, or permission denial ⇒ `""`.
+- **Reclaim rule, branch (d) only**: refuse (`ErrLeaseHeld`) when
+  `existing.Host == host && pidAlive(existing.PID)`, EXCEPT when
+  `existing.BootRef != "" && current != "" && existing.BootRef != current`, in
+  which case fall through to branch (e)'s reclaim CAS (`lease.go:248`).
+  Equality/inequality only — the refs are never ordered, aged, or parsed.
+- **Ordering (C8), unchanged**: the freshness refusal (`lease.go:230-232`) runs
+  FIRST, before any pid or boot reasoning.
+- **Field preservation, verified**: `readClaim` (`lease.go:101-114`) is a plain
+  `json.Unmarshal` into the closed `ServeClaim`, and `RenewLease`
+  (`lease.go:317-340`) round-trips read → mutate `LastSeen` → marshal →
+  `atomicWriteFile`. So `BootRef` survives every heartbeat **only because it is
+  a real struct field**; it must never be smuggled as an ad-hoc JSON key.
+  Corollary the tests must assert correctly: an unknown extra key **parses**
+  (mixed-version tolerance) but is **dropped** on the next renew — assert
+  parsing, never preservation.
+- **Test seam, required**: the host's current ref must be injectable — a
+  package-level `var readBootRef = platformBootRef` in `internal/loop`.
+  Without it, none of the rows below can run deterministically on a CI runner.
+
+(e) Rows: stale `LastSeen` + DIFFERING ref + live decoy pid ⇒ **reclaim**;
+stale + MATCHING ref ⇒ `ErrLeaseHeld`; stale + ABSENT ref (a pre-upgrade claim)
+⇒ `ErrLeaseHeld` (the upgrade path); host ref unreadable ⇒ `ErrLeaseHeld`;
+FRESH `LastSeen` + differing ref ⇒ `ErrLeaseHeld` (freshness first);
+**clock stepped FORWARD and BACKWARD under a live lease ⇒ NOT stolen**, and the
+claim file is byte-unchanged (same `serve_token`); `boot_ref` present and
+identical after repeated `RenewLease`.
+
+(f) Done-when: all seven cases green on linux AND darwin; no other lease test
+changed; `git diff` on `internal/loop` limited to `lease.go` + the three new
+files.
+
+(g) ~160 LOC.
+
+**WI-3.5 — conformance L vectors + the HUB-SIDE half of the W vectors.**
+
+(a) Executable-spec coverage for the lease/fencing gap and for the hub half of
+the wire lifecycle.
+
+(b) §9.3 (L1–L4; W1–W5 and the timing rule).
+
+**(c) Placement, pinned — this IS the finding (B3/X3).** Verified facts:
+`conformance/go.mod` is exactly three lines (`module agentchute.dev/conformance`,
+`go 1.21`) with no `require`, no `replace`, no `go.sum`, and there is no
+`go.work` anywhere in the repo. It therefore **cannot import `internal/*`**;
+root `go test ./...` never enters it; `tools/test.sh` never enters it; only
+`ci.yaml:39-40` and `release.yaml:47-48` run it (`cd conformance && go test
+./...`). So:
+
+- **Drivers live in the ROOT module**, and **the assertions live in NON-test
+  files (R6)** — identifiers declared in a `_test.go` compile only into that
+  package's own test binary, so a second package (WI-6.4's sshd driver) cannot
+  see them. As pinned in round 2 the sshd driver could not compile, or would
+  have to duplicate the assertions — the one thing that item forbids. So:
+  - NEW `internal/spectest/vectors.go` — a stdlib-only loader.
+  - NEW `internal/spectest/lease.go` and `internal/spectest/wire.go` — the
+    **exported, transport-parameterized** assertion helpers. The codec half
+    takes the transport as an `io.ReadWriter`; the lease half takes a small
+    seam interface the in-process and sshd drivers both satisfy. Signature
+    shape: `func AssertW1(t *testing.T, rw io.ReadWriter, v Vector)` and
+    siblings — `testing` is an ordinary stdlib import and is legal in a
+    non-test file.
+  - NEW `internal/spectest/lease_test.go` / `wire_test.go` — **thin drivers
+    only**: they load the vectors and call the exported helpers over
+    `net.Pipe`, and hold no assertion logic of their own. WI-6.4 passes the
+    ssh transport to the same helpers.
+  They run under the existing `go test ./...` — no new CI job, no new step.
+- **Vectors are transport-neutral shared JSON DATA**: NEW
+  `conformance/vectors/lease.json`, `conformance/vectors/wire.json`, beside the
+  existing `core.json` — data, not an import, so no module boundary is crossed
+  and BOTH `go.mod` files stay byte-identical. **The loader derives the
+  directory ONCE from its own source path (R8)**:
+  `_, self, _, _ := runtime.Caller(0)` →
+  `filepath.Join(filepath.Dir(self), "..", "..", "conformance", "vectors")`.
+  A bare relative `../../conformance/vectors/…` resolves against the *test's
+  working directory*, so it works only while every importing package happens
+  to sit exactly two levels below the root — a depth coincidence that
+  `integration/sshd/` (WI-6.4) satisfies today and any third caller would
+  break. `runtime.Caller` is stdlib; `go:embed` cannot reach a parent
+  directory, which is why the path is computed rather than embedded.
+- **`conformance/` gains one prose block** in `CONFORMANCE.md` naming the two
+  files and stating that the reference driver lives in the root module (other
+  bindings drive the same JSON through their own harness). **No new Go file
+  under `conformance/`** — the module stays three lines and stdlib-only.
+- `tools/fact-sweep.sh` is unaffected: its vector count (check 2) greps
+  `conformance/vectors/core.json` specifically, not the directory.
+- **`tools/test.sh` gains exactly ONE block**, closing the pre-existing gap
+  that the canonical ritual never exercised the second module (CI does;
+  test.sh does not). This is the **only** change this plan makes to
+  `tools/test.sh`. It must use the script's own `$strip_env` and its own
+  failure reporting (R7 — the literal bare `cd conformance && go test ./...`
+  round 2 mandated bypasses the env strip that §3 rule 1 and E10 make
+  mandatory, and swallows the failure). Inserted after the `go test ./...`
+  block (`tools/test.sh:18-20`) and before `go build`, in the shipped shape
+  (`tools/test.sh:14-24`), in a **subshell** so the following `go build ./...`
+  still runs from the repo root:
+
+  ```sh
+  say "cd conformance && go test ./..."
+  # shellcheck disable=SC2086
+  (cd conformance && env $strip_env go test ./...) || { say "FAIL: conformance go test"; exit 1; }
+  ```
+
+(e) **S7 — restated, because M3 has no client.** M3's W set is HUB-SIDE ONLY:
+
+- **W1-hub**: a `check` whose emitter returns an error mid-stream leaves the
+  already-claimed items in `.claimed/`, and a second `check` on the same pool
+  re-lists them with `redelivered` set.
+- **W2-hub**: a `send` whose response frame cannot be written still leaves
+  **exactly one** inbox file, and the hub never re-executes it.
+- **W3-hub**: a reclaim between `lease-acquire` and the send's in-lock fence
+  check ⇒ `op.ErrFenced` / `E_FENCED`, nothing linked.
+- **W4/W5**: identity and version mismatch close the session at the handshake
+  (already fully hub-side).
+
+The CLIENT halves — "reported unknown and not replayed" and "next check
+redelivers **with the banner**" — cannot run here and move to **M4 (WI-4.10)**.
+A green W2 in M3 that claims client behavior is testing nothing; that is the
+review's canary for this item.
+
+L1–L4 as §9.3 states them, driven in-process against the seam.
+
+(f) Done-when: L1–L4 plus the four hub-side W assertions green under
+`tools/test.sh`; `git diff` shows both `go.mod` files unchanged.
+
+(g) ~350 LOC.
+
+### M4 — client transport + remote discovery
+
+**WI-4.1 — `config.json` format + read/write helper.** *(S5 — nothing else in
+M4 can be tested without this, and there is no producer until M5.)*
+
+(a) Pin the per-hub config file's struct, its on-disk contract, and the helper
+every other M4 item reads it through.
+
+(b) §7.4 (the layout block), §4.3/D3 (`pool`/`pool12` are RECORDED from
+`hello-ok`, never derived from URL text).
+
+(c) NEW `internal/hubclient/config.go`.
+
+**Layering note the implementer would otherwise have to stop and ask about:**
+`internal/loop` cannot import `internal/hubclient` (the direction is
+`loop ← op ← hubwire ← hubclient ← cli`, §7.4), but discovery needs to know
+whether a join exists in order to raise `E_NOT_JOINED`. Split accordingly: the
+**path builder and the existence check** live in `internal/loop/remote.go`
+(WI-4.2) — `loop.HubDir(hubID)`, `loop.HubConfigPath(hubID)`, and a stat — and
+`internal/loop` **never parses** the file. The struct and the read/write helper
+live here.
+
+(d) Fixed shape, verbatim from §7.4:
+
+```go
+type HubConfig struct {
+    URL      string            `json:"url"`
+    JoinedAs []string          `json:"joined_as"`
+    Names    map[string]string `json:"names"`
+    Pool     string            `json:"pool"`
+    Pool12   string            `json:"pool12"`
+}
+```
+
+- Path `~/.agentchute/hub/<hub-id>/config.json`, file 0600, dir 0700.
+- `ReadHubConfig(hubID string) (*HubConfig, error)` returns a **named
+  not-found error** — the `E_NOT_JOINED` trigger (§7.4, C3) — distinguishable
+  by the caller from a parse or I/O error. The read is bounded through
+  `loop.ReadFileLimit` (`registration.go:34-48`) with a 64 KiB cap.
+- `WriteHubConfig(hubID string, c *HubConfig) error` = temp file in the same
+  directory + fsync + `rename` (the same discipline WI-5.3c's migration commit
+  uses).
+- **Unknown JSON fields are ignored on read and DROPPED on write**, stated
+  explicitly because `ServeClaim` (`lease.go:101-114`) and `GuardLatch`
+  (`guard.go:31-35`) behave the same way and an implementer must not assume
+  round-tripping.
+
+(e) Round-trip test; not-found vs parse-error distinction; 0600/0700
+permissions asserted; and a fixture helper
+`plantHubConfig(t *testing.T, hubID string, c HubConfig)` reused by every
+later M4 item.
+
+(f) Done-when: the helper round-trips and the two error classes are
+distinguishable. **Every other M4 row runs against a HAND-PLANTED
+`config.json`** — `hub join` does not exist until WI-5.3a, so an M4 test that
+expects join to have run cannot pass.
+
+(g) ~120 LOC.
+
+**WI-4.2 — `ssh://` discovery arm + shadow dir (§6.8 contract).**
+
+(a) Remote config resolution, purely local and offline-safe.
+
+(b) §6.8 (points 1–4), §7.4 (hub-dir layout, hub-id hash, pointer lifecycle
+including probe-before-pointer and the `E_NOT_JOINED` join-state check — C3),
+§4.4.2 client-side codes.
+
+(c) MODIFY `internal/loop/config.go`. **CORRECTION: `discoverControlRepo`
+(`config.go:208-259`) has FOUR arms, not three** — flag (`209-216`), env
+(`218-225`), pointer file (`227-246`), cwd walk-up (`248-255`), then
+`ErrNoControlRepo` (`257-258`). The `ssh://` branch goes in the flag, env, and
+pointer arms, **before** `validateExplicitControlRepo` (`264-273`) and before
+`absExistingDir` (`359-375`).
+
+MODIFY `internal/loop/pointer.go` — **S3, with corrected anchors.** The
+round-1 citation (`pointer.go:93,105-118`) was wrong; the real functions are
+`DiscoverPointer` (`pointer.go:58-103`) and `ResolvePointerTarget`
+(`pointer.go:113-122`), and neither file contains the directory check itself —
+it is `absExistingDir` in `config.go:359-375` (`os.Lstat`, symlink reject,
+`IsDir` reject). What an `ssh://` pointer does **today**, traced:
+`ParsePointerFile` (`pointer.go:31-51`) accepts the line verbatim →
+`ResolvePointerTarget:118` finds `filepath.IsAbs("ssh://user@host/path")` is
+**false** → `:119` joins it onto the pointer's directory and `filepath.Join`'s
+`Clean` collapses the `//` into `<pointerDir>/ssh:/user@host/path` →
+`absExistingDir` fails ENOENT → and `config.go:229-234` treats a pointer error
+as **hard**, so the whole cascade dies before any ssh arm could run, naming a
+mangled local path. Fix: `ResolvePointerTarget` returns the raw line unchanged
+when it carries the `ssh://` prefix; `DiscoverPointer` propagates it; the caller
+branches. `ParsePointerFile` is unchanged (its grammar is already "one
+non-comment line").
+
+NEW `internal/loop/remote.go`: `RemoteConfig`; the URL grammar (`user`/`host`
+match `[A-Za-z0-9._-]+` and must not start with `-`; port 1–65535; path
+absolute); the canonical form (lowercase host, port elided at 22, no trailing
+slash); `hub-id = hex(sha256(canonical))[:12]`; `HubDir` / `HubConfigPath` /
+shadow-loop-dir builders; and the `E_NOT_JOINED` existence check (a **stat
+only** — see WI-4.1).
+
+(d) `Config` (`config.go:34-53`) gains `Remote *RemoteConfig`. The shadow
+LoopDir is `~/.agentchute/hub/<hub-id>/.agentchute/loop/` — the literal
+`.agentchute` segment keeps the dotdir invariant `vendorFromLoopDir`
+(`config.go:348-357`) relies on. An explicit `--loop-dir` /
+`AGENTCHUTE_LOOP_DIR` combined with an `ssh://` control repo is a **hard
+error** (rule 4).
+
+(e) Unit: grammar accept/reject table; pointer-vs-env precedence; shadow path
+shape; `E_NOT_JOINED` (no `config.json`) vs joined-with-the-same-path.
+
+(f) Done-when: `guard --pre-tool-use` in a joined checkout (hand-planted
+`config.json`) resolves the SHADOW latch with **no network call** — asserted by
+pointing the URL at an unroutable host and requiring the call to return
+promptly, not by mocking the transport; and an `ssh://` pointer no longer
+produces the mangled-local-path error.
+
+(g) ~280 LOC.
+
+**WI-4.3 — launcher forwarding: `dispatch.go` + `shims.go`.** *(B4 — ships in
+the SAME MERGE as WI-4.2; §6.8 rule 5: the arm and its launchers must ship
+together, or every `ac serve` in a joined checkout silently de-remotes itself
+with no error anywhere.)*
+
+(a) Make both launcher paths forward the **locator**, not the derived local
+paths.
+
+(b) §6.8 point 5 in full; §7.4 (canonical URL form).
+
+(c) MODIFY `internal/cli/dispatch.go`: `buildDispatchRunArgs`
+(`dispatch.go:245-258`, called at `dispatch.go:241`) today always emits
+`--control-repo <cfg.ControlRepo> --loop-dir <cfg.LoopDir>` (`:251-252`) from
+the RESOLVED config. In remote mode it must emit
+`--control-repo <cfg.Remote canonical ssh:// URL>` and **omit `--loop-dir`
+entirely**. A caller-supplied `--loop-dir` peeled off the dispatcher's global
+flags (`dispatch.go:220-223`) against a remote config is the rule-4 refusal,
+raised **in the dispatcher, before the exec**.
+
+MODIFY `internal/cli/shims.go`: the identical pair at `shims.go:304-305`, inside
+`cmdShimsExec` (`shims.go:259-312`), whose own `loop.Discover` call
+(`shims.go:285-289`) takes only `Cwd` + env.
+
+**Executability note the implementer needs.** `cmdShimsExec` is the **legacy**
+`ac-*` shim path: `removeLegacyWrapperShims` (`shims.go:237-257`) deletes those
+shims during setup, and only the single `ac` dispatcher
+(`renderDispatcherScript` `169-176`, `installDispatcher` `208-231`) is installed
+today. So the §10.3 "launcher preserves remoteness" row must **construct** a
+legacy `ac-*` shim (or call `cmdShimsExec` directly) to exercise this half — a
+row that only runs `ac serve` never touches `shims.go` and passes green while
+`shims.go` is still broken.
+
+(e) Argv golden tests for **both** launchers in **both** modes: remote ⇒
+`--control-repo ssh://…` present and `--loop-dir` **absent**; local ⇒ today's
+pair, byte-identical. Plus the rule-4 refusal test.
+
+(f) Done-when: the golden argv tests pass **and** a discovery round-trip on the
+emitted argv yields `Remote != nil` with `LoopDir` = the shadow. The assertion
+must be on `Remote != nil` — never on "the command succeeded", because today's
+code succeeds while running LOCAL against a mail-free shadow.
+
+**Cross-merge interlock (B5).** The migration attribution predicate in WI-5.3c
+has a `--control-repo`-URL arm that is correct **only because of this item**.
+They cannot land in one merge — the predicate has no caller until `hub join`
+exists (M5) — so the interlock is enforced by review instead, and this is
+binding: WI-5.3c's gate ask must re-verify this item's argv goldens at the M5
+head SHA, and the M6 rows "launcher preserves remoteness" **and** "migration
+attribution, normal lane" must both be green before v1.7.0. A reviewer of
+either item must check the other.
+
+(g) ~120 LOC.
+
+**WI-4.4 — ssh invocation builder + transport sessions (+ the ControlPath
+contingency).**
+
+(a) Spawn and own `ssh` per §4.2 exactly; frame client sessions over it.
+
+(b) §4.2 (both argv blocks verbatim, incl. `-T`, `BatchMode`, per-hub
+`known_hosts`, `IdentitiesOnly` + the symlinked `-i` path,
+`ClearAllForwardings`, the mux split: `ControlMaster=no` channel /
+`auto`+60 s one-shot), §4.6 deadlines, §4.4.2 client-side code mapping.
+
+(c) NEW `internal/hubclient/ssh.go`, `internal/hubclient/session.go`.
+
+(d) Argv exactly as §4.2. Code mapping: ssh remote exit 127 → `E_HUB_NO_BINARY`
+**immediately** (never burn the 10 s hello timeout); host-key stderr →
+`E_HOSTKEY_CHANGED`; auth failure → `E_UNAUTHORIZED`; `ssh` binary absent →
+`E_NO_SSH`.
+
+**ControlPath contingency (X5) — DESIGN §4.2 is silent; this plan decides, and
+the decision has a trigger that can actually be exercised.**
+
+- The one-shot ControlPath is `<muxDir>/%C`. The builder refuses to emit a path
+  whose worst-case expansion could exceed the unix `sun_path` limit, using the
+  **shipped** threshold verbatim:
+  `len(muxDir) + 1 + controlPathTokenWidth >= 100`, where `100` is the literal
+  `internal/loop/config.go:170` already uses for runner sockets (**one number in
+  the codebase, not two** — note it is a bare literal there, with no named
+  constant), and `controlPathTokenWidth = 64` is a deliberately **conservative
+  upper bound** for `%C`. Over-triggering the fallback costs one extra
+  authentication; under-triggering costs a broken mux and an opaque ssh error.
+- **Preferred** `muxDir` = `<hubdir>/mux`.
+- **First fallback**: `<tempRoot>/agentchute-hub-<uid>/<hub-id>`, trying
+  `os.TempDir()` then `/tmp`, taking the first that passes the same budget
+  (macOS's `$TMPDIR` is itself long, so `/tmp` is a real second candidate, not
+  decoration). Created and verified through the **shipped** owned-0700
+  discipline — `EnsureRunnerSocketDir` (`config.go:200-206`) →
+  `ensureOwnedRunnerSocketDir` (`internal/loop/runner_socketdir_unix.go:24-49`:
+  `MkdirAll` 0700, symlink reject, uid-ownership reject, `Chmod` 0700) —
+  generalized to a caller-supplied path rather than copied.
+- **Second fallback**: if neither passes, **disable multiplexing for this hub**
+  (`-o ControlMaster=no -o ControlPath=none` on one-shots) and emit exactly one
+  `warn` note naming both attempted paths. Correctness is unaffected; only the
+  per-op authentication cost changes. Never a hard refusal — an unusually deep
+  `$HOME` must not make the CLI unusable.
+- The **channel** is unaffected: it is already `ControlMaster=no
+  -o ControlPath=none` (§4.2).
+
+(e) Argv golden tests for both shapes; the exit/stderr → code mapping table;
+and a **deterministic deep-home builder test** that injects a synthetic hub dir
+of a pinned length (no real deep `$HOME`, no OS dependence): short ⇒ preferred
+path; long ⇒ first fallback; long **and** an over-budget/unwritable temp root ⇒
+mux disabled plus exactly one warn note.
+
+(f) Done-when: the golden argv matches §4.2 byte-for-byte in the preferred
+case, and all three ControlPath branches are asserted.
+
+(g) ~330 LOC.
+
+**WI-4.5 — one-shot routing + remote turn-end order.** *(P2, part a.)*
+
+(a) Route the CLI verbs over one-shot sessions with the §4.5.1 semantics, and
+implement the remote `turn-end` ordering.
+
+(b) §4.5.1 (read-after-hello), §6.6 (remote turn-end order and the E1 arming
+point), §3.5 (the `Announce` bullet — the view, the three facts it renders, and
+the announce-failure-rides-in-`Warnings` rule).
+
+(c) MODIFY `internal/cli/send.go`, `check.go`, `ack.go`, `status.go`,
+`gate.go`, `pending.go`, `boot.go`, `clean.go`, `turn_end.go`,
+**`self_check.go`**, **`register.go`**.
+
+**S1 — `self_check.go` is in the file list.** `selfRepairRegistration`
+(`self_check.go:117-133`) is step 0 of `turn-end` (`turn_end.go:120`) and the
+whole of `self-check` (`self_check.go:71`); in remote mode it becomes a wire
+`register`, and its "non-empty id even when the write failed" contract
+(`self_check.go:129-131`) must survive, because `turn_end.go:121-123` aborts
+only on an empty id.
+
+**The `status` renderer switch lands HERE, not in M1.** M1 left `printStatus`
+byte-unchanged and re-derived the STATUS label and the inbox depth locally
+(WI-1.4(d)), which a remote client cannot do — it can neither stat the hub's
+inbox dirs nor read its serve claims. In remote mode `cmdStatus` renders from
+the response instead: `StatusAgent.Status`, `.InboxDepth`, and
+`StatusResp.Now` for the AGE column (never the client's clock). The
+lenient-read warnings arrive as `warn` **`note` frames** and are printed by the
+same `warning: %s` stderr loop as local mode (WI-1.4(d)), which also keeps
+them ahead of the table; `Truncated:true` — set by the hub's `status-ok`
+encoder, never by the op (WI-3.1a) — renders as one trailing line that names
+**the wire limit as well as the row cap**, so a truncated remote listing is
+never silent AND never misattributed: the budget that binds first is often the
+64 KiB line, not 64 rows (WI-3.1a(d) — one row with a large `host` can
+truncate a three-agent pool), and a notice saying only "64 rows" would tell an
+operator with three agents something visibly false. The notice states the two
+limits and that rows were withheld; it does **not** state a total, because
+`status-ok` carries only the kept rows and the flag — a `total` field is a
+shape change no finding asked for, and inventing "N of M" from data the frame
+does not carry is worse than omitting it.
+
+**The notice's exact text is PINNED** (DESIGN §4.4.3 states the identical
+literal — two compliant implementations must not print two different lines,
+and the byte-exact assertions in (e) cannot be written against a paraphrase).
+One unindented line on **stdout**, emitted only when `truncated` is true, as
+the LAST line of `status` output (after the table and after any
+`PROTOCOL WARNINGS:` block), preceded by one blank line:
+
+`note: listing truncated by the hub at the first row that would exceed 64 rows or a 64 KiB response; later agent ids are missing.`
+
+Modelled on the shipped trailing notice at
+`internal/cli/check.go:262 @ 1244ae4` — lowercase `note: ` prefix, no indent,
+one sentence, a semicolon before the consequence. It names both budgets and
+states the PREFIX rule, so the operator knows the missing rows are the TAIL
+of the agent-id sort and not an arbitrary subset. Local mode keeps today's
+path unchanged, so `status_test.go` stays untouched here too.
+
+**The status HEADER is a decision this item owns, and it is: print the HUB's
+pointer.** The three header lines come from local config, never from row data
+(`internal/cli/status.go:98-100 @ 1244ae4`), so the settled row shape decides
+nothing about them and a renderer switch that only retargets the TABLE leaves
+a remote lane printing local paths above hub rows. Per DESIGN §3.6's header
+sub-bullet, on a remote lane (`cfg.Remote != nil`):
+
+- `control_repo:` prints the canonical `ssh://` URL from `cfg.Remote` — never
+  `cfg.ControlRepo`, which under §6.8 rule 2 is only the nearest local
+  ancestor holding `AGENTCHUTE.md` and exists for local concerns like hook
+  refresh (`serve.go:159`). The rows below came from the hub; a header naming
+  a local directory that holds none of them is §6.8 rule 5's failure one
+  command later. Keep `formatOriginSuffix(cfg.ControlRepoOrigin)`
+  (`status.go:210-215`) — the URL really is what the flag/env/pointer arm
+  resolved, so `(via env)` stays true.
+- `loop_dir:` keeps printing the **local shadow**, plus one parenthetical
+  line under it marking it as the shadow. **That line's exact text is PINNED**
+  (DESIGN §3.6 states the identical literal) — printed immediately under the
+  `loop_dir:` line and ahead of `vendor:`, with **two leading spaces** and no
+  trailing space, only when `cfg.Remote != nil`:
+
+  `  (local shadow: this process's own loop dir, not the hub's)`
+
+  It is modelled on the marker line already in this same header block,
+  `  (shadowed pointer: %s)` (`status.go:101-103 @ 1244ae4`), for its
+  two-space indent and parenthesised `label: value` form, and on
+  `  (pull-only: senders deliver to your inbox; you poll it yourself)`
+  (`internal/cli/boot.go:204 @ 1244ae4`) for a label followed by prose rather
+  than by a path. It genuinely is this process's
+  loop dir — guard latch, `runner.json`, the send spool all live
+  there (§6.8 rule 3, §4.5.3) — so replacing it loses a real diagnostic; and
+  the hub's loop dir is on another filesystem and rides on no frame
+  (`hello-ok` carries `pool`, a pool path, not a loop dir), so printing it
+  would mean a new wire field for a path the operator cannot open. What
+  misleads is the shadow printed UNMARKED, and the marker is the whole fix.
+- `vendor:` is unchanged, and needs no branch: `cfg.Vendor` is the loop dotdir
+  namespace, vendor namespacing is gone (`fixedNamespace`,
+  `internal/loop/config.go:19-25,348-357 @ 1244ae4`), and §6.8 rule 3 gives
+  the shadow the same `.agentchute/loop` shape deliberately — so both modes
+  print the same string. Do not "fix" this line to the actor's registered
+  vendor: `StatusAgent` carries no `Vendor` (T1b cut it), and re-adding a
+  field to feed a header line reopens a settled shape.
+- `ShadowedPointers` is unchanged — a diagnostic about local pointer files
+  that lost discovery, equally local in both modes.
+
+The branch keys on `cfg.Remote != nil` — already in hand wherever the header
+is printed, since `cfg` is the renderer's own argument (WI-1.4(d)) — so the
+header needs no new parameter and no new wire field, and
+`status_test.go:35,77,126,181` stay local-mode calls with unchanged output.
+
+**`register.go` is in the file list because the enrollment ANNOUNCE fan-out
+must move to the hub.** `cmdRegister` is the only command that fans out on
+enrollment, and it does so by calling `loop.AnnounceEnrollment(cfg, reg)`
+directly against the discovered config and rendering the result
+(`register.go:280-294 @ 1244ae4`). On a remote lane that `cfg` is the
+**mail-free shadow** (§6.8 rules 2–3), whose agents dir holds no peer
+registrations at all — so the call would walk an empty directory, print
+`no peers to announce to`, and exit 0: announced to nobody, silently, **no error
+anywhere**. Same failure class as §6.8 rule 5's de-remoted launcher, one command
+later. The request/response fields that fix it were pinned in M1 (WI-1.6:
+`RegisterReq.Announce`, `RegisterResp.Announce *AnnounceView`) and deliberately
+left with **no caller**; this item is where the caller lands. The rule, both
+arms:
+
+- **Local (`cfg.Remote == nil`) — unchanged.** The direct `loop.AnnounceEnrollment`
+  call may stay exactly where it is and render exactly as today; M1's adapter
+  already passes `Announce:false` (WI-1.6), so `register_test.go` stays
+  untouched here as it did there.
+- **Remote (`cfg.Remote != nil`)** — `cmdRegister` MUST NOT call
+  `loop.AnnounceEnrollment`. It sets `RegisterReq.Announce` from the
+  `--announce` flag (`register.go:210`) so the **hub** performs the fan-out over
+  its own pool, and renders from `RegisterResp.Announce`, reproducing today's
+  output line-for-line and stream-for-stream:
+  - each `Announce.Warnings` entry ⇒ `warning: <w>` on **stderr**
+    (`register.go:285-287`);
+  - `Announce.Total == 0` ⇒ `  announce:      no peers to announce to` on
+    **stdout** (`:288-289`);
+  - otherwise ⇒ `  announce:      sent to %d of %d peer(s)` from `Sent` **and**
+    `Total` (`:290-292`).
+
+  A hub-side announce that failed outright arrives as `Announce == nil` plus an
+  `announce failed: <err>` entry in `RegisterResp.Warnings` (§3.5), printed by
+  the existing warnings loop (`:276-278`) — the same bytes in the same stderr
+  position as today's `warning: announce failed: %v` (`:282-284`) — and
+  `register` still exits 0. `--announce` unset ⇒ `Announce:false` on the wire and
+  nothing rendered, as today.
+
+**Boot's sweep crosses the wire here (T3).** `RegisterReq.Sweep` was pinned in
+M1 with no `true` caller (WI-1.6(d)); this is where it gets one, and the two
+arms must stay exclusive:
+
+- **Local (`cfg.Remote == nil`) — unchanged.** `cmdBoot` sends `Sweep:false`
+  and keeps its own `loop.SweepStaleRegistrations` call (`boot.go:99-101`),
+  appending `sweep stale registrations: <err>` to `result.Warnings` on
+  failure exactly as today. `boot_test.go` is untouched.
+- **Remote (`cfg.Remote != nil`)** — `cmdBoot` sets `Sweep:true` on the wire
+  register **and skips `boot.go:99-101` entirely**. Skipping is not an
+  optimization: that call would run against the discovered cfg, which on a
+  remote lane is the mail-free shadow (§6.8 rules 2–3) — a sweep of a pool
+  with no peer rows, i.e. hygiene performed on the wrong filesystem while the
+  hub's pool goes unswept. The hub runs it instead, after the registration
+  write, and a failure comes home in `RegisterResp.Warnings`, which
+  `cmdBoot` already renders through `bootStatus.Warnings` (`boot.go:143`) —
+  same string, same field, same output position.
+- **No other command sweeps**, verified at `1244ae4`: the only other
+  production caller is the runner tick (`serve.go:640`), which is `op.Tick`'s
+  (WI-1.7) and unaffected. `register`, `self-check` and `turn-end`'s step-0
+  repair all send `Sweep:false` in both modes, as does the channel's startup
+  `register` (WI-5.1) — whose lane sweeps on its first tick anyway. **Exactly
+  one sweep per boot, in either mode; zero for every other verb.**
+
+**Remote result paths render the RESOLVED vendor (T4).** S2 has the four
+remote call sites send `Vendor:nil` so the HUB resolves it — but all three
+renderers print the **pre-wire** `opts.Vendor`, which on exactly those bare
+invocations is the empty string: `cmdRegister` (`register.go:269`), `cmdBoot`
+(`boot.go:136`, feeding `bootStatus.Vendor` and therefore all four boot
+emitters) and `cmdSelfCheck` (`self_check.go:78`). Sending nil and printing
+the request field means a successful bare `register`/`boot`/`self-check` on a
+remote lane renders `vendor: ` — an empty vendor on a success path. **Fix: all
+three read `result.Reg.Vendor` (the resolved value the hub wrote) instead.**
+This is one code path, not a mode branch: locally the two are provably the
+same value, because `publishRegistrationOnce` sets `Vendor: opts.Vendor`
+unconditionally (`register.go:133`) and the merge arm touches only
+`WorkingRepos` and `Body` (`register.go:140-149`), so no local test output
+changes. `RegisterResp.Reg` already carries `Vendor` (WI-1.6(d)'s
+`RegistrationView`) — nothing new goes on the wire.
+
+`register` is also **S2's fourth `resolveAgentVendor` call site**
+(`register.go:259`); its `Vendor:nil` branch rides on the same remote arm added
+here (`boot.go:86` and `self_check.go:126` are already this item's;
+`serve.go:152` is WI-5.1's).
+
+**No other command announces**, verified at `1244ae4`: `loop.AnnounceEnrollment`
+has exactly one caller in the whole tree (`register.go:281`), and `boot`,
+`serve`'s `registerRunner` and `self-check` all reach `performRegister` with no
+announce input of any kind (`cmdBoot`'s flag set declares none,
+`boot.go:26-40`). So this branch is `register`'s alone — no other file in this
+item's list needs it. (§2 rule 3: WI-4.8 also touches `register.go` for the
+`resolveAgentID` signature, so the two run in numeric order, never in parallel.)
+
+(d) Remote `turn-end` order (§6.6), stated against today's local code
+(`turn_end.go:120` / `144-158` / `162-166` / `169`): **(0)** best-effort wire
+`register` carrying the inherited `AGENTCHUTE_SERVE_TOKEN` — a failure is warned
+with `turn_end.go:126`'s text and does **not** abort; **(1)** wire `ack`;
+**(2)** LOCAL `ClearGuardLatch`; **(3)** wire `gate`. The step-1 latch-ownership
+test (`turn_end.go:144-150`) is local and unchanged — the latch never crosses
+the wire (§6.6).
+
+**E1**: `check`'s event emitter arms the local latch on the FIRST
+`MessageEvent`, **before rendering it**, in both the normal and `--no-archive`
+paths — mirroring `setLatch` at `check.go:185/243/256`, never after the wire op
+returns.
+
+(e) In-process harness (the WI-3.3a fake-transport session driven as a
+subprocess over pipes): every verb round-trips; the turn-end order asserted by
+call trace; `turn-end` with the hub unreachable leaves the latch armed and the
+claimed mail in the hub's `.claimed/`.
+
+Plus the row **remote `status` renders the hub, header included**: against a
+hub pool of three agents, with the client's clock skewed and its shadow
+holding no rows at all, run `agentchute status` remotely and assert (1) the
+STATUS and INBOX columns and the AGE column come from the response
+(`StatusAgent.Status`, `.InboxDepth`, `StatusResp.Now`) and are byte-identical
+to the same pool driven locally with the clock pinned — a renderer still
+re-deriving them locally prints `-`/`0`/a skewed age and fails; (2) the header
+prints `control_repo:` = the canonical `ssh://` URL with its `(via …)` suffix,
+`loop_dir:` = the shadow WITH its marker line, asserted **byte-exact** against
+the marker literal pinned in (d) (two leading spaces included), `vendor:` =
+the same string the local run printed; a renderer that leaves the header on
+`cfg.ControlRepo` fails this row by printing a local path above hub rows;
+(3) the `warning: …` lines land on stderr AHEAD of the table.
+
+Then plant one valid registration whose `host` alone exceeds 64 KiB in the
+same three-agent pool and re-run. **The fixture pins WHERE that row sorts:
+the oversized `host` belongs to the lexicographically LAST of the three agent
+ids** — say `alpha` / `bravo` / `zulu`, with the huge host on `zulu`. The
+producer emits a PREFIX of the sort order (WI-3.1a(d)), so an oversized row
+sorting first or in the middle drops every row behind it and "the other two
+agents still render" would be false; the first-row case is its own
+producer-level row and asserts `agents:[]` with both later rows dropped
+(WI-3.1a(e)), so this integration row must not contradict it. With the row
+sorting last: the other two agents still render, and the trailing truncation
+line is asserted **byte-exact** against the notice literal pinned in (d) — it
+names the WIRE limit as well as the row cap, and a notice naming only
+"64 rows" is false on a three-agent pool and fails this row.
+
+Plus the row **`register --announce` fans out HUB-side** — the M4 half of
+§10.3's "register field semantics (C2/D1)" row, its announce clause, landing
+here because the branch ships here; WI-5.7 re-runs that row whole. Against a hand-planted `config.json` (WI-4.1) and a hub pool
+seeded with three peers, one of them undeliverable — the undeliverable one must
+be a **readable** registration whose inbox write fails, since an unreadable
+registration warns *without* incrementing `Total` (`message.go:75-83`) and would
+quietly change the expected counts — run
+`agentchute register --as <id> --announce` and assert: the wire request carries
+`announce:true`; the **hub's** two reachable inboxes each gain one message; the
+**shadow's** loop tree is byte-unchanged; stdout carries
+`  announce:      sent to 2 of 3 peer(s)` and stderr the one per-peer warning,
+byte-identical to the same pool driven by a local `register --announce`.
+**This row fails if the local `loop.AnnounceEnrollment` call is left in place on
+a remote lane**: the shadow has no peers, so the local call renders
+`  announce:      no peers to announce to`, writes nothing hub-side, and still
+exits 0 — which is why the assertion is on hub-side inbox files AND the rendered
+counts, never on "the command succeeded". Two arms beside it: a hub pool with
+**no** peers ⇒ `  announce:      no peers to announce to`; a hub-side announce
+error ⇒ `Announce` nil, `warning: announce failed: <err>` on stderr, exit 0.
+
+Plus the row **remote `boot` sweeps HUB-side, exactly once (T3)**: with a
+stale, lease-dead peer row planted in the HUB pool and an identically named
+row planted in the SHADOW, run `agentchute boot --as <id>` remotely and
+assert the wire request carries `sweep:true`, the hub's stale row is gone, the
+**shadow's row is untouched** (proving the local call was skipped, not merely
+duplicated), and a hub-side sweep failure surfaces as
+`sweep stale registrations: <err>` in boot's rendered warnings. Beside it:
+remote `register`, `self-check` and `turn-end` each send `sweep:false` and
+leave the hub's stale row in place.
+
+Plus the row **the resolved vendor is rendered, not the request's (T4)** — the
+M4 half of §10.3's "remote vendor resolution skipped client-side (S2)" row.
+In a joined checkout whose hub pool holds a custom-id row with vendor
+`anthropic` that no canonical-prefix rule can name, run each command **bare**
+(no `--vendor`) and assert the OUTPUT, not just the wire and the exit code:
+`register` ⇒ stdout carries `  vendor:        anthropic` (text only — the
+command has no `--json`); `boot` ⇒ `emitBootText`'s
+`Registered|Refreshed <id> (anthropic) — …` **and** `boot --json`'s
+`"vendor":"anthropic"`; `self-check` ⇒ its text line **and** `self-check
+--json`'s `"vendor":"anthropic"`. Each of the three fails today with an empty
+vendor rendered on a success path, which is the defect. Assert the same three
+outputs from a LOCAL run of the same pool, byte-identical.
+
+(f) Done-when: all remote verbs work against the in-process harness and the
+four turn-end steps execute in the pinned order with step 0 non-fatal; a
+remote `register --announce` puts the announcements in the **HUB's** inboxes
+(never the shadow) with its three output lines byte-identical to local mode;
+remote `boot` sweeps the hub pool once and the shadow never; no
+remote `register`/`boot`/`self-check` can render an empty vendor on success;
+and a remote `status` renders the hub in BOTH halves — table from the response,
+header on the `ssh://` pointer with the shadow marked — with its shadow marker
+line and its truncation notice each byte-identical to the literals pinned in
+(d).
+
+(g) ~300 LOC.
+
+**WI-4.6 — send ambiguity + spool.** *(P2, part b.)*
+
+(a) The §4.5.3 fail-closed, never-replay semantics.
+
+(b) §4.5.3 in full; §7.5's `E_SEND_UNKNOWN` text.
+
+(c) MODIFY `internal/cli/send.go`, `internal/hubclient/session.go`.
+
+(d) The **ambiguity window opens at the first byte handed to the ssh child's
+stdin** and closes when `send-ok` or an `error` frame for that `id` is read.
+This needs a deliberate test seam in the transport — a package-level
+`var afterSendFirstByte func()` in `internal/hubclient`, mirroring the shipped
+`afterSendPreflightHook` idiom (`internal/cli/send.go:19`) — and must **not** be
+approximated as "after the response deadline". The remote spool is
+`~/.agentchute/hub/<hub-id>/spool/`, deliberately **outside** the shadow loop
+tree, because `rejectLoopStateBodyFile` (`send.go:600-633`) would otherwise make
+the printed retry command refuse its own file. The retry command is
+`--body-file <spool>` — never local mode's `< <spool>` redirection, which the
+guard denies while latched.
+
+(e) Before-window failures spool and exit 1 with a safe-retry text; in-window
+failures spool, exit 1 with `E_SEND_UNKNOWN`, and never retry automatically; a
+`send-ok` with a non-empty `durability_note` renders `send.go:269`'s
+"delivered … Do NOT resend".
+
+(f) Done-when: the `E_SEND_UNKNOWN` test proves **at most one inbox file**
+hub-side, and the printed retry command is executed in the test and **accepted**
+by `--body-file` (proving the spool path is not self-refusing).
+
+(g) ~180 LOC.
+
+**WI-4.7 — negative cache + hook-mode `boot`.** *(P2, part c.)*
+
+(a) The 30 s negative cache and the hook-context degradation rule.
+
+(b) §7.5 (the hook-context degradation paragraph and the cache), D6.
+
+(c) NEW `internal/hubclient/cache.go`; MODIFY `internal/cli/boot.go` (the
+hook-mode arms, `boot.go:15-40`), `pending.go`, `self_check.go`.
+
+(d) Any `E_CONNECT` writes `~/.agentchute/hub/<hub-id>/hub-down.json`
+`{"last_econnect":"<T>"}`; until `T+30s` the **participants** — `pending`,
+`self-check`, and **hook-mode `boot`** (`--context-only` /
+`--codex-hook SessionStart`, D6) — skip the dial entirely and take the
+warn-to-stderr-and-exit-0 path. Any successful connection deletes the file.
+**Bypassers**: `turn-end` (it is the commit path — correctness over latency) and
+every human-typed command (`send`, `check`, `doctor`, interactive `boot`).
+
+(e) Row: with the hub down, hook-mode `boot` then `pending` within 30 s ⇒
+**exactly one** dial (one 5 s stall), both exit 0; a successful connection
+clears the file.
+
+(f) Done-when: that row is green and the bypass list is asserted (a `turn-end`
+during the cache window still dials).
+
+(g) ~130 LOC.
+
+**WI-4.8 — names-map runtime resolver.**
+
+(a) Local-name → joined-id resolution at the single identity choke point, plus
+the direct-serve fallback candidate.
+
+(b) §7.2 (the naming block and the runtime-resolution bullet in full, rounds
+9/9b/10).
+
+(c) MODIFY `internal/cli/identity.go`, **`internal/cli/identity_test.go`**.
+**CORRECTION**: `resolveAgentID` is
+`identity.go:13-25` and `resolveAgentIDRaw` is `identity.go:27-39` — the
+round-1 citation `13-38` conflated them. The map lookup goes **inside**
+`resolveAgentID` and needs the discovered config, so its signature gains a
+parameter.
+
+**`identity_test.go` calls `resolveAgentID` DIRECTLY, five times (T2)** —
+`identity_test.go:19`, `:25`, `:33`, `:44`, `:55` — so the signature change
+leaves those five sites uncompilable, and the widened move-set rule (M1
+preamble, population 2) requires them named rather than discovered at build
+time. They are the ONLY direct test calls in the tree: the same grep over
+`internal/cli/*_test.go` finds no other caller, and `:20`/`:26` are format
+strings inside the assertions, not calls. Each update is the same one-token
+edit — pass the `cfg` the test already has, or `nil` — so the honest arm is
+naming the file, not inventing a compatibility shim:
+- **`nil` cfg must be legal and must mean "no map"**, which these five sites
+  rely on. `TestResolveAgentIDRejectsTraversal` (`:19,:25`) and
+  `TestResolveAgentIDExplicitOnly` (`:33,:44,:55`) construct no pool at all;
+  they assert flag-beats-env, env fallback, traversal rejection, and the
+  exact `missingAgentIdentityHint` text. Every one of those is map-free
+  behavior and its assertion must not change by a byte — a nil (or
+  pool-less) cfg resolves the candidate verbatim, exactly as today.
+- `TestCommandsWithoutIdentityFailWithHint` (`:65-92`) drives whole commands
+  and needs nothing: it never names `resolveAgentID`.
+- The alternative — keeping the old signature behind a cfg-aware helper —
+  is rejected: it leaves two spellings of the one identity choke point this
+  item exists to make single, which is how a later caller silently gets the
+  unmapped one.
+
+**All 12 `resolveAgentID` call sites are in scope (R9), enumerated** — a
+signature change updates every caller, so the file list is the union and §2
+rule 3 reads it that way: nothing else may run in parallel with this item on
+these files. Each site already Discovers **before** resolving except the three
+called out below, so each just passes `cfg`:
+`check.go:87`, `ack.go:91`, `boot.go:78`, `pending.go:63`, `send.go:127`,
+`gate.go:80`, `clean.go:80`, `register.go:254`, `self_check.go:118`,
+`serve.go:145`, plus the two reorder cases `status.go:34` and
+`identity_cmd.go:24`. (`guard.go:175-189` is a **13th, inline** resolution that
+never calls `resolveAgentID`; it is handled separately below.)
+
+**S8 — the three call sites that resolve identity BEFORE `loop.Discover`**, all
+verified, with one correction:
+
+- `internal/cli/status.go:34` calls `resolveAgentID` and only then Discovers at
+  `status.go:43` — reorder. **status.go appeared in no work item in round 1;
+  it is named here.**
+- `internal/cli/guard.go:175-189` resolves **inline** (deliberately not via
+  `resolveAgentID`) and Discovers at `guard.go:195` — reorder and route the
+  lookup through the same map. **Keep the fail-open behavior on every failure**
+  (`guard.go:171-173`, `184-189`, `202-204`): a guard that starts failing
+  *closed* on a resolution error is a worse regression than the one being
+  fixed.
+- `internal/cli/identity_cmd.go:24` — **CORRECTION to the finding**: this file
+  calls `resolveAgentID` at `:24` and **never calls `loop.Discover` at all**
+  (it does not even import `internal/loop`; its `--control-repo`/`--loop-dir`
+  flags at `identity_cmd.go:13-18` are declared and unused). So this is not a
+  reorder but an **addition**: `identity_cmd.go` gains a `loop.Discover` call
+  before resolution. **That Discover MUST be non-fatal** — on any discovery
+  error, fall back to today's behavior and print the resolved id unchanged.
+  `agentchute identity` currently succeeds in a directory with no pool at all,
+  and must keep doing so.
+
+MODIFY `internal/cli/serve.go`: pass `launchedWrapper` (computed at
+`serve.go:122-129`, today consumed only at `serve.go:159-161`) as the fallback
+candidate when both `--as` and `AGENTCHUTE_AGENT_ID` are absent —
+`resolveAgentIDRaw` has exactly two sources today (`identity.go:27-39`) and then
+errors, which is precisely the quickstart's own bare
+`agentchute serve codex` in a fresh shell.
+
+(d) Rule: take the candidate from `--as` / `AGENTCHUTE_AGENT_ID` / the wrapper
+default as today; **if the candidate is a LOCAL NAME present in
+`config.json.names`, resolve it to the joined id; treat it as a pool id only
+when it is not in the map or already equals the joined id.** **No send-side peer
+aliasing** — `--to` is never mapped.
+
+(e) Rows, in-process now and re-run under sshd in M6: "resolver, direct launch
+with env UNSET" (this row must **not** export env — the earlier row
+false-greened by doing so); "resolver with env exported", both launch paths;
+unmapped passthrough; `--to` never mapped.
+
+(f) Done-when: both resolver rows green in-process; `agentchute identity`
+still succeeds outside any pool; and `identity_test.go`'s diff is limited to
+the five call sites in (c) — same test names, same assertions, same
+`missingAgentIdentityHint` comparison — with `go vet ./...` clean, i.e. no
+other test file needed an edit.
+
+(g) ~180 LOC.
+
+**WI-4.9 — `agentchute identity` listing + doctor client-side checks.**
+
+(a) `identity` lists the local-name map and the resolution; `doctor` gains the
+`hub` group (client half).
+
+(b) §7.2 (the identity listing), §7.6 (config/key/connect/identity/pool lines;
+the `AGENTCHUTE_CONTROL_REPO` warning; the env local-name warning with its
+EXACT text; the negative-cache report; `E_NO_SSH` FAIL).
+
+(c) MODIFY `internal/cli/identity_cmd.go` (it gained a non-fatal Discover in
+WI-4.8), `internal/cli/doctor.go` (a new check group beside `runDoctorChecks`,
+`doctor.go:197`).
+
+(e) Row "env local-name warning"; the doctor probe budget is 10 s via one
+one-shot hello.
+
+(f) Done-when: `doctor` output matches the §7.6 sample shape against the
+in-process harness, each line has its FAIL form naming the §7.5 remediation
+verbatim, and `identity` outside a joined checkout is byte-identical to today.
+
+(g) ~160 LOC.
+
+**WI-4.10 — the CLIENT half of the W vectors.** *(S7 — these could not run in
+M3.)*
+
+(a) The two W vectors whose client-side behavior M3 had no client to test.
+
+(b) §9.3 (W1, W2); §4.5.2, §4.5.3.
+
+(c) MODIFY `internal/spectest/wire.go` — add the client-driven halves as
+**exported, transport-parameterized helpers** beside the hub-side ones (R6, the
+same rule WI-3.5 pins: assertions never live in a `_test.go`, or WI-6.4 cannot
+import them) — and `internal/spectest/wire_test.go` to drive them over
+`net.Pipe`. Both halves reuse the **same** `conformance/vectors/wire.json`
+definitions, so the vector has one source and two drivers.
+
+(e) **W1-client**: after a disconnect mid-`check`, the NEXT check redelivers and
+renders the REDELIVERED banner (the `check.go:180-193` path). **W2-client**: an
+in-window disconnect is reported as `E_SEND_UNKNOWN`, the body is spooled, and
+nothing is replayed automatically — asserted by counting **hub-side inbox
+files**, not by inspecting client state.
+
+(f) Done-when: W1–W5 are green with hub-side halves (M3) and client halves (M4)
+in one `tools/test.sh` run. The sshd re-run is WI-6.4's and gates the tag.
+
+(g) ~120 LOC.
+
+### M5 — remote serve channel + join/authorize UX
+
+**WI-5.1 — channel lifecycle in `serve`.**
+
+(a) Remote mode of `cmdServe`: a dedicated channel, the §6.1 startup order, the
+tick loop, and fence-on-drop.
+
+(b) §6.1 (hello → lease-acquire → register(+token, template) → export token →
+child; the `E_LEASE_HELD` refusal text), §6.2, §6.4 (client steps; the hub-side
+release is WI-3.3a's), §6.5 (last-tick counts; single channel writer), §6.8
+point 1 (env exports).
+
+(c) MODIFY `internal/cli/serve.go` (`runWrapper` branches on `cfg.Remote != nil`;
+`runnerChildEnv` `serve.go:502-530`; the fence path `serve.go:616-623` /
+`937-953` reused); NEW `internal/hubclient/channel.go`.
+
+(d) - The remote startup order is **register BEFORE child** — a deliberate
+  strengthening over the local order (lease `serve.go:374` → child
+  `serve.go:379-385` → register `serve.go:393`), which M1 pinned as unchanged
+  (C10). Both orders coexist; the branch is on `cfg.Remote`.
+- Env exports (§6.8 rule 1): `AGENTCHUTE_CONTROL_REPO=<canonical ssh:// URL>`
+  and **no** `AGENTCHUTE_LOOP_DIR` — strip an inherited one, the same hygiene
+  `runnerChildEnv` already applies to `AGENTCHUTE_GUARD` (`serve.go:510`, with
+  the five appends at `511-521` and the guarded re-add at `522-528`).
+  `AGENTCHUTE_SERVE_TOKEN` (`serve.go:520`) carries `Channel.Token()`.
+- **Single channel writer** (§6.5): only the tick goroutine ever writes to the
+  ssh child's stdin; nothing else holds a reference to it. Two goroutines
+  interleaving bytes would corrupt framing and spuriously fence the child.
+- `hasPendingInboxMail` (`serve.go:757-763`) becomes "last tick's counts"
+  (≤5 s stale), and so does `injectIfPending`'s immediately-before-injecting
+  re-check (`serve.go:740-750`) — there is no `poll` op. Preserve the fail-open
+  direction the local listing-error path already chose.
+
+(e) In-process: the startup order asserted; tick cadence 5 s; a channel drop ⇒
+SIGTERM to the child ⇒ exit path; the counts feed `enqueueWake` unchanged
+(`serve.go:659-668`).
+
+(f) Done-when: a scripted child under a fake channel gets cued on
+tick-pending and fenced on drop, and the child's environment carries the URL
+with no `AGENTCHUTE_LOOP_DIR`.
+
+(g) ~400 LOC.
+
+**WI-5.2 — supervised relaunch (default-on).**
+
+(a) §6.7 in full.
+
+(b) §6.7; §8 rows 22–24.
+
+(c) MODIFY `internal/cli/serve.go`.
+
+(d) `--relaunch` boolean, **default true iff `Remote != nil`**, error on a
+local serve; trigger set = transport loss (ssh child exit, tick deadline,
+`E_CONNECT` during an attempt) plus **exactly one** attempt on `E_FENCED`,
+stopping for real if that attempt sees `E_LEASE_HELD`; **never** on
+`E_IDENTITY` / `E_VERSION` / `E_POOL_MISMATCH` / `E_HOSTKEY_CHANGED`; backoff
+1 → 2 → 4 … capped at 60 s with ±20 % jitter, unbounded attempts; a fresh §6.1
+sequence and a fresh child with the **original argv verbatim**
+(`opts.WrapperArgs`, `serve.go:117`); one status line per attempt to the
+terminal and the runner log; the dead session's latch is inert by construction
+(`internal/loop/guard.go:20-24` — a latch whose stored session differs from the
+current key reads as unset to every reader).
+
+(e) Rows (in-process now, sshd in M6): "supervised relaunch — default path
+(D5)" driven with a **bare** `agentchute serve` (an implementation that kept
+relaunch opt-in fails this row); "relaunch opted out"; "`E_FENCED` single
+relaunch attempt".
+
+(f) Done-when: all three green in-process, with exactly one lane instance and
+the old child SIGTERM'd first in the default row.
+
+(g) ~250 LOC.
+
+**WI-5.3a — `hub join`: core flow.** *(S9 split, part a.)*
+
+(a) URL validation, naming, the lock file, probing, the pointer, shims, and the
+env warnings — everything except keys (5.3b) and migration (5.3c).
+
+(b) §7.2 (naming block, shadowing refusals, the per-hub-dir mutual exclusion
+block, probe-before-pointer, writability, shim install), §7.4 (pointer
+lifecycle), §7.5 (the three join refusal texts this item emits).
+
+(c) NEW `internal/cli/hub_join.go` (+ helpers in `hub.go`).
+
+(d) - URL validated against the §7.4 grammar; canonicalized; `hub-id` derived.
+- **Naming**: with `--as` omitted, mint `<local-name>-<hostname>`;
+  `<local-name>` is `--name`'s value canonicalized through `wrapperForToken`
+  (**`internal/cli/shims.go:51-64`** — CORRECTION: it is not in `dispatch.go`;
+  `dispatch.go:133,147` merely calls it), `<hostname>` is the first DNS label of
+  `os.Hostname()`. Each component sanitized to `[a-z0-9][a-z0-9-]*` **exactly**:
+  lowercase; every character outside `[a-z0-9-]` → `-`; runs of `-` collapsed;
+  leading/trailing `-` trimmed; an empty result is an error. `--as` at join time
+  is minted **verbatim**, never suffixed. The mapping is minted once and
+  recorded in `config.json.names`; a later hostname change never re-derives it.
+- **A non-wrapper `--name` is REFUSED** (S4), before keygen and before any
+  authorize call, with the §7.5 text. The rule is forced by both launch paths:
+  `ac serve <token>` hard-refuses an unknown token at `dispatch.go:133-137`
+  before any identity work, and direct `agentchute serve <token>` treats the
+  positional as the **wrapper command to exec** (`serve.go:117-129`) — so a
+  non-wrapper name produces a lane with no launch form at all. Teaching the
+  dispatcher the `names` map is the **rejected** alternative (§7.3); do not
+  implement it.
+- **Local-name / pool-id shadowing is REFUSED in BOTH orders**, before keygen
+  and authorize, with the two exact §7.2 texts.
+- **The lock file (G2)**: `~/.agentchute/hub/.locks/<hub-id>.lock` — a
+  **sibling** of the dirs it guards, because migration renames and deletes them.
+  Taken **before any probe** and held to the end of the run. Idiom: the shipped
+  one, generalized to a caller-supplied lock path rather than an agent state dir
+  — `syscall.Flock(fd, LOCK_EX|LOCK_NB)` in a deadline-bounded poll loop
+  (`internal/loop/filelock_unix.go:46-67`; `agentLockTimeout` 5 s at `:20`,
+  `agentLockRetryInterval` 25 ms at `:23`). `.locks/` is created 0700 on demand.
+  One acquisition per run, never nested. Timeout ⇒ the named §7.5 refusal,
+  **never a silent wait**.
+- **Probe before pointer**: `.agentchute-control-repo` is written only after a
+  probe proves the hub is real (a successful hello, or an SSH auth refusal —
+  which proves host + sshd + reachability). Connect/DNS/host-key failures write
+  nothing. Join appends the pointer filename to `.git/info/exclude`; if the
+  pointer is already **tracked**, warn loudly instead of hiding it.
+- **Writability proof (G-M5)**: the verification hello checks
+  `hello-ok.writable`, and a false verdict fails the join with the §7.2 text.
+- **Auto-authorize** over the operator's own SSH (interactive, not BatchMode),
+  single-quoting **per argument**; every value already excludes `'` by grammar.
+  On failure, print the complete ready-to-paste line and exit 0.
+- Shim install (reusing setup's machinery) + the new-shell reminder; the
+  `AGENTCHUTE_CONTROL_REPO`-disagrees-with-pointer warning.
+
+(e) Rows in-process: join idempotence; default naming; the hostname-change
+invariant; shadowing both orders; the non-wrapper `--name` refusal (no key file,
+no authorized_keys line, no `config.json` change); sanitization cases; lock
+mutual exclusion (two concurrent joins ⇒ exactly one proceeds, the other gets
+the lock-busy refusal, state identical to a single run).
+
+**(f) Done-when — X4, the circular done-when fixed.** The §7.2 quickstart
+transcript is reproduced against the **M5 in-process harness** (WI-3.3a's
+fake-transport session, driven as a subprocess over pipes), **not** against real
+sshd. The real-sshd quickstart transcript is WI-6.2's "join→authorize→verify
+happy path" row. Round 1 pointed this item at "the M6 harness", which does not
+exist while M5 is being implemented.
+
+(g) ~320 LOC.
+
+**WI-5.3b — `hub join`: key lifecycle.** *(S9 split, part b — specialist
+hand-off inside the M5 merge; see §2 rule 1 and §4.)*
+
+(a) Keygen, versioning, the active symlink, rotation, and the recovery
+classifier.
+
+(b) §7.2 (key handling, the version-file grammar G3, `--rotate-key`, and the
+three recovery shapes E3/F3/H3/J2).
+
+(c) NEW `internal/cli/hub_keys.go` (helpers used by `hub_join.go`).
+
+(d) - **Idempotent by contract (G-B1)**: if `keys/<id>_ed25519` already exists,
+  join **reuses** it — never a second keygen, never a surprise `--replace-key`.
+  Generation happens only when absent, with the exact §7.2 argv
+  (`ssh-keygen -q -t ed25519 -N "" -C agentchute:<id> -f …_ed25519.v1`), then
+  the active-pointer symlink. `ssh-keygen` is **never** re-run onto an existing
+  path (`-q` still prompts "Overwrite?", which hangs a scripted join).
+- A pre-existing passphrase-protected key is refused (probe:
+  `ssh-keygen -y -P "" -f <key>` must succeed).
+- **Version-file grammar (G3), normative**: `.v<N>` is parsed as a **NUMBER**,
+  `<N>` matching `^[1-9][0-9]*$`, and ordering is **numeric** — `v10` is newer
+  than `v2`; minting uses `max(existing N) + 1`. A **non-numeric suffix is not a
+  version file and is never guessed at**: `v01`, `v2b`, `vold`, `v` are excluded
+  from the scan, neither adopted as newest nor pruned as residue, and the run
+  **refuses**, naming the file with the §7.5 text. `*.pub` and `*.invalid.*` are
+  never version candidates.
+- **`.invalid.<ts>`** is `<original-file-name>.invalid.<stamp>` where `<stamp>`
+  is the codebase's existing UTC filename stamp (`tsStampLayout`,
+  `internal/loop/tsid.go:22,51`) — microsecond resolution, so two retirements
+  within one second cannot collide; the `.pub` half is retired under the **same**
+  stamp. Retired files are inert forever.
+- **There is deliberately NO `.pub` symlink** — `keys/<id>_ed25519` is the one
+  and only pointer, and the current pubkey is **derived**:
+  `readlink(keys/<id>_ed25519)` → `<id>_ed25519.v<N>` → pubkey is
+  `keys/<id>_ed25519.v<N>.pub`. This is what keeps promotion ONE atomic step.
+  Both paste lines that need a "current pubkey" resolve it this way: §7.5's
+  `E_UNAUTHORIZED` prints the **active** target's pubkey; the rotation-recovery
+  branches print the pubkey of the version that branch selected (the STAGED
+  `v<N+1>.pub` while resuming, the ACTIVE `v<N>.pub` in the residue branch).
+- **`--rotate-key`**, five steps: mint `v<N+1>` at its versioned path (keygen,
+  then dir fsync) → remote replace via `hub authorize --replace-key`, **only**
+  over the operator's own unrestricted SSH or the printed paste line (never over
+  the agent's pinned key, whose forced command can only run `hub session`) →
+  promote (write a temp symlink, one `rename()` over the active path) → verify
+  by hello with the new active key → delete the `v<N>` files.
+- **Recovery classifier**, run by EVERY join/rotate, in this order: (1)
+  **version files with no pointer symlink** (H3a) — probe the newest with
+  `ssh-keygen -y -P ""`; pass ⇒ adopt (create the initial symlink) and continue;
+  fail ⇒ `.invalid.<ts>` rename and mint fresh. (2) **A version newer than the
+  symlink's target** (staged rotation) — probe hello with the STAGED key FIRST;
+  success ⇒ promote if needed, then fall through to (3), never re-driving the
+  remote replace over a now-revoked key; staged failure ⇒ if the active key still
+  answers, resume at step 2 through the operator path; if neither answers, print
+  the paste line with the STAGED pubkey. (3) **Older versions beside the active
+  target** (H3b) — **VERIFY first, prune second**: probe hello with the ACTIVE
+  key; only on success delete the older versions. On ANY failure prune nothing,
+  and split by error class (J2): **only `E_UNAUTHORIZED` prints the paste line**;
+  `E_CONNECT`, `E_HOSTKEY_CHANGED`, `E_VERSION`, `E_IDENTITY`,
+  `E_POOL_MISMATCH`, `E_HUB_NO_BINARY` each get their own §7.5 remediation
+  unchanged, with no reauthorize hint overlaid.
+- A leftover temp symlink (crash mid-promote, before the rename) is inert and
+  removed on the next run.
+
+(e) Failure injection at EVERY transition (§10.3's staged-rotation row):
+between first keygen and the initial symlink (adoption, and the probe-fail
+retire path), after mint, before and after the remote replace, mid-promote,
+after promote before verify, after verify before cleanup — the post-replace
+cases running with the old key **already revoked**. Plus the G3 grammar rows:
+`.v2` vs `.v10`; a `.vold`/`.v01`/`.v2b` file neither adopted nor deleted; two
+retirements within one second not colliding; the "current pubkey" resolved by
+`readlink` + `.pub` and no `keys/<id>_ed25519.pub` symlink existing.
+
+(f) Done-when: every injected failure point converges on a re-run, in-process;
+the numeric-ordering and invalid-suffix rows green.
+
+(g) ~300 LOC.
+
+**WI-5.3c — `hub join`: same-hub URL migration.** *(S9 split, part c —
+specialist hand-off inside the M5 merge.)*
+
+(a) The D4a migration: detect the same hub under a different spelling, refuse
+while a lane is live, and move the hub dir atomically.
+
+(b) §7.2 (the migration block in full, incl. the B5 attribution predicate, the
+G1 completion boundary, and the G4 mux reaping), §6.8 rule 5 (the interlock).
+
+(c) NEW `internal/cli/hub_migrate.go`; MODIFY `internal/cli/hub_join.go`.
+
+(d) - **Fingerprint scan**: before any keygen, connect and obtain the host-key
+  fingerprint (available pre-auth), then scan `~/.agentchute/hub/` for dirs whose
+  recorded fingerprint matches — **considering only entries whose name is exactly
+  12 lowercase hex characters**, so `<new-id>.partial` and `.locks/` can never be
+  scan candidates. For each match, attempt a hello with that dir's existing key
+  for this `--as`; success **and** `hello-ok.pool12` equal to that dir's recorded
+  pool12 ⇒ same hub ⇒ migrate.
+- **Two locks, ascending lexicographic hub-id order, always** — never "old then
+  new" — so deadlock is structurally impossible.
+- **The attribution predicate is REMOTE-SPECIFIC (B5).**
+  `setupCommandMatchesPool` (`internal/cli/setup_reset.go:308-345`) **must not
+  be reused unchanged**: its pool proof is an OR of two exact-value comparisons
+  of argv `--control-repo` / `--loop-dir` against `cfg.ControlRepo` /
+  `cfg.LoopDir` through `setupPathsEquivalent` (`setup_reset.go:340-341`). In
+  remote mode argv carries the `ssh://` URL, `cfg.ControlRepo` is the LOCAL repo
+  root, and `cfg.LoopDir` is the shadow — so **every** live lane would fall into
+  the "alive but unattributed" branch, and every ordinary migration would print
+  the pid-reuse text with its "remove runner.json" advice, which for a genuinely
+  live lane is both wrong and destructive. The new predicate:
+  1. **Subcommand match, unchanged**: reuse `setup_reset.go:320-332`'s test —
+     `agentchute serve` (with the pre-v0.9.1 `agentchute run` alias kept for
+     upgrade cleanup). Anything else ⇒ **ambiguous**.
+  2. **Pool proof**, on values extracted with `setupCommandFlagValue`
+     (`setup_reset.go:352+`, which already truncates at `--` at `355-358`, so a
+     wrapper's own flags can never be misread):
+     - argv has `--control-repo` ⇒ canonicalize with §7.4's **URL**
+       canonicalizer and require equality with the old dir's recorded URL ⇒
+       **attributed**; a different `ssh://` URL, or any local path ⇒
+       **ambiguous**.
+     - else argv has `--loop-dir` ⇒ `setupPathsEquivalent` against the old
+       dir's shadow ⇒ **attributed**; mismatch ⇒ **ambiguous**. (This arm exists
+       only for lanes launched by a pre-§6.8 binary or by hand.)
+     - else **neither flag** — the direct `agentchute serve <wrapper>` form the
+       quickstart itself prints ⇒ **attributed**, because the `runner.json` that
+       named this pid lives under that hub dir's own shadow state and nothing
+       else writes there.
+       **Known and deliberate (R11)**: after OS pid reuse this arm can
+       false-attribute — a stale `runner.json` naming a pid that now belongs to
+       an unrelated flagless `agentchute serve`. The consequence is a refusal
+       to migrate (fail CLOSED), never a kill and never a deletion, and the
+       operator's own inspection clears it. **Do not "fix" this into
+       proceeding**: trading a spurious refusal for a migration that races a
+       genuinely live lane is strictly worse, and the ambiguous-pid arm exists
+       for exactly the cases we cannot attribute.
+  The liveness read is `loop.RunnerStatePath` (`config.go:149-151`) with the
+  same-host and pid-alive gates `stopSetupRunner` uses
+  (`setup_reset.go:196-224`). Three outcomes, with the §7.2 texts verbatim:
+  attributed live lane ⇒ the "still running against the old URL … stop that
+  session first" refusal (**never** a `kill` command); pid alive but
+  unattributed ⇒ the ambiguous-pid text (inspection guidance only); pid dead or
+  no `runner.json` ⇒ proceed.
+- **Completion boundary (G1) — a single `rename()`, no step optional**:
+  (1) copy key material + config (latch/spool residue included) into
+  `~/.agentchute/hub/<new-id>.partial/` — **`mux/` is deliberately NOT copied**;
+  (2) write the new `config.json` inside `.partial` (recorded URL updated;
+  `joined_as`/`names`/`pool`/`pool12` carried over), then **fsync every written
+  file and fsync the `.partial` directory itself**; (3)
+  `rename("<new-id>.partial", "<new-id>")` — **this is the commit point**; then
+  fsync `~/.agentchute/hub/`; (4) rewrite the checkout's pointer to the new URL;
+  (5) delete the old hub dir. Recovery is deterministic: before step 3 the only
+  complete dir is the old one and the `.partial` is **scratch, never adopted**;
+  after step 3 the ordinary joined-verify path sweeps for the leftover (a sibling
+  dir with the SAME fingerprint but a stale recorded URL) and finishes steps 4–5.
+- **Mux reaping (G4)**: step 5 first issues a best-effort `ssh -O exit` for the
+  old URL (one call, failure ignored). An unreaped master is harmless — it holds
+  an unlinked socket inode and no new one-shot can attach to a ControlPath that
+  no longer exists.
+
+(e) Rows in-process: same-hub alias rejoin (zero new keys, one authorized_keys
+line, pointer updated); **migration attribution, normal lane** — a lane launched
+**exactly as the quickstart launches one**, both `ac serve codex` and the direct
+`agentchute serve codex` form, must produce the "still running against the old
+URL" refusal, never the ambiguous-pid text (a predicate that exact-matched argv
+against `cfg` fails this row in the normal case); migration vs pid reuse (both
+sub-cases); crash injection before and after the `rename()`; the fingerprint scan
+never returning `<new-id>.partial` or `.locks/`; both locks in ascending order
+under a reversed-pair concurrent run.
+
+(f) Done-when: every crash-injection point converges on a re-run with exactly
+one authoritative dir at every instant, and the normal-lane attribution row is
+green. **The M6 re-runs under sshd are WI-6.2's.**
+
+**Interlock (B4/B5):** this item's URL arm is correct only because WI-4.3
+forwards the URL. This item's gate ask must re-verify WI-4.3's argv goldens at
+the M5 head SHA.
+
+(g) ~300 LOC.
+
+**WI-5.4 — `hub authorize`.**
+
+(a) The §7.1/§5.1/§5.2 hub-side story.
+
+(b) §5.1 (template line verbatim incl. `--pool-id`; reject-not-encode grammars
++ `E_POOL_PATH_UNSAFE`; the pool.id read-or-mint contract; the marker
+`agentchute:<id>:<pool12>`), §5.2 (marker-keyed `--list`/`--revoke`/
+`--replace-key`; the duplicate-(id,pool12) refusal with the hostname-collision
+hint), §7.1 (0600/0700 enforcement + the StrictModes rationale; `--list` PASS/FAIL
+health audit; `--revoke`'s live-session note).
+
+(c) NEW `internal/cli/hub_authorize.go`.
+
+(d) **This item is the SOLE PRODUCTION WRITER of `state/pool.id` in the entire
+codebase** (P3 — verified: no Go file, test, or tracked source mentions
+`pool.id` or `pool12` today). It mints by **exclusive create** — the shipped
+first-writer-wins idiom (`loop.WriteRegistrationExclusive`,
+`registration.go:133-169`), never a plain atomic replace — 0600, content exactly
+`^[0-9a-f]{12}\n$` where `pool12 = hex(sha256(EvalSymlinks(Clean(abs(--pool)))))[:12]`;
+the H2 loser of the race re-reads and **adopts** the winner's value.
+
+**Validation contract (J1)** runs on BOTH consumers and BEFORE any comparison or
+interpolation: exactly one regular, non-symlink, 0600 file read through the
+bounded no-follow reader (`loop.ReadFileLimit`, `registration.go:34-48`) with a
+64-byte cap, content matching the grammar exactly. The two consumers are `hub
+authorize` (the fresh-read path AND the H2 loser-re-read path) and `hub session`
+at startup (WI-3.3a — which until this item lands runs only against the WI-3.2
+test fixture). Anything else ⇒ `E_POOL_ID_INVALID`: authorize writes **nothing**
+to `authorized_keys`; the session refuses before any op.
+
+Also: authorize validates before writing (the `--pool` path must exist and
+contain `AGENTCHUTE.md` + `.agentchute/loop/`; the resolved binary path must be
+executable), and it must run **as the SSH login user**.
+
+(e) Rows: durable pool identity (realpath / symlink / trailing-slash / macOS
+case-alias spellings ⇒ ONE marker); the `--pool`-only key-line edit; pool
+mismatch consistent re-point; pool.id validation (the full J1 malformed set, with
+`authorized_keys` byte-identical before/after); concurrent alias first-authorize
+(H2); authorize validation; shell-safety refusals (the C5 metacharacter set).
+
+(f) Done-when: all authorize-side rows green — no sshd needed, these are pure
+local file operations.
+
+(g) ~470 LOC.
+
+**WI-5.5 — `setup --wipe-state` preserves `state/pool.id`.** *(S9 — peeled out
+of the authorize item because a destructive surface deserves its own review
+focus. Ships in the SAME MERGE as WI-5.4: landing the writer without the
+preservation bricks every key binding on the next `--wipe-state`.)*
+
+(a) Add `pool.id` to the wipe's preserved, non-runtime scaffold (H1).
+
+(b) §5.1 (the preservation paragraph), §9.1 third bullet (the M2 spec text this
+implements).
+
+(c) MODIFY `internal/cli/setup_wipe.go` **only**. Three places, each of which
+today exempts exactly `setup.json` and nothing else:
+
+- `wipeStateCategory` (`setup_wipe.go:295-316`): the name test at `:307`
+  becomes `name == "setup.json" || name == "pool.id"` → `cat.Preserved`.
+- `rescanWipeLeftovers` (`setup_wipe.go:516-536` — CORRECTION: the round-1
+  citation `519-536` started mid-doc-comment): the skip at `:529` gains
+  `pool.id`, or the post-wipe rescan flags the very survivor it was told to
+  preserve.
+- `printWipePlan`'s preserved rendering (`setup_wipe.go:703-711`) must list it,
+  so `--dry-run` shows it.
+
+(e) Row "wipe preserves pool identity (H1)": `setup --reset --wipe-state` on a
+pool with `state/pool.id` ⇒ listed as Preserved in the **dry-run and the wipe**,
+survives the wipe, is **not** flagged by the rescan, and a following `hub
+session` startup still validates it against `--pool-id`.
+
+(f) Done-when: `setup_wipe_test.go` green with that row added, and `git diff`
+touches no file but `setup_wipe.go` and its test.
+
+(g) ~60 LOC.
+
+**WI-5.6 — error-catalog wiring + hub-side doctor audit.**
+
+(a) Every §7.5 text emitted from its mapped condition, verbatim; plus the
+hub-side authorize-line audit (§7.6).
+
+(b) §7.5 (all three tables), §7.6 (the third bullet).
+
+(c) MODIFY `internal/cli/hub_*.go`, `internal/cli/doctor.go`; texts centralized
+in NEW `internal/cli/hub_errors.go`.
+
+(d) Both `E_POOL_MISMATCH` arms have **distinct exact texts** (§7.5) and each
+must be emitted from its own condition (hub arm at session start; client arm
+after `hello-ok`) — a single shared string fails this item. `E_CHANNEL_LOST`
+echoes the lane's **own** argv (G-m5), never a hard-coded example.
+
+(e) Golden-text tests per catalog row — the §7.5 tables ARE the fixtures.
+
+(f) Done-when: a table-driven test walks every §7.5 row and asserts the emitted
+text byte-for-byte.
+
+(g) ~250 LOC.
+
+**WI-5.7 — M5 integration pass (in-process).**
+
+(a) Wire WI-5.1–5.6 together against the fake transport, before real sshd
+exists.
+
+(e) Rows runnable in-process: live-lease self-check/turn-end (C2); register
+field semantics (C2/D1), including the `Sweep` arm (WI-4.5: remote `boot`
+sweeps the HUB pool once, the shadow never, and every other verb sends
+`sweep:false`); **remote vendor resolution skipped client-side (S2)** —
+in a joined checkout with a custom pool id, drive all four `resolveAgentVendor`
+call sites bare (`serve.go:152`, `register.go:259`, `boot.go:86`,
+`self_check.go:126`) and assert each sends `Vendor:nil` on the wire, **that
+each renders the RESOLVED vendor from `RegisterResp.Reg.Vendor` and not the
+nil-on-wire request value** — `register`'s text line, `boot`'s text **and**
+`--json`, `self-check`'s text **and** `--json`, all byte-identical to a local
+run of the same pool (T4: asserting only "nil on the wire, exit 0" passes
+while a success path prints an empty vendor) — that
+`cmdServe`'s missing-vendor refusal (`serve.go:153-155` — CORRECTION: the
+surrounding block is `152-157`, not `152-158`) is **suppressed** for remote
+lanes, and that an explicit `--vendor` still wins and is still validated;
+**remote `status` renders the hub, header included** (WI-4.5: table from the
+response, `control_repo:` on the `ssh://` pointer, `loop_dir:` on the shadow
+with its pinned marker line byte-exact, and — with one 64 KiB-`host` row
+planted on the lexicographically LAST of three agent ids, WI-4.5(e)'s fixture
+rule, so the two earlier rows survive the prefix cut — the pinned truncation
+notice byte-exact, naming the WIRE limit and not only the row cap);
+mid-stream disconnect arms the latch (E1); the negative cache covers
+SessionStart (D6).
+
+(f) Done-when: `tools/test.sh` green across the repo.
+
+(g) ~250 LOC (tests).
+
+### M6 — real-sshd matrix + CI + docs → tag v1.7.0
+
+**WI-6.1 — sshd harness + the test wrapper script.**
+
+(a) A self-contained sshd fixture per the §10.3 preamble, plus the named script
+every M6 done-when cites.
+
+(b) §10.3 preamble; §5.1 (the forced-command line the harness writes).
+
+(c) NEW `integration/sshd/harness_test.go` (build-tagged
+`//go:build sshd_integration`); NEW `integration/sshd/doc.go`; NEW
+`tools/sshd-test.sh`.
+
+**`integration/sshd/` is part of the ROOT module** — no nested `go.mod`, so
+cross-cutting rule 6's empty-`go.mod`-diff still holds. `doc.go` is **untagged**
+and contains only a doc comment and the `package` clause, so the package always
+has one buildable file and `go build ./...` / `go vet ./...` / `go test ./...`
+can never hit "build constraints exclude all Go files" with the tag absent.
+Every test file is tagged.
+
+**`tools/sshd-test.sh` — the decision P7/X7 asked for, with the reasoning that
+produced it.** `tools/test.sh` is 26 lines with **no argument parsing of any
+kind** (it never references `$@`, has no `case`/`getopts`, no modes), and its
+first action is `gofmt -w .` — which **mutates the checkout** and runs without
+the env strip. Adding a tagged mode would introduce arg plumbing that does not
+exist and drag a tree-mutating step into a suite that must run on a read-only CI
+checkout. The repo's own precedent for "a second suite gets its own invocation"
+is the conformance module (`ci.yaml:39-40`). So: a new script, exact content:
+
+```sh
+#!/bin/sh
+# sshd-test.sh — the real-sshd hub integration suite (PLAN WI-6.1/6.2).
+# Strips EVERY AGENTCHUTE_* var (the same idiom as tools/test.sh:7) and sets
+# only AGENTCHUTE_SSHD_TEST=1, so a run from inside a serve session can never
+# reach the live pool.
+set -u
+strip_env=$(env | awk -F= '/^AGENTCHUTE_/{print "-u " $1}')
+exec env $strip_env AGENTCHUTE_SSHD_TEST=1 go test -tags sshd_integration ./integration/sshd/...
+```
+
+No gofmt, no mutation, no arguments. **Every M6 done-when cites
+`tools/sshd-test.sh`, never a bare `go test`.** It is deliberately NOT added to
+ci.yaml's `shell` job shellcheck list: that job checks `install.sh` and
+`tests/*.sh`, and neither `tools/test.sh` nor `tools/fact-sweep.sh` is in it
+today — adding one `tools/` script and not the others would be an inconsistency,
+not a gate.
+
+(d) The harness generates throwaway host + client keys in a temp dir, starts
+`sshd -D -f <generated sshd_config>` on a random high port with
+`AuthorizedKeysFile` pointing at a generated file containing the §5.1
+forced-command line (absolute path to the freshly built test binary), and a pool
+in a temp dir. It **REFUSES to run** when `AGENTCHUTE_LOOP_DIR` or
+`AGENTCHUTE_CONTROL_REPO` point at a real pool.
+
+**(f) Done-when (X4 — round 1 gave this item no done-when at all):**
+
+1. The harness starts sshd on a random high port and a probe client
+   authenticates with the generated key.
+2. The forced command actually runs the freshly built test binary — asserted by
+   the session recording `SSH_ORIGINAL_COMMAND` and the client's requested exec
+   string being **discarded**.
+3. Teardown through `t.Cleanup` leaves **no listening socket and no temp tree**,
+   even when a test fails.
+4. **Real-pool containment**: with `AGENTCHUTE_LOOP_DIR` or
+   `AGENTCHUTE_CONTROL_REPO` pointing at a real pool the harness refuses, and
+   the test asserts **both** the refusal and that nothing under the named pool
+   was written.
+5. All four green locally on macOS **and** in CI on ubuntu-latest **and**
+   macos-latest, invoked as `sh tools/sshd-test.sh`.
+
+Watch-item (budget, not a finding): a non-root `sshd -D` authenticates only the
+invoking user, and macOS needs its host-key and config paths hand-fed.
+
+(g) ~280 LOC.
+
+**WI-6.2 — the full §10.3 matrix.**
+
+(a) Every §10.3 row as a named test, including the sshd-only rows and the sshd
+re-runs of the M4/M5 in-process rows.
+
+(b) §10.3 in full.
+
+(c) NEW `integration/sshd/*_test.go` — one file per §10.3 cluster (handshake,
+disconnect/fence, lease, launcher/resolver, join/migrate/rotate, authorize/pool
+identity, env contract).
+
+(e) Sshd-only rows: happy path (**the real §7.2 quickstart transcript lands
+here**, X4); identity/version mismatch; disconnect-after-claim and
+disconnect-after-send; reclaim-during-send; channel drop fences the child
+(≤15 s); half-open hub (20 s read deadline + release); lease-held; host-key
+change; **mux reuse — run through BOTH ControlPath branches** (the harness's
+normal hub dir and an injected deep hub dir forcing WI-4.4's fallback), each
+asserting 1 sshd auth log entry for 3 sequential one-shots; child env contract
+(§6.8, incl. the offline guard latch DENYING while armed and a child `send`
+landing in the hub pool); **launcher preserves remoteness** — via `ac serve`
+AND a constructed legacy `ac-*` shim (WI-4.3's note), asserting `Remote != nil`
+and never merely "the command succeeded"; both resolver rows; hub-reboot pid
+reuse and the clock-step row; the relaunch rows; and the sshd re-runs of the
+M4/M5 in-process rows (migration attribution, staged rotation recovery,
+pool identity spellings — the macOS case-alias spelling REQUIRES the macos
+runner and cannot pass on Linux).
+
+(f) Done-when: the full matrix green locally on macOS and in CI on both OSes,
+run as `sh tools/sshd-test.sh`.
+
+(g) ~500 LOC.
+
+**WI-6.3 — CI wiring.**
+
+(a) Add the `hub-integration` job; leave every other suite where it already
+runs.
+
+(b) §10.4.
+
+(c) MODIFY `.github/workflows/ci.yaml` **only**.
+
+**(d) Verified starting state (F10 — the round-1 item was written against an
+assumed CI).** `ci.yaml` has four jobs: `go`, `shell`, `upgrade-smoke`,
+`upgrade-hook-refresh-smoke`. The `go` job (matrix `ubuntu-latest` +
+`macos-latest`, `fail-fast: false`) runs `gofmt -l` (ubuntu only, the
+**non-mutating** form), `go vet ./...`, `go test ./...`, `go test -race ./...`,
+`go build ./...`, and `cd conformance && go test ./...`. **No job calls
+`tools/test.sh`**, and `tools/test.sh` runs `gofmt -w .`, which would mutate the
+CI checkout. Therefore:
+
+- **NEW job `hub-integration`**, matrix `ubuntu-latest` + `macos-latest`,
+  `fail-fast: false`; steps: `actions/checkout@v6`, `actions/setup-go@v6` with
+  `go-version: 'stable'` and `check-latest: true` (mirroring the `go` job, NOT
+  release.yaml's pinned 1.21), then **ONE step**: `sh tools/sshd-test.sh`. That
+  single step runs **only the tagged package**. `tools/test.sh` appears
+  nowhere.
+- **The §10.2 hubwire tests, the `internal/spectest` L/W drivers, and the M1
+  seam tests are ordinary untagged root-module tests** — they run in the
+  **existing** `go` job's `go test ./...` step and need no CI change at all.
+- `hub-integration` is a **separate required check**, so a matrix flake never
+  masks unit failures.
+
+(f) Done-when: both jobs green on the PR and `gh pr checks` clean; **and** a run
+with the tag ABSENT confirms `go build ./...`, `go vet ./...`, and
+`go test ./...` all still pass and report nothing from `integration/sshd/` (the
+untagged `doc.go` from WI-6.1 is what makes that deterministic).
+
+(g) ~50 LOC YAML.
+
+**WI-6.4 — sshd-backed W vector runs.**
+
+(a) Re-drive conformance W1–W5 through the real transport (§9.3's timing rule:
+they gate the tag).
+
+(c) NEW `integration/sshd/conformance_wire_test.go`, which **imports
+`internal/spectest`** (same module) and calls its exported vector loader and
+assertion helpers, driving them through the real ssh transport instead of
+`net.Pipe`. The vector definitions have exactly ONE source — the shared JSON
+under `conformance/vectors/` — and ONE assertion implementation, parameterized
+by transport.
+
+(f) Done-when: W1–W5 (hub-side halves and client halves alike) green under sshd
+on both OSes, run as `sh tools/sshd-test.sh`.
+
+(g) ~150 LOC.
+
+**WI-6.5 — docs (repo + web).**
+
+(a) Ship the quickstarts and the Tailscale recipe, and put the hub on the
+website.
+
+(b) §7.1, §7.2, §7.7; post-M2 the spec wins on any conflict.
+
+**(c) The exact artifacts (X6 — round 1 deferred this to "the integrator
+confirms at merge time"). Verified layout: `web/` is hand-written static HTML
+with NO templating, NO build step, and NO nav include — nav markup is duplicated
+per page.**
+
+- MODIFY `README.md`: a short "Multi-machine pools (SSH hub)" section pointing
+  at the new doc.
+- NEW `docs/hub.md`: the §7.1 + §7.2 quickstarts, a pointer to the §7.5 error
+  catalog, and the §7.7 Tailscale recipe. (Root `docs/` is repo-internal
+  markdown — `decisions/`, `internal/`, `releases/` — which is the right home
+  for an operator walkthrough.)
+- NEW `web/hub.html`: modelled on `web/spec.html` — links `style.css` and
+  reuses `spec.html`'s `<header class="site">` + `<nav>` block
+  (`web/spec.html:17-27`) verbatim, so the site chrome matches.
+- MODIFY the nav of the three **current-surface** pages, by hand, because there
+  is no include: `web/index.html:188-193`, `web/spec.html:20-25`,
+  `web/blog/index.html:20-25`. Individual blog posts' navs are historical
+  artifacts and are **not** touched — the same line `tools/fact-sweep.sh:19`
+  draws when it excludes `web/blog/*` from the live-surface scan.
+- MODIFY `web/sitemap.xml`: add one `<loc>https://agentchute.dev/hub.html</loc>`
+  in the same bare shape as the existing 15 entries (the file carries no
+  `lastmod`/`changefreq`/`priority` — match that).
+- `web/_redirects` and `web/robots.txt`: no change.
+
+**(f) Done-when:**
+
+1. `tools/fact-sweep.sh` PASS. Its live-surface set is `README.md AGENTCHUTE.md
+   web` minus `web/blog/*` (`tools/fact-sweep.sh:12,19`), so `web/hub.html` IS
+   scanned — any number claimed there must match the tree.
+2. **Link verification**: every local `href`/`src` in `web/hub.html` and in the
+   three edited navs is enumerated and stat'd, and each target exists. A broken
+   relative link is the characteristic failure mode of a hand-written site with
+   no build step.
+3. `web/hub.html` opens in a browser with the site chrome and the new nav link
+   is present on all three edited pages.
+4. grok persona-walk SHIP.
+
+(g) ~220 LOC prose/markup.
+
+**WI-6.6 — v1.7.0 release notes + CHANGELOG. (Integrator-owned; lands in the
+M6 PR, before the tag.)**
+
+(a) The tag cannot release without the notes file (`release.yaml:110` runs
+`test -s "docs/releases/${tag}.md"`; `:168` uses it as `--notes-file`).
+
+(c) NEW `docs/releases/v1.7.0.md`; MODIFY `CHANGELOG.md` (a new
+`## v1.7.0 (<date>) — <headline>` section in the shape v1.5.7 uses).
+
+(d) The notes MUST carry the rollout order: **the hub upgrades first**, then the
+remotes; plus the note that a hub `agentchute update` fences every live lane
+once (§8 row 24) and that default-on relaunch brings them back under the new
+binary automatically. They must also restate the P8 rule for lanes: a remote
+that updated ahead of its hub gets `E_VERSION` and must **wait** — re-running
+`hub join` is not the fix.
+
+(f) Done-when: `docs/releases/v1.7.0.md` exists and is non-empty at the M6 PR
+head; `tools/fact-sweep.sh` PASS.
+
+(g) ~60 LOC prose.
+
+→ **Integrator: tag v1.7.0** (checklist §5.2).
+
+---
+
+## 3. Cross-cutting rules (binding on every implementer)
+
+1. **Tests only via `tools/test.sh` — NEVER bare `go test ./...`.** Env-strip is
+   mandatory on this fleet: a bare run from a serve session has kicked the whole
+   fleet before (env leak through `AGENTCHUTE_*`). `tools/test.sh:7` builds the
+   strip list dynamically from the live environment and applies it to vet/test/
+   build. If `env -u` is refused by the sandbox, stop and ask — never fall back
+   to bare. From M6 on, the sshd suite runs as `sh tools/sshd-test.sh`, which
+   applies the identical strip (WI-6.1).
+2. **Worktree isolation.** The working directory is the LIVE fleet checkout. All
+   implementation happens on a worktree branch (`EnterWorktree` for scratch;
+   `git worktree add .tmp/worktrees/<merge> <sha>` for pinned review checkouts,
+   removed the same turn). Never edit the live tree; re-check `git status`
+   rather than trusting a snapshot.
+3. **Never test against the live pool.** The sshd harness and every destructive
+   test refuse when env points at a real pool (WI-6.1 done-when 4); unit tests
+   use temp dirs exclusively.
+4. **Spec-first ordering.** M2 merges before any M3+ code. After M2 the spec
+   text is authoritative over DESIGN.md; an M3+ implementer who finds a
+   spec/DESIGN conflict **stops and files it** — never silently follows either.
+5. **Ritual per PR = `tools/test.sh`, and nothing else** (X7 — the round-1 rule
+   listed `gofmt`, `go vet`, `tools/test.sh`, `go build` as if they were four
+   things). `tools/test.sh` **IS** gofmt + `go vet` + `go test` + `go build`
+   (`tools/test.sh:11-24`), with the env strip on the last three. There is no
+   separate raw-command list. Two facts an implementer needs: `gofmt` there is
+   `gofmt -w .` and **mutates the tree** (expected locally; CI uses the
+   non-mutating `gofmt -l` instead, `ci.yaml:22-30`), and after WI-3.5 the
+   script also runs the conformance module. From M6 on, `sh tools/sshd-test.sh`
+   runs **in addition** — it is not part of `test.sh` and never will be.
+6. **Zero new Go dependencies.** **BOTH** `go.mod` files — the root
+   (`github.com/agentchute/agentchute`) and `conformance/`
+   (`agentchute.dev/conformance`, a three-line module with no requires and no
+   `go.sum`) — must be byte-identical before and after every merge.
+   `golang.org/x/sys` is **already** a direct requirement (`go.mod:7`, v0.30.0),
+   currently imported only from `filelock_windows.go`, so WI-3.4's
+   `x/sys/unix` import adds no module; `release.yaml:28-30` (`go mod tidy` +
+   `git diff --exit-code go.mod go.sum`) is the check that proves it. The client
+   shells out to the system `ssh`/`ssh-keygen` only.
+7. **Review freeze (E3).** Every gate ask carries pinned base+head SHAs, the
+   file list, and the allowed delta. Reviewers verify against
+   `git show <sha>:file`, never working-tree reads.
+8. **Delta re-gates (E4).** After a FIX round, re-gate the delta only — with
+   fresh pinned SHAs.
+9. **Verdict mechanics.** Verdicts on the bus; mirrored to `gh pr comment` when
+   authorized — never `gh pr review` (shared-token self-block).
+10. **Push discipline.** Explicit refspec always; verify the PR's `headRefOid`
+    equals the SHIP'd SHA before merge (a bare push from a worktree branch can
+    silently push nothing).
+11. **Embedded-asset coupling.** Run `gh pr checks` before any SHIP: embedded
+    hooks/templates/spec mean a zero-`.go`-diff is not a zero-behavior-change.
+    WI-2.4 is the item where this bites (marker-versioned enrollment prose +
+    `templates_drift_test.go` / `assets_test.go`).
+
+---
+
+## 4. Lane assignments
+
+The roster is DYNAMIC — the integrator confirms it via `agentchute status` at
+execution start (this plan does not run it). Planned against today's roster;
+pairings satisfy E2 (implementer + primary reviewer) with codex always the
+second, mandatory gate. Per §2 rule 1, **one lane owns each merge**; a named
+specialist item is handed over inside that merge and the owner integrates.
+
+| merge | merge owner (implementer) | specialist hand-off inside the merge | primary reviewer | second gate |
+|---|---|---|---|---|
+| M1 | opus-high | — | opus-xhigh (seam/design-sensitive) | codex |
+| M2 | opus-xhigh (spec prose is design work) | — | grok (persona-walk readability) | codex |
+| M3 | opus-high | **WI-3.4** (the sole `internal/loop` change) → opus-xhigh | opus-xhigh (security surface: parser, pinning, deadlines) | codex — conservative lane (wire schema) |
+| M4 | opus-high | — | opus-xhigh (§6.8 contract + resolver precedence) | codex |
+| M5 | opus-high | **WI-5.3b** (key lifecycle + recovery classifier) and **WI-5.3c** (migration state machine) → opus-xhigh | opus-xhigh + grok persona-walk (§7 quickstarts, every §7.5 text) | codex — conservative lane (install surface) |
+| M6 | opus-high | — | grok (walks the matrix vs §10.3 row-for-row) | codex — conservative lane (Actions YAML) |
+
+**Integrator-owned items** (claude-code, not the merge owner): **WI-1.9** and
+**WI-6.6** — the release notes and CHANGELOG entries, each landing inside its
+merge's PR because the tag's release job hard-fails without the notes file.
+
+claude-code is otherwise integrator ONLY — merges, tags, releases, fleet
+cutover, cross-lane sync. Never implementation. grok is a read-only
+reviewer/persona-walker per the standing roster rule.
+
+Cross-merge review obligation (B4/B5): the M5 gate ask must re-verify WI-4.3's
+argv goldens at the M5 head SHA (see WI-4.3 and WI-5.3c).
+
+---
+
+## 5. Release / rollout checklists
+
+### 5.1 v1.6.0 (after M1, before M2)
+
+1. `tools/fact-sweep.sh` clean; `tools/test.sh` green on main.
+2. **`docs/releases/v1.6.0.md` exists and is non-empty** (WI-1.9) — the release
+   job runs `test -s` on it (`release.yaml:110`) and would fail *after* the tag
+   is pushed.
+3. `gh pr checks` green on the M1 PR **before** SHIP (embedded-asset rule).
+4. Verify the PR's `headRefOid` == the SHIP'd SHA; squash per convention
+   (unstage loop state; no stray `.agentchute/` files in the squash).
+5. Annotated tag via `-F <notes-file>`; push with the explicit
+   `refs/tags/v1.6.0`.
+6. The release pipeline is external: a `v*` tag → smoke-gated goreleaser (the
+   stub-codex gotcha applies — check the smoke logs, not just the tag).
+7. Release notes state explicitly: internal refactor, no behavior change, no hub
+   capability claimed.
+8. Fleet update per the normal cadence — no forced cutover, the change is
+   invisible.
+
+### 5.2 v1.7.0 (after M6)
+
+1. All L vectors, all W vectors (in-process **and** sshd-backed), and the full
+   sshd matrix green on ubuntu + macos in CI — hard gate, no exceptions (§9.3
+   timing rule).
+2. **`docs/releases/v1.7.0.md` + the CHANGELOG entry present** (WI-6.6).
+3. `tools/fact-sweep.sh` over docs + spec; the §7.1/§7.2 quickstarts walked
+   verbatim once on a real second machine (grok persona-walk or operator).
+   **Containment, mandatory (P5): that walkthrough runs against a SCRATCH POOL,
+   or as a SECOND UNIX USER on the hub host — NEVER against this checkout's live
+   loop directory.** The walkthrough issues `hub join`, `serve`, and
+   `hub authorize`, all of which mutate pool and machine state; the destructive-
+   test env-guard rule (§3.3) applies to a human walkthrough exactly as it
+   applies to a test.
+4. Steps 3–6 of §5.1 verbatim, for `v1.7.0`.
+5. Rollout order: **hub upgrades first** (the handshake's own rule), then the
+   remotes. Note in the release notes that a hub `agentchute update` fences every
+   live lane once (§8 row 24 — default-on relaunch brings lanes back under the
+   new binary automatically), and that a remote which updated ahead of its hub
+   must WAIT rather than re-join (P8).
+6. agentchute.dev auto-deploys from main (Cloudflare Pages) — confirm
+   `hub.html` and the three edited navs render post-merge.
+
+---
+
+## 6. Risks & watch-items
+
+1. **The sole `internal/loop` change (WI-3.4, §6.9).** Highest blast radius: it
+   alters lease reclaim for LOCAL pools too. The ordering is spec-fixed
+   (freshness refusal first — C8) and the comparison is **equality only**; any
+   drift toward wall-clock ordering re-creates the bug B6 caught, where an NTP
+   step steals a live lane's lease. opus-xhigh implements, codex
+   conservative-gates, and the seven cases are non-negotiable — including the
+   clock-step row, which the withdrawn rule failed.
+2. **Guard-latch M4 routing.** `guard` resolves its id inline
+   (`guard.go:175-189`) — if WI-4.8 misses it, the latch lives under `codex`
+   while the lane acts as `codex-tiny` and the guard silently never denies. The
+   child-env-contract row (M6) must assert a **DENY while latched**, not just
+   resolution. Second edge: `guard` fails **open** on every resolution and
+   Discover error (`guard.go:171-173,184-189,202-204`); the fix must not turn any
+   of those into a closed failure.
+3. **E1 latch arming.** The client emitter must arm on the FIRST message event
+   BEFORE rendering it — an implementer following the "after the op returns"
+   instinct reintroduces the round-4 blocker. The mid-stream disconnect row
+   exists precisely for this.
+4. **Send-ambiguity honesty.** The `E_SEND_UNKNOWN` window opens at the first
+   byte handed to ssh stdin and needs the deliberate transport seam (WI-4.6) —
+   do not approximate it with "after the response deadline". Never auto-replay;
+   the retry command must use `--body-file` and the hub-dir spool (a state-tree
+   spool self-refuses, B-M1).
+5. **Resolver precedence traps (rounds 9/9b/10).** Three separately-shipped
+   pieces must agree: env/flag candidates remap through `names`; the
+   `launchedWrapper` fallback on the direct path; the shadowing refusal at join.
+   The env-UNSET direct-launch row is the canary — it false-greens if anyone
+   "helpfully" exports env in the test. New in this revision: `identity_cmd.go`
+   gains a `loop.Discover` call it never had, so that call **must be non-fatal**
+   or `agentchute identity` starts failing outside a pool, where it succeeds
+   today.
+6. **`pool.id` has no owner before M5 (P3).** No Go file, test, or tracked
+   source mentions `pool.id` or `pool12` today. **M3 tests mint their own
+   fixture** (WI-3.2's `writeFixturePoolID`, `O_EXCL`, 12 lowercase hex + LF);
+   the **sole production writer is WI-5.4**; and the wipe-preservation change
+   (WI-5.5) must land in the SAME MERGE as that writer — landing the writer
+   without the preservation bricks every key binding on the next `--wipe-state`,
+   because `wipeStateCategory:307` and `rescanWipeLeftovers:529` exempt exactly
+   `setup.json` and nothing else today. J1 validation runs on BOTH consumers and
+   on the H2 loser-re-read path.
+7. **Conformance module boundary (B3/X3).** `conformance/` is a separate,
+   dependency-free module that **cannot** import `internal/*`, and neither root
+   `go test ./...` nor `tools/test.sh` enters it today. Any attempt to put an
+   internal-driving adapter there fails to compile; the drivers go in
+   `internal/spectest` and the vectors travel as shared JSON data. Both `go.mod`
+   files must come out of every merge byte-identical.
+8. **Conformance gating discipline.** The v1.7.0 tag waits for the sshd-backed W
+   runs (M6), not just the in-process ones — the §9.3 timing rule exists because
+   vectors-after-release was a review finding (C7). Note the split introduced by
+   S7: hub-side halves are M3, client halves are M4, sshd re-runs are M6.
+9. **The M4↔M5 interlock (B4/B5).** The launcher forwarding fix (WI-4.3) and the
+   migration attribution predicate (WI-5.3c) are two halves of one contract in
+   two different merges. Either alone is silently wrong: without the launcher
+   fix every joined lane de-remotes with no error; without the remote-specific
+   predicate every ordinary migration prints destructive pid-reuse advice about a
+   live lane. Enforced by the cross-merge review obligation in §4.
+10. **macOS runner quirks.** User-owned sshd on a high port (no Remote Login);
+    APFS case-insensitivity is an **asset** for the pool-identity row (the
+    case-alias spelling test REQUIRES the macOS runner and cannot pass on
+    Linux); `os.TempDir()` on darwin is a long `/var/folders/…` path, which is
+    exactly why WI-4.4's ControlPath fallback tries `/tmp` as a second
+    candidate.
+11. **ControlPath length — decided, not deferred (X5).**
+    `~/.agentchute/hub/<hub-id>/mux/%C` can approach the ~104-byte `sun_path`
+    limit for deep home directories. WI-4.4 pins the threshold (the shipped
+    literal `100` from `config.go:170`, with a conservative 64-byte `%C`
+    allowance), the owned-0700 temp fallback, and a mux-disabled third arm. The
+    residual: no CI runner has a deep enough `$HOME` to trigger it naturally,
+    which is precisely why the builder test **injects** the length rather than
+    relying on the environment, and why the M6 mux-reuse row runs through both
+    paths.
+12. **Fleet self-hosting hazard.** This repo's own pool coordinates the
+    implementation. Any rehearsal of join/serve/update flows happens in the sshd
+    harness, a scratch pool, or as a second unix user on the hub host ONLY —
+    including the human §5.2 step-3 walkthrough. The destructive-test env-guard
+    rule (§3.3) is hard, and was learned the hard way.
+
+---
+
+## 7. Pins this plan added beyond DESIGN.md (all non-normative packaging)
+
+- **Package/file names.** `internal/op` was design-fixed; this plan pins
+  `internal/hubwire` (codec, handshake), `internal/hubclient` (config, ssh
+  transport, channel, cache), `internal/cli/hub.go` / `hub_session.go` /
+  `hub_join.go` / `hub_keys.go` / `hub_migrate.go` / `hub_authorize.go` /
+  `hub_errors.go`, `internal/loop/remote.go`,
+  `internal/loop/bootref_{linux,darwin,other}.go`, `internal/spectest/`, and
+  top-level `integration/sshd/` (with an untagged `doc.go`) for the build-tagged
+  matrix.
+- **Seam shapes DESIGN left implicit** (all forced by the round-1 implementer
+  walk): `op.NewChannel(cfg, ctx, ChannelOpts)` with
+  `AcquireLease`/`Token`/`Register`/`Tick`/`ReleaseLease` (F2), and
+  `ChannelOpts.Lease` as the local **adoption** arm (R1c) so
+  `refuseLiveRunnerCollision` keeps its signature; `TickResp.Warnings []string`
+  with `Tick` erroring only when fenced (F3); the three `Level:"info"`
+  NoteEvents `op.Claim` emits at their production points, with `ClaimSummary`
+  staying DESIGN §3.2's four counts (R2, replacing round 2's
+  `Listed`/`Remaining`); `NoteEvent.Level` ∈ {`warn`,`info`} with pinned
+  stdout/stderr routing (F4); the exact eight-member op sentinel set plus
+  `op.CodeFor(error)` with an `E_HUB_IO` default arm, and the 9/8/9 code-set
+  arithmetic with `E_POOL_MISMATCH` classified `both` (F6, R3); the
+  `GateReq`/`GateResp`/`StatusResp`/`StatusAgent`/`RegistrationView`/
+  `CleanOwedReq`/`CleanOwedResp`/`RegisterResp` shapes (F8, R4, R1b); the
+  exported `op.SendTsMessageWithCommit` test seam (F1); the `HubConfig` struct
+  and its read/write helper (S5).
+- **The M1 test-edit exception list** — three files, three hunks — and the
+  move-set grep rule that keeps it closed (R1); the aliases/adapters that keep
+  every other moved identifier invisible (`gateStatus` alias,
+  `performRegister` adapter, `printStatus` and `refuseLiveRunnerCollision`
+  signature preservation).
+- **Test placement.** Which §10.3 rows run in-process in M4/M5 (and re-run under
+  sshd in M6) vs sshd-only — assigned per work item. Conformance L/W drivers in
+  the ROOT module (`internal/spectest`) with vectors as shared JSON under
+  `conformance/vectors/` (B3/X3); the hub-side/client-side W split across M3/M4
+  (S7).
+- **Scripts and CI.** `tools/sshd-test.sh` as a NEW script rather than a mode in
+  `tools/test.sh` (P7/X7), with its exact content; the `hub-integration` job
+  running only the tagged package in one step, while the wire/seam/spectest
+  suites stay in the existing `go` job (F10); one line added to `tools/test.sh`
+  for the conformance module.
+- **The spec section number.** The normative hub spec lands as AGENTCHUTE.md
+  §13 — a genuinely vacant number (the file runs §12 → §14) — unless length
+  forces the `HUB.md`-by-reference option DESIGN §9.1 allows.
+- **ControlPath-length contingency** (WI-4.4) — DESIGN §4.2 is silent; this plan
+  pins the threshold, the fallback, and the mux-disabled third arm.
+- **Doc/web artifacts** (WI-6.5) — DESIGN says "a README/docs section"; this
+  plan names `README.md`, `docs/hub.md`, `web/hub.html`, the three nav edits, and
+  the sitemap entry, because `web/` has no nav partial and no build step.
+- **Release-notes items** (WI-1.9, WI-6.6) — `docs/releases/<tag>.md` is a hard
+  release-job gate (`release.yaml:110,168`), so the notes are work items, not
+  checklist prose.
+
+Corrections this revision made to round-1 anchors, all re-verified at `1244ae4`:
+`check.go` "(inbox empty)" is `:201` (not 198), reached-limit `:207` (not 210),
+the CLAIMED note `:262` (not 265), `displayConsumed` `312-334` with the
+still-CLI-side renderers at `338-408` (not "335-408"); `performRegister` is
+`register.go:72-98` (not 35-189); `resolveAgentID` is `identity.go:13-25` and
+`resolveAgentIDRaw` `27-39` (not 13-38); `resolveAgentVendor` is
+`identity.go:72-83` (not 57-82); `wrapperForToken` is `shims.go:51-64` (not in
+`dispatch.go`); `commandHandlers` is populated at `dispatch.go:22-46` (not
+23-45); `rescanWipeLeftovers` is `setup_wipe.go:516-536` (not 519-536);
+`pointer.go`'s functions are `58-103` / `113-122` (not 93 / 105-118) and the
+directory check lives in `config.go:359-375`; `discoverControlRepo` has FOUR
+arms (not three); `serve.go`'s vendor block is `152-157` (not 152-158); the two
+not-registered texts differ by their first word and are NOT byte-identical.
+
+Round-3 corrections, re-verified at `1244ae4`: §10.3 has **three** boot rows,
+not four (`hub-reboot pid reuse`, `clock step does not steal a live lease`,
+``boot_ref` survives the heartbeat`); `op.CodeFor` outputs **9** codes and
+`internal/hubwire` adds **8**, not 8 + 9; there are **12** `resolveAgentID`
+call sites plus one inline resolution in `guard.go`; `cleanOwedResult` is
+`clean.go:99-103` with `Pruned []string`, not a count; `loop.Registration`
+(`registration.go:58-68`) carries **no JSON tags**.
+
+**The round-1 "FLAGGED, not fixed" list is obsolete.** All six DESIGN defects
+it recorded are fixed in DESIGN as it stands — cited by stable NAME, because
+DESIGN co-evolves and a line number that has drifted is worse than no anchor
+at all (T6):
+
+| defect | where it is fixed in DESIGN |
+|---|---|
+| `tick-ok.warnings` | §4.4.1's `tick-ok` example (clean and step-failure shapes) + the "`warnings` … is **always present**" paragraph under it |
+| both not-registered texts + `status.go:62` | §4.4.2's `E_NOT_REGISTERED` registry row + its §7.5 catalog entry |
+| ControlPath length rule | §4.2's "**`ControlPath` length rule (normative)**" block + §8's row 25 + §10.3's `ControlPath length rule (§4.2)` row |
+| legacy-shim launcher row | §6.8 rule 5 (the `cmdShimsExec` half) + §10.3's `launcher preserves remoteness (§6.8 rule 5, B4)` row |
+| mixed-version parse-vs-persist | §6.9 + the second half of §10.3's ``boot_ref` survives the heartbeat` row |
+| the three latch arming sites | §3.2's E1 bullet + §6.6's remote arming point + §10.3's `mid-stream disconnect arms the latch (E1)` row |
+
+Do not re-amend them. The one
+DESIGN gap this round flagged — recorded in
+[`plan-reviews-r2.md`](plan-reviews-r2.md) §"Revision log (plan round 3)":
+§3.5's `RegisterResp` Output line was a strict subset of the fields the CLI
+renders today — is now **closed in DESIGN**, together with the defect that
+survived it: the announce fan-out is `Announce *AnnounceView{Sent, Total int;
+Warnings []string}`, not `AnnouncedTo int`, and the redundant `Created bool` is
+gone (`Created == !ExistingFound` in every response). DESIGN §3.5/§4.4.1/§4.4.3
+and WI-1.6 state one schema; do not re-amend either alone.

--- a/proposal/ssh-hub/operator-qa-2026-08-15.md
+++ b/proposal/ssh-hub/operator-qa-2026-08-15.md
@@ -1,0 +1,56 @@
+# Operator Q&A — decisions and clarifications (Alex ⇄ claude-code, 2026-08-15)
+
+Post-SHIP walkthrough of the design with the operator. Recorded for reviewer
+awareness before implementation starts. Numbers reference DESIGN.md sections
+where applicable.
+
+## Clarified (no design change — restating what the doc already says)
+
+1. **Hub is chosen, not elected.** The operator picks the machine that holds
+   the pool folder; no election, no failover; hub down = pool paused
+   (fail-stop by design).
+2. **No A→B proxy hop.** Every inbox is a file on the hub's disk; A's send
+   writes B's inbox file there, B pulls it over its own connection. Agents
+   never talk to each other, only to the hub's files.
+3. **One binary everywhere.** Install is identical on hub and agent
+   machines; only one-time setup differs (hub: today's pool setup + stable
+   binary path; agent machine: `hub join` then `serve`).
+4. **Two commands, one shell** on the agent machine: `hub join ssh://…`
+   once, then regular `agentchute serve <wrapper>`. The "new shell" note is
+   only for the optional `ac` alias.
+5. **Join is per-agent, not per-machine**; run it once per id, any time —
+   no upfront count of agents.
+6. **Multiple lanes, one remote user**: per-agent keypairs; sshd picks the
+   authorized_keys line by offered key; forced command pins the id. The
+   shared unix account carries no identity.
+7. **Multi-hub / multi-pool topology confirmed**: one hub machine may host
+   many pools; each remote checkout points at exactly one pool; a team may
+   span machines by joining the same pool from each; pools are isolated.
+8. **`@` in ids rejected**: id grammar is `[a-z0-9][a-z0-9-]*`
+   (inbox.go:40), load-bearing in message-filename parsing; the same
+   convention is spelled with hyphens (`codex-tiny`).
+
+## Decided (design change, round 8 — hostname-suffix naming default)
+
+`hub join` without `--as` defaults the id to `<local-name>-<hostname>`
+(sanitized to the id grammar). Rationale, both operator-stated:
+(a) uniqueness becomes local-only from the operator's view — pick `codex`,
+`codex-2` locally, never remember other machines' names, list local ids
+locally; (b) traffic becomes human-legible — every filename/roster row
+carries the origin machine (`from-codex-tiny`), so who-talks-to-whom-from-
+where is visible with no lookup. `--as` stays the verbatim override;
+duplicate-id refusal (with a "hostnames collide, use --as" hint) covers
+same-hostname edge; the suffix is minted once at join, never re-derived.
+
+## Discussed, NOT decided (explicitly not in the design)
+
+- `serve --join <url>` sugar (join-if-needed on first serve). Viable because
+  join is idempotent; caveats noted (join state is per-folder so all lanes
+  must agree on the URL; first run may need the operator present). Parked
+  until Alex asks for it.
+
+## Status
+
+Implementation is expected to start soon (M1, operation seam, per DESIGN.md
+§11). This file + the round-8 delta are the awareness package for codex and
+grok.

--- a/proposal/ssh-hub/plan-reviews-r1.md
+++ b/proposal/ssh-hub/plan-reviews-r1.md
@@ -1,0 +1,529 @@
+# Plan review round 1 — PLAN.md @ sha256 bdd0847d… (2026-08-15)
+
+All four lanes returned FIX. Condensed findings; full texts in the mail
+archive. Reviser: fix all, log dispositions at the end. Findings marked
+[DESIGN] require amending DESIGN.md, not just PLAN.md.
+
+## grok (executability/pacing)
+
+- **P1** Split oversized items, same owners: 3.1a codec+roundtrip / 3.1b
+  fuzz+streaming; 3.3a dispatcher+state machine+release-on-EOF / 3.3b
+  deadlines+every-op e2e; 5.3 split (see also S9).
+- **P2** Split WI-4.3: 4.3a one-shot routing + turn-end order; 4.3b send
+  ambiguity + spool; 4.3c negative cache + D6 boot.
+- **P3** pool.id has no owner before M5: pin in WI-3.2 that M3 tests mint a
+  fixture pool.id (O_EXCL, valid hex); sole production writer is WI-5.4; add
+  to risk 6.
+- **P4** No CHANGELOG/tag-notes owner: add WI-1.9 (v1.6.0 notes) and WI-6.6
+  (v1.7.0 notes + CHANGELOG + hub-upgrades-first), integrator-owned, landing
+  with the tag.
+- **P5** §5.2.2 "real second machine" walk must say: scratch pool only (or
+  second unix user on the hub host), NEVER this checkout's live loop.
+- **P6** One implementer per merge; items in numeric order; no parallel WIs
+  sharing a file — state once under §2.
+- **P7** Name the sshd test wrapper: tools/test.sh tagged path or new
+  tools/sshd-test.sh (strip AGENTCHUTE_*, set only AGENTCHUTE_SSHD_TEST=1);
+  WI-6.3 done-when cites that script, never bare go test. (= codex #7.)
+- **P8** Release checklist line: a remote updating before the hub gets
+  E_VERSION and must wait — do not "fix" by re-running join. [DESIGN §7.5 or
+  checklist only — reviser's call]
+
+## opus-high (M1 implementer walk; anchors verified @ 1244ae4)
+
+- **F1** WI-1.2 vs the sendTsMessageWithCommit test seam (send.go:21;
+  send_a5_test.go:229-237, send_b3_test.go:137-146 reassign it): pick option
+  (a) — op owns an equivalent injectable var, named exception to the
+  zero-test-edit rule for those two files; reword WI-1.8(f) accordingly.
+- **F2** op.Tick unpinned and cannot be stateless (template serve.go:237,
+  lastSweep, token): pin a stateful handle, e.g. op.NewChannel(cfg, ctx) with
+  Register/Tick/ReleaseLease methods; runnerRuntime stores it. The seam IS
+  the wire schema — M3/M5 inherit this shape.
+- **F3** Tick non-fatal warnings (pollOnce logs+continues on renew/heartbeat/
+  sweep errors, serve.go:609-677): error only for ErrFenced; else
+  TickResp.Warnings []string rendered as today's logf lines; note tick-ok
+  example gains the field.
+- **F4** Three load-bearing stdout lines unrepresented: "(inbox empty)"
+  (check.go:198), "(reached limit…)" (check.go:210 — add Remaining int to
+  ClaimSummary or pin as info note), CLAIMED note (check.go:265). Pin
+  NoteEvent Level vocabulary + routing (warn/error→stderr, info→stdout);
+  these three are info notes in production order (or the pinned alternative).
+- **F5** WI-1.3 contradicts itself on ClearOwed: displayConsumed
+  (check.go:312) splits — ClearOwed half (321-331) into op.Claim (suppressed
+  under NoArchive), print half to renderer; "stays" range becomes 335-408.
+- **F6** WI-1.1 sentinel table mixes M3-only codes, existing loop sentinels,
+  and catch-all E_HUB_IO: list the exact M1 op-layer sentinel set; op
+  re-exports loop's four; define op.CodeFor(error) (default E_HUB_IO);
+  completeness test over that function. Also: ErrNotRegistered rendered texts
+  (send.go:145, check.go:120) stay byte-identical via Context.ActorID — say
+  so.
+- **F7** Import-cycle ordering: WI-1.7's gate move is a prerequisite of
+  WI-1.4 (op.Ack needs finishGateClear, gate.go:262); delete WI-1.6's
+  non-compiling "stays in cli" branch. (= codex #2, B1.)
+- **F8** WI-1.7 has no fixed-shapes clause: pin StatusResp (+ per-agent entry,
+  64-cap + Truncated bool), GateResp, CleanOwedReq/Resp — M3 serializes them.
+- **F9** E_POOL_MISMATCH is on both sides: correct the registry — hub-emitted
+  at session start (pool.id absent/≠ --pool-id), client-emitted on
+  hello-ok.pool12 mismatch; fix WI-1.1 enumeration + WI-2.1 spec text.
+  [DESIGN §4.4.2 + §5.1] (= codex #1.)
+- **F10** WI-6.3 CI job: hub-integration runs ONLY the tagged package, one
+  step, no test.sh (ci.yaml never calls test.sh; test.sh mutates via gofmt
+  -w); §10.2 hubwire tests stay in the existing go job; pin whether
+  integration/sshd/ is root-module (decides go build/vet visibility).
+- **F11** send-ok example missing "committed" (load-bearing for never-replay):
+  add to §4.4.1 example + WI-2.1 spec copy. [DESIGN §4.4.1]
+
+## codex (plan-vs-design gate)
+
+- **X1** = F9 [DESIGN]: resolve before M1/M2.
+- **X2** = F7/B1: mandate move of validate/mutate/evaluate cores into
+  internal/op; thin CLI adapters; pin gate core before op.Ack; delete
+  stays-in-cli option.
+- **X3** = B3: conformance/ is module agentchute.dev/conformance — cannot
+  import internal/*; root go test and test.sh never enter it. Put
+  internal-driving L/W adapters/tests in the ROOT module; transport-neutral
+  vectors as shared JSON data; define how M6 consumes them; add any nested
+  run to the canonical script.
+- **X4** Circular/absent done-whens: WI-5.3 gates on the M5 in-process
+  harness (real quickstart transcript moves to M6); WI-6.1 gains a done-when
+  (sshd start/auth/forced-command/cleanup + real-pool containment, both OSes).
+- **X5** ControlPath contingency has no trigger: pin a conservative
+  expanded-path threshold + owned 0700 per-user temp fallback; deterministic
+  deep-home builder test; M6 mux-reuse runs both paths.
+- **X6** Doc placement deferred: name the exact repo doc and web/ artifacts
+  now (web/hub.html + nav/sitemap if intended); render/link verification in
+  WI-6.5 done-when.
+- **X7** = P7 + rule-5 conflict: cross-cutting rule 5 is exactly tools/test.sh
+  (drop the separate raw-command line); pin the sshd script/mode semantics.
+
+## opus-xhigh (senior implementer; anchors verified)
+
+- **B1** [also X2/F7] Every wrapped helper MOVES to internal/op (list:
+  evaluateGate/finishGateClear/gateStatus gate.go:129,262,271;
+  archiveAllClaimed ack.go:164; performRegister & co register.go:35-189;
+  hasPendingInboxMail serve.go:757); op MUST NOT import cli; add a
+  dependency-direction test; re-price M1 to 2,000-2,500 LOC.
+- **B2** Second cycle — transport selection: pin direction: op is a leaf over
+  loop; hubwire imports op; hubclient imports hubwire+op; CLI selects the
+  transport (or op declares a Transport interface cli injects). [DESIGN §7.4
+  wording "op picks the transport" must change accordingly]
+- **B3** = X3.
+- **B4** [DESIGN §6.8] Launcher de-remotes joined lanes: buildDispatchRunArgs
+  (dispatch.go:246-257) and shims (shims.go:300-306) forward --control-repo
+  <local root> + --loop-dir <shadow>; flag arm outranks pointer → Remote=nil,
+  lane runs local against the shadow, NO error. Fix: in remote mode forward
+  --control-repo <canonical ssh URL>, omit --loop-dir; own dispatch.go +
+  shims.go in a WI; row: ac serve in joined checkout ⇒ Remote != nil.
+- **B5** [DESIGN §7.2] Migration attribution predicate broken for normal
+  lanes: setupCommandMatchesPool (setup_reset.go:308-344) exact-matches argv
+  flags against cfg — wrong strings in remote mode ⇒ every live lane
+  unattributed ⇒ migration permanently fail-closed. Define the remote
+  predicate (argv --control-repo vs old hub dir's recorded ssh URL, or
+  --loop-dir vs its shadow); test with a lane launched exactly as the
+  quickstart launches it.
+- **B6** [DESIGN §6.9] Clock-step lease theft: both boot-time sources move
+  with wall-clock steps; NTP step ⇒ live lane's LastSeen stale + StartedAt
+  pre-boot ⇒ live lane reclaimed (branch (d) lease.go:242-244 was its only
+  protection). Fix: record boot_ref IN the claim at acquire (linux
+  /proc/sys/kernel/random/boot_id; darwin recorded kern.boottime), reclaim in
+  (d) only when a PRESENT ref DIFFERS (equality, no ordering); absent ref ⇒
+  today's behavior. RenewLease preserves extra fields (lease.go:315-339,
+  verified). Add row: clock stepped forward under a live lane ⇒ NOT stolen.
+- **S1** self_check.go (selfRepairRegistration :117, used by turn-end :120)
+  into WI-1.6 + WI-4.3 file lists.
+- **S2** [DESIGN §3.5/§6.8 note] Client-side vendor resolution in remote mode:
+  all four resolveAgentVendor sites (serve.go:152, register.go:259,
+  boot.go:86, self_check.go:126) skip local resolution, send Vendor:nil;
+  cmdServe's missing-vendor refusal (serve.go:153-155) suppressed for remote
+  lanes.
+- **S3** internal/loop/pointer.go must change (DiscoverPointer/
+  ResolvePointerTarget pointer.go:93,105-118 require an existing directory;
+  ssh:// pointer dies before the ssh arm) — add to WI-4.1's files.
+- **S4** Non-wrapper --name yields unlaunchable lane (wrapperForToken
+  dispatch.go:133-136; direct serve treats positional as wrapper command
+  serve.go:117-129): refuse non-wrapper --name at join OR teach the
+  dispatcher the names map; add a --name work row. [DESIGN §7.2 join rules]
+- **S5** config.json ownership: pin struct + read/write helper in M4; M4 rows
+  run against a hand-planted config.json until M5.
+- **S6** WI-3.4 build tags: add boottime_windows.go + !linux&&!darwin&&
+  !windows fallback ("unreadable" = unchanged behavior); prefer
+  x/sys/unix.SysctlRaw on darwin (x/sys already in go.mod) over exec'ing
+  sysctl.
+- **S7** W2/W1-client cannot run in M3: restate M3's W set as hub-side
+  assertions; client halves move to M4 (or W wholesale to M4).
+- **S8** Three identity call sites resolve before Discover (status.go:34,
+  identity_cmd.go:24, guard.go:175-181): need reorder; status.go named in no
+  WI.
+- **S9** Splits (with P1): 5.3a join core / 5.3b key lifecycle / 5.3c
+  migration (D4a/F2), lanes per sub-item; peel setup_wipe H1 change out of
+  WI-5.4 into its own small item.
+- **G1** [DESIGN §7.2] Migration completion: copy into <newid>.partial,
+  fsync, rename() into place, delete old — pin the sequence.
+- **G2** [DESIGN §7.2] Lock file over ~/.agentchute/hub/<hub-id>/ (flock
+  idiom, filelock_unix.go) for join/rotate/migrate concurrency.
+- **G3** [DESIGN §7.2] Version-file details: numeric .v<N> ordering,
+  .invalid.<ts> format, whether .pub follows the active symlink (both paste
+  lines need a defined current-pubkey path).
+- **G4** [DESIGN §7.2] Mux masters survive migration up to ControlPersist=60s:
+  reap with ssh -O exit or declare harmless — one line.
+- Watch-item (budget, not a finding): non-root sshd -D auths only the
+  invoking user; macOS needs host-key/config paths hand-fed — WI-6.1.
+
+## Revision log (plan round 2)
+
+PLAN.md revised in place (2026-08-15). Section refs below are PLAN.md's, after
+the renumbering §2 rule 2 forced. Every code anchor used in the revision was
+re-opened at `1244ae4`; where a finding's own citation was wrong, the corrected
+anchor is in PLAN.md and noted here.
+
+**Sizing/count after revision: 45 work items, ≈10,700 LOC; M1 re-priced to
+2,000–2,500 (plan carries ~2,060).**
+
+### grok (executability/pacing)
+
+- **P1** FIXED — WI-3.1a (codec+round-trip) / WI-3.1b (fuzz+streaming);
+  WI-3.3a (dispatcher+state machine+release-on-EOF) / WI-3.3b (deadlines+
+  every-op e2e); 5.3 split under S9. Same owners.
+- **P2** FIXED — WI-4.5 (one-shot routing + turn-end order), WI-4.6 (send
+  ambiguity + spool), WI-4.7 (negative cache + hook-mode boot/D6).
+- **P3** FIXED — WI-3.2 pins the fixture (`writeFixturePoolID`, `O_EXCL`, 12
+  lowercase hex + LF, reused by WI-3.3a/b); WI-5.4 is named the sole production
+  writer; risk 6 rewritten. Verified and stated: no Go file, test, or tracked
+  source mentions `pool.id`/`pool12` today.
+- **P4** FIXED, and stronger than proposed — WI-1.9 (`docs/releases/v1.6.0.md`
+  + CHANGELOG) and WI-6.6 (`docs/releases/v1.7.0.md` + CHANGELOG +
+  hub-upgrades-first), integrator-owned, each landing inside its merge's PR.
+  Reason for the upgrade from "nice to have": `release.yaml:110` runs
+  `test -s "docs/releases/${tag}.md"` and `:168` passes it as `--notes-file`, so
+  a missing file fails the release job *after* the tag is pushed.
+- **P5** FIXED — §5.2 step 3 now reads "SCRATCH POOL, or a SECOND UNIX USER on
+  the hub host — NEVER this checkout's live loop directory", with the reason
+  (the walkthrough issues `hub join`/`serve`/`hub authorize`, all mutating).
+- **P6** FIXED — §2 "Execution rules for every merge", stated once: one lane per
+  merge (with named specialist hand-offs *inside* the merge), numeric order with
+  the load-bearing orderings restated on the items, and no parallel items
+  sharing a file.
+- **P7** FIXED — new `tools/sshd-test.sh`, exact content pinned in WI-6.1, with
+  the reasoning: `tools/test.sh` is 26 lines with **no** argument parsing of any
+  kind and opens with `gofmt -w .`, which mutates the checkout; the repo's own
+  precedent for a second suite is the conformance module's own CI step
+  (`ci.yaml:39-40`). Every M6 done-when cites the script, never bare `go test`.
+- **P8** FIXED (plan side; DESIGN already carries the `E_VERSION` text and the
+  §9.1 fourth rule) — WI-2.4 now says **four** lane-facing rules, not three, and
+  WI-6.6's notes restate the wait-don't-rejoin rule.
+
+### opus-high (M1 implementer walk)
+
+- **F1** FIXED, with one deliberate refinement to option (a). `internal/op`
+  declares an **exported** `var SendTsMessageWithCommit = loop.SendTsMessageWithCommit`
+  rather than an unexported var plus a test-only setter: the two reassigning
+  tests live in package `cli`, so an unexported var would still leave them
+  nothing to patch, and an exported var needs no setter function and no test
+  relocation — their surrounding assertions keep exercising the real `cmdSend`.
+  WI-1.2 names the exception (`send_a5_test.go:229-237`,
+  `send_b3_test.go:137-146`, verified, including what each stub does) and
+  WI-1.8's acceptance criterion is reworded: zero test edits **except** those two
+  files, whose diffs must show only the retarget hunks.
+- **F2** FIXED — `op.NewChannel(cfg, ctx, ChannelOpts{HeartbeatTemplate *loop.Registration})`
+  with `AcquireLease`/`Token`/`Register`/`Tick`/`ReleaseLease`, pinned in WI-1.7
+  and explicitly marked as inherited by M3's hub session and M5's remote serve.
+  The `HeartbeatTemplate` two-arm shape (non-nil = the local runner's verbatim
+  `heartbeatTemplate(cfg, opts)`, so M1 changes no heartbeat byte; nil = derived
+  and cached by `Register`, with `Tick`-before-`Register` ⇒ `op.ErrOrder`) is the
+  one addition to the proposed shape, and it exists so M3 does not have to
+  reshape the seam. `runnerRuntime` stores one `*op.Channel` in place of three
+  fields (lease, `regTemplate` `serve.go:237`, `lastSweep` `serve.go:242`).
+- **F3** FIXED — `TickResp.Warnings []string`; `Tick` errors only on
+  `op.ErrFenced`; the three warning sources are pinned with their exact
+  `r.logf` strings (`serve.go:622`, `:631`, `:641`) minus the trailing newline,
+  rendered `r.logf("%s\n", w)`. `serve.go:675`'s runner-state write failure is
+  explicitly NOT a tick concern. `lastSweep` still advances on sweep failure
+  (`serve.go:643`). The `tick-ok` wire example is **flagged** below.
+- **F4** FIXED — both halves, deliberately. Two count fields on `ClaimSummary`:
+  `Listed` (= `len(msgs)` at `check.go:200`, so the renderer reproduces the
+  `(inbox empty)` guard verbatim — counts alone cannot, because an all-quarantined
+  inbox has `Claimed == 0` and must NOT print it) and `Remaining`
+  (= `len(msgs)-claimed` at `check.go:207`). The CLAIMED note needs **no** field:
+  the renderer derives it from `NoArchive == false && Claimed > 0`, today's guard
+  at `check.go:261`. Separately, `NoteEvent.Level` is pinned to exactly
+  {`"warn"`,`"info"`} with routing (warn→stderr as `warning: <Msg>`, info→stdout)
+  and `Msg` never carrying its own prefix.
+  Anchors corrected: `(inbox empty)` is `check.go:201`, reached-limit `:207`,
+  CLAIMED `:262`.
+- **F5** FIXED — WI-1.3 now states the split explicitly (ClearOwed half
+  `check.go:321-331` + its two warning sites `:324`/`:328` → `op.Claim`,
+  suppressed under `NoArchive` to match `displayConsumedReadOnly`
+  `check.go:338-341`; print half → renderer). The "stays" range is corrected:
+  not `335-408` (`:335` is blank) but `displayConsumedReadOnly` 338-341,
+  `printConsumedBody` 348-364, `sanitizeControlBytes` 374-388,
+  `printReplyRefIfRequired` 393-408.
+- **F6** FIXED, with one correction to the finding's premise. The exact M1
+  op-layer sentinel set is enumerated as a table of **eight** — four re-exports
+  (`var X = loop.X` aliases, so `errors.Is` matches across packages) and four
+  new, including the split of `*loop.ErrRecipientStale` into `ErrRecipientStale`
+  (preflight, `seq.go:240`) and `ErrRecipientRacing` (under lock, `seq.go:253`),
+  which the hub needs because §4.4.2 gives them two codes. `op.CodeFor(error)` is
+  a function with an `E_HUB_IO` default arm; `loop.ErrInboxMissing` takes that arm
+  deliberately; the completeness test runs over the function plus a name-list test
+  so a ninth sentinel without a code arm fails. The codes M1 does NOT own (M3
+  session/codec, M4 client-only) are listed so the test cannot over-reach.
+  **Correction**: the two rendered not-registered texts are *not* byte-identical
+  today — `send.go:145` says `sender %q …`, `check.go:120` says `agent %q …`,
+  identical thereafter. So the rule is one sentinel, two renderers, each keeping
+  its own wording; the local/remote divergence this creates is **flagged** below.
+- **F7** FIXED — resolved structurally rather than by a note. M1's items were
+  renumbered so dependencies run in numeric order (P6): the read-ops + gate core
+  is now **WI-1.4** and `op.Ack` is **WI-1.5**, with the prerequisite stated on
+  both. The "stays in cli / moves wholesale — implementer's choice" branch is
+  deleted everywhere in M1; the M1 preamble lists the full move set and states
+  that the alternative does not compile.
+- **F8** FIXED — WI-1.4 gains a fixed-shapes clause: `GateReq` (exactly
+  `evaluateGate`'s parameters, `gate.go:129`), `GateResp` (= `gateStatus`'s
+  fields verbatim, `gate.go:271-286`, so `gate --json` and `turn-end --json`
+  stay byte-identical), `StatusResp{Agents, Truncated}` with the 64-entry cap
+  enforced **in the op** and sorting applied before truncation,
+  `StatusAgent{…, Claim *StatusClaim}` with `ServeClaim.ServeToken`
+  (`lease.go:59`) explicitly excluded as the fence secret, `PendingReq`/
+  `PendingSummary`, and `CleanOwedReq`/`CleanOwedResp`.
+- **F9** [DESIGN] — DESIGN.md already amended; PLAN.md made consistent: WI-1.1's
+  enumeration says neither arm is an op-layer sentinel; WI-3.2 carries only
+  `hello-ok.pool12`; WI-3.3a owns the hub arm at session start; M4 owns the
+  client arm; WI-2.1 requires the registry to record each code's emitter side;
+  WI-5.6 requires two distinct texts from two distinct conditions.
+- **F10** FIXED, against the verified CI rather than an assumed one. WI-6.3
+  records the real starting state (four jobs; the `go` job runs gofmt -l/vet/
+  test/test -race/build plus `cd conformance && go test ./...`; **no** job calls
+  `tools/test.sh`, which would mutate the checkout via `gofmt -w .`). The new
+  `hub-integration` job is ubuntu+macos with **one** step, `sh tools/sshd-test.sh`,
+  running only the tagged package; §10.2/spectest/seam tests stay in the existing
+  `go` job with no CI change. `integration/sshd/` is pinned as **root-module**
+  (no nested `go.mod`, so rule 6 holds) with an **untagged `doc.go`** so
+  `go build ./...`/`go vet ./...`/`go test ./...` are deterministic with the tag
+  absent — and the done-when requires proving that empirically.
+- **F11** [DESIGN] — DESIGN.md already amended; PLAN.md made consistent: WI-2.1's
+  spec copy carries `"committed":true`, and WI-3.1a decodes it as `*bool` with
+  absence ⇒ `E_MALFORMED_FRAME`, never a defaulted `false`.
+
+### codex (plan-vs-design gate)
+
+- **X1** = F9. FIXED as above.
+- **X2** = F7/B1. FIXED — the move is mandated with a full list, thin CLI
+  adapters, the gate core before `op.Ack`, and the stays-in-cli option deleted.
+- **X3** = B3. FIXED as below.
+- **X4** FIXED — WI-5.3a's done-when now gates on the **M5 in-process harness**
+  (WI-3.3a's fake-transport session), with the real quickstart transcript
+  explicitly moved to WI-6.2's happy-path row; WI-6.1 gains a five-part
+  done-when (sshd start/auth, forced command actually running the test binary
+  with the client's exec string discarded, `t.Cleanup` teardown leaving no
+  socket or tree, real-pool containment asserted *both* as a refusal and as
+  "nothing was written", and green on both OSes).
+- **X5** FIXED — WI-4.4 pins a conservative trigger
+  (`len(muxDir) + 1 + 64 >= 100`, reusing the shipped literal at
+  `config.go:170` so there is one number in the codebase), a first fallback
+  under an owned 0700 per-user temp dir created through the shipped
+  `ensureOwnedRunnerSocketDir` discipline (`runner_socketdir_unix.go:24-49`)
+  trying `os.TempDir()` then `/tmp` (macOS's `$TMPDIR` is itself long), a
+  mux-disabled third arm with one warn note rather than a hard refusal, a
+  deterministic **length-injecting** builder test, and WI-6.2's mux-reuse row
+  running through both paths.
+- **X6** FIXED — WI-6.5 names `README.md`, NEW `docs/hub.md`, NEW
+  `web/hub.html` (modelled on `web/spec.html:17-27`), the **three** nav edits
+  (`web/index.html:188-193`, `web/spec.html:20-25`, `web/blog/index.html:20-25`
+  — there is no nav partial and no build step; blog posts' navs are historical
+  and untouched, mirroring `tools/fact-sweep.sh:19`'s own exclusion), and one
+  bare `<loc>` in `web/sitemap.xml`. The done-when adds fact-sweep PASS,
+  enumerate-and-stat link verification, and a render check.
+- **X7** FIXED — cross-cutting rule 5 rewritten to "`tools/test.sh`, and nothing
+  else", stating that it IS gofmt+vet+test+build (`tools/test.sh:11-24`), that
+  its gofmt is `-w` and mutates (which is why CI uses `-l`), and that
+  `tools/sshd-test.sh` runs in addition from M6 and is never folded in.
+
+### opus-xhigh (senior implementer)
+
+- **B1** FIXED — the M1 preamble lists the full move set with verified anchors
+  (`evaluateGate` 129-256, `finishGateClear` 262-268, `gateStatus` 271-286,
+  `archiveAllClaimed` 164-179, `performRegister` **72-98** — the finding's
+  `35-189` conflated three declarations — plus `publishRegistrationOnce`
+  107-187, `registrationLiveElsewhere` 189-195, `hasPendingInboxMail` 757-763,
+  and the delivery seam var `send.go:21`), states that `internal/op` MUST NOT
+  import `internal/cli`, adds the dependency-direction test in WI-1.8
+  (`go/build` import scan, stdlib only), and re-prices M1 to 2,000–2,500.
+- **B2** [DESIGN] — DESIGN §7.4 already pins the direction; PLAN.md made
+  consistent (M1 preamble, WI-1.8's test, §7 pins). No "op picks the transport"
+  wording survives in the plan.
+- **B3** FIXED — WI-3.5 rewritten around the verified module facts
+  (`conformance/go.mod` is three lines, no requires, no `go.sum`, no `go.work`;
+  root `go test ./...` and `tools/test.sh` never enter it; only `ci.yaml:39-40`
+  and `release.yaml:47-48` do). Drivers go in the ROOT module as
+  `internal/spectest/{vectors.go,lease_test.go,wire_test.go}`; vectors travel as
+  transport-neutral shared JSON at `conformance/vectors/{lease,wire}.json`, read
+  by relative path (data, not an import); `conformance/` gains prose only and no
+  Go file; WI-6.4 consumes the same vectors by importing `internal/spectest` and
+  swapping the transport; both `go.mod` files must come out byte-identical.
+  `tools/test.sh` gains the one missing nested run (`cd conformance && go test
+  ./...`) — the only change this plan makes to that script.
+- **B4** [DESIGN] — DESIGN §6.8 already amended; PLAN.md gains **WI-4.3**
+  (dispatch.go + shims.go), shipping in the same merge as WI-4.2, with the
+  §10.3 row asserting `Remote != nil` rather than "the command succeeded".
+  **PARTIALLY REJECTED as stated in the task framing** ("must ship in one merge
+  with the migration-attribution rule"): they cannot, and DESIGN does not ask
+  them to. §6.8 rule 5 requires the launcher fix to ship with the **discovery
+  arm** (M4); the migration predicate has **no caller** until `hub join` exists
+  (M5), so putting it in M4 would merge dead code and putting the launcher fix in
+  M5 would leave M4 shipping a discovery arm every launcher silently defeats.
+  §7.2's own words are "the two changes ship together (M4/M5) and a review of
+  either must check the other" — a *review* obligation across two merges, which
+  is what the plan now encodes: an explicit cross-merge interlock on WI-4.3 and
+  WI-5.3c, a mandatory re-verification of WI-4.3's argv goldens at the M5 head
+  SHA (§4), and risk 9.
+  One executability addition the finding did not cover: `cmdShimsExec` is the
+  **legacy** `ac-*` path — `removeLegacyWrapperShims` (`shims.go:237-257`)
+  deletes those shims at setup and only the single `ac` dispatcher is installed
+  — so the row must construct a legacy shim or it silently never tests
+  `shims.go`. Also **flagged** for DESIGN below.
+- **B5** [DESIGN] — DESIGN §7.2 already carries the remote predicate; PLAN.md's
+  WI-5.3c restates it with verified anchors (`setupCommandMatchesPool`
+  **308-345**, its OR-of-two-exact-matches at `340-341`, `setupCommandFlagValue`
+  at `352+` truncating at `--` at `355-358`, `stopSetupRunner` 196-224) and with
+  the normal-lane row as the item's own done-when.
+- **B6** [DESIGN] — DESIGN §6.9 already replaced boot *time* with `boot_ref`;
+  WI-3.4 rewritten end to end: `ServeClaim.BootRef` (`lease.go:55-62`),
+  population at `lease.go:160-167`, branch (d) only (`lease.go:242-244`),
+  freshness first (`230-232`), equality never ordering, absent ⇒ unchanged, the
+  `readClaim`/`RenewLease` round-trip (`101-114`, `317-340`) requiring a real
+  struct field, an injectable `readBootRef` seam without which none of the rows
+  are deterministic, and seven rows including both clock-step directions.
+  Filename pin changed from `boottime_*` to `bootref_*` to match the semantics.
+- **S1** FIXED — `self_check.go` added to WI-1.6 (op.Register) and WI-4.5
+  (one-shot routing) file lists, with the verified anchors:
+  `selfRepairRegistration` is `self_check.go:117-133`, driven from
+  `self_check.go:71` and `turn_end.go:120`, and its "non-empty id even when the
+  write failed" contract (`self_check.go:129-131`) must survive because
+  `turn_end.go:121-123` aborts only on an empty id.
+- **S2** [DESIGN] — DESIGN §3.5 already normative; PLAN.md consistent: WI-1.6
+  states `resolveAgentVendor` is UNCHANGED in M1 and the four call sites branch
+  in M4; WI-5.7 carries the row asserting `Vendor:nil` at all four sites and the
+  suppression of `cmdServe`'s refusal. Anchor corrected: `resolveAgentVendor` is
+  `identity.go:72-83`; the vendor block in `serve.go` is `152-157`.
+- **S3** FIXED, with corrected anchors — the finding cited
+  `pointer.go:93,105-118`; the real functions are `DiscoverPointer`
+  (`pointer.go:58-103`) and `ResolvePointerTarget` (`pointer.go:113-122`), and
+  the existing-directory check is not in `pointer.go` at all but in
+  `absExistingDir` (`config.go:359-375`). WI-4.2 traces exactly what an `ssh://`
+  pointer does today (`filepath.IsAbs` false ⇒ joined onto the pointer dir ⇒
+  `Clean` collapses `//` ⇒ ENOENT on `<pointerDir>/ssh:/user@host/path`, and
+  `config.go:229-234` makes a pointer error **hard**, killing the cascade before
+  any ssh arm) and pins the fix.
+- **S4** [DESIGN] — DESIGN §7.2/§7.3/§7.5 already carry the refusal; PLAN.md's
+  WI-5.3a implements it before keygen and before any authorize call, validating
+  through `wrapperForToken` (**`shims.go:51-64`** — not `dispatch.go`), and names
+  the rejected dispatcher-teaching alternative so nobody re-invents it.
+- **S5** FIXED — WI-4.1 pins the `HubConfig` struct verbatim from §7.4, the
+  0600/0700 contract, `ReadHubConfig` with a **named** not-found error (the
+  `E_NOT_JOINED` trigger) distinguishable from parse/IO errors,
+  `WriteHubConfig` as temp+fsync+rename, and the explicit statement that unknown
+  fields are dropped. It also resolves the layering question the finding implies:
+  `internal/loop` cannot import `internal/hubclient`, so the path builder and the
+  existence **stat** live in `internal/loop/remote.go` and only the struct and
+  helper live in `hubclient`. WI-4.1's done-when states that every other M4 row
+  runs against a hand-planted `config.json` until WI-5.3a.
+- **S6** FIXED, one part **modified with an argument**. Accepted in full:
+  `x/sys/unix` over an exec'd `sysctl`, with an added reason the finding did not
+  give — the boot ref is read inside `AcquireServeLease`'s `withAgentLock`
+  critical section, and forking under a flock is exactly the failure surface this
+  codebase avoids; plus the verification that `golang.org/x/sys` is already a
+  **direct** requirement (`go.mod:7`, v0.30.0, today imported only from
+  `filelock_windows.go`), so rule 6's empty-`go.mod`-diff survives and
+  `release.yaml:28-30` proves it.
+  **Modified**: the plan pins **three** files (`bootref_linux.go`,
+  `bootref_darwin.go`, `bootref_other.go` = `!linux && !darwin`) rather than the
+  four the finding asked for (`…_windows.go` plus a
+  `!linux && !darwin && !windows` fallback). Argument: `internal/loop`'s existing
+  convention is a **total** platform partition with no uncovered GOOS and no
+  third file — all four tagged pairs are `!windows`/`windows` — and a
+  `bootref_windows.go` returning `""` would be byte-for-byte identical to
+  `bootref_other.go` returning `""`. Three files is the minimal total partition,
+  covers Windows and every other GOOS, and preserves "unreadable ⇒ unchanged
+  behavior" exactly as the finding requires. If a reviewer wants the fourth file
+  anyway, it is a one-line addition and nothing else in the item changes.
+- **S7** FIXED — WI-3.5's W set is restated as four **hub-side** assertions
+  (W1/W2/W3 rewritten to assert hub-side state only, W4/W5 already hub-side),
+  and the client halves move to the new **WI-4.10**, which reuses the same
+  `conformance/vectors/wire.json` definitions. The plan names the failure mode
+  explicitly: a green W2 in M3 that claims client behavior is testing nothing.
+- **S8** FIXED, with a correction that changes the work. `status.go:34` (before
+  `Discover` at `:43`) and `guard.go:175-189` (before `Discover` at `:195`) are
+  reorders, and status.go is now named in WI-4.8 — it appeared in no item
+  before. **`identity_cmd.go:24` is NOT a reorder**: that file calls
+  `resolveAgentID` at `:24` and **never calls `loop.Discover` at all** — it does
+  not even import `internal/loop`, and its `--control-repo`/`--loop-dir` flags
+  (`identity_cmd.go:13-18`) are declared and unused. So it is an **addition**, and
+  the plan requires that new Discover to be **non-fatal**, because
+  `agentchute identity` succeeds today in a directory with no pool and must keep
+  doing so (risk 5). Also pinned: `guard`'s fail-open behavior must not become
+  fail-closed. Anchors corrected: `resolveAgentID` is `identity.go:13-25`,
+  `resolveAgentIDRaw` `27-39`.
+- **S9** FIXED — WI-5.3a (join core) / WI-5.3b (key lifecycle) / WI-5.3c
+  (same-hub migration), with the lane table assigning 5.3b and 5.3c to the
+  specialist as hand-offs **inside** the M5 merge (reconciling S9 with P6's
+  one-implementer-per-merge rule, stated in §2 rule 1). The `setup_wipe.go`
+  H1 change is peeled into its own **WI-5.5**, with its own row and its own
+  done-when, and is required to ship in the same merge as WI-5.4.
+- **G1** [DESIGN] — DESIGN §7.2 already pins the sequence; WI-5.3c restates it
+  step by step (`.partial` → fsync files and dir → `rename` as the commit point →
+  fsync the parent → pointer → delete old; `mux/` deliberately not copied) with
+  crash-injection rows on both sides of the rename.
+- **G2** [DESIGN] — DESIGN §7.2 already pins the lock; WI-5.3a implements it
+  (sibling `.locks/<hub-id>.lock`, 0700 on demand, taken before any probe, the
+  shipped `syscall.Flock` idiom generalized from `filelock_unix.go:46-67` with
+  `agentLockTimeout` `:20` / `agentLockRetryInterval` `:23`, named refusal on
+  timeout), and WI-5.3c adds the two-lock ascending-order rule.
+- **G3** [DESIGN] — DESIGN §7.2 already pins the grammar; WI-5.3b implements
+  numeric `.v<N>` ordering, the refuse-don't-guess rule for non-numeric
+  suffixes, `.invalid.<ts>` with `tsStampLayout` (`tsid.go:22,51`) at microsecond
+  resolution, and **no `.pub` symlink** — the current pubkey derived as
+  `readlink(...) + ".pub"`, used by both paste-line sites.
+- **G4** [DESIGN] — DESIGN §7.2 already covers it; WI-5.3c's step 5 issues the
+  best-effort `ssh -O exit` and states why an unreaped master is harmless.
+- **Watch-item** (non-root `sshd -D`; macOS host-key/config paths) — carried
+  verbatim into WI-6.1 as a budget note.
+
+### Design defects found while revising — FLAGGED, not fixed
+
+DESIGN.md is owned by another agent; these are recorded here instead of edited.
+
+1. **§4.4.1's `tick-ok` example does not carry `warnings`** — the direct
+   consequence of F3. The plan requires the field in the M2 spec copy (WI-2.1)
+   and in the codec's fixed shape (WI-3.1a), so the design example is now the
+   only place it is missing.
+2. **§7.5 gives `E_NOT_REGISTERED` one exact text, but the CLI has two.**
+   `send.go:145` renders `sender %q is not registered. …` and `check.go:120`
+   renders `agent %q is not registered. …`. §7.5's single text is `check.go`'s
+   wording, so a remote `send` will print "agent …" where a local `send` prints
+   "sender …" — a one-word local/remote divergence in a catalog that is otherwise
+   byte-exact. Either the catalog needs a send-side row, or §7.5 should say the
+   client re-renders it per call site.
+3. **§4.2/§7.4 give the mux `ControlPath` no length rule.** With
+   `~/.agentchute/hub/<12 hex>/mux/%C` a sufficiently deep `$HOME` can approach
+   the ~104-byte `sun_path` limit. PLAN WI-4.4 decides a contingency (threshold,
+   owned-0700 temp fallback, mux-disabled third arm), but if that behavior is
+   meant to be normative it belongs in §4.2 rather than in the plan.
+4. **§10.3's "launcher preserves remoteness" row names `ac-*` shims as a live
+   launcher, but they are legacy.** `removeLegacyWrapperShims`
+   (`shims.go:237-257`) deletes generated `ac-*` shims at setup and only the
+   single `ac` dispatcher is installed (`installDispatcher`, `shims.go:208-231`);
+   `cmdShimsExec` (`shims.go:259-312`) is reachable only from a surviving old
+   shim. As written, an implementer can satisfy the row by exercising the
+   dispatcher alone while `shims.go:304-305` stays broken. The plan requires the
+   row to construct a legacy shim; the design row should say so too.
+5. **§6.9/§10.3's "unknown extra key still parses (mixed-version tolerance)" is
+   true but easy to misread as preservation.** `readClaim` (`lease.go:101-114`)
+   is a plain `json.Unmarshal` into the closed `ServeClaim` and `RenewLease`
+   (`lease.go:317-340`) re-marshals only that struct, so an unknown key **parses
+   and is then dropped on the first renew**. The design's own field-preservation
+   paragraph says this correctly; the §10.3 row's phrasing does not, and the
+   plan's WI-3.4 spells out "assert parsing, never preservation".
+6. **§3.2 names two latch-arming sites but the code has three.** DESIGN cites
+   `check.go:243,256`; the `setLatch` closure (`check.go:169-175`) is also called
+   at `check.go:185` for the redelivered-residue path. An implementer following
+   §3.2 alone would leave the redelivery path unarmed — precisely the E1 failure
+   the design exists to prevent. PLAN WI-1.3 lists all three.

--- a/proposal/ssh-hub/plan-reviews-r2.md
+++ b/proposal/ssh-hub/plan-reviews-r2.md
@@ -1,0 +1,279 @@
+# Plan review round 2 — PLAN.md @ 027f18cc / DESIGN.md @ 4600cd7c (2026-08-15)
+
+grok: **SHIP** (1 nit). opus-xhigh: **FIX, narrow** (4, one blocking) — all 19 of
+its round-1 items verified resolved. opus-high: **FIX** (2 real, 1 nit) — all
+F1–F11 dispositions verified accurate. codex: **FIX** (5 blockers + stale-note
+cleanup) — agrees with both deliberate deviations, as do grok and opus-xhigh.
+
+**Both deviations are now confirmed by all three reviewing lanes** (B4 M4/M5
+split with the interlock; S6 three build-tagged files). Do not revisit.
+
+Note the convergence: **codex #4 and opus-xhigh N1 are the same defect.**
+
+## Blocking
+
+- **R1 (opus-high D1) — M1's zero-test-edit criterion is violated by three
+  more moves.** F1 proved the seam retarget needs two test exceptions; the same
+  check was never run against the other identifiers the move set removes from
+  package `cli`, and three are referenced by name in existing tests:
+  - (a) `gateStatus` — 11 sites in 4 files (`consume_boundary_test.go:257`,
+    `gate_test.go:207,221,372`, `enforced_enrollment_test.go:106,128`,
+    `turn_end_test.go:38,87,126,236,494`), all `var got gateStatus` for JSON
+    unmarshal. Fix: leave a one-line **type alias** in cli
+    (`type gateStatus = op.GateResp`) — alias, not defined type; state it in the
+    gate item's (c).
+  - (b) `performRegister`/`registerOpts` — 13 call sites in `register_test.go`
+    (`:34,58,100,131,165,234,243,270,279,306,336,365,369`), and `:365` uses
+    `Bio:"old", BioProvided:true`, fields the reshaped request does not have, so
+    **no alias can bridge it**. Fix (recommended): keep
+    `performRegister(cfg, registerOpts, now)` in cli as a thin **adapter** that
+    maps to the op request and calls the op — a caller, not a callee, so no
+    cycle. (Alternative: name `register_test.go` as a second exception with its
+    hunk list — 13+ hunks in the merge whose claim is invisibility.)
+  - (c) `runnerRuntime.lease`/`regTemplate` — `run_test.go:500-507`
+    (`newPollTestRuntime`, also used by `b1_convergence_test.go:36`) builds the
+    literal. Fix: name that helper as a third exception (one hunk, one helper).
+  - **Preamble rule that would have caught all three**: for every identifier the
+    move set removes from package `cli`, either leave a thin alias/adapter or
+    name the test file and hunks as an exception — and grep each moved
+    identifier across `internal/cli/*_test.go` before calling the item done.
+    Then M1's criterion reads "EXCEPT the named list", which is honest.
+- **R2 (opus-high D2) — F4's fix relocates three stdout lines after the owed
+  lines.** `Listed`/`Remaining` reproduce the TEXT but are derived from the
+  summary, which arrives after the stream, while expired-owed events are emitted
+  inside the claim op. So `(inbox empty)` (check.go:201), `(reached limit of …)`
+  (:207) and the CLAIMED note (:262) all move after the obligation lines —
+  a silent behavior change inside the merge whose whole claim is zero behavior
+  change, and `check_age_owed_test.go:196-224` stays green because it uses
+  `strings.Contains`. Fix: emit all three as `Level:"info"` NoteEvents at their
+  production points (exactly what the pinned note vocabulary is for; ordering
+  then survives the wire too). Stop telling the renderer to print from
+  `Listed`/`Remaining`.
+- **R3 (codex #1) — the registry-completeness test is impossible as written.**
+  PLAN:122-146 gives `op.CodeFor` eight sentinel codes plus default `E_HUB_IO`
+  including `E_ORDER`; PLAN:706-717 says M3 ADDS nine including `E_ORDER`, calls
+  the op side "eight codes", requires no duplicate AND requires the client-only
+  list disjoint. Cannot all hold. Fix: pin op outputs = 9 including the default;
+  M3-only = 8 excluding `E_ORDER`; model `E_POOL_MISMATCH` as an explicit
+  both-sides classification instead of requiring disjointness.
+- **R4 (codex #2) — F8's shapes still lose behavior.** `StatusAgent{…}`
+  (PLAN:351-358) is not a fixed struct/JSON schema and "row's own fields" is
+  ambiguous; `op.Status` has no channel for `ReadRegistrationsLenient` warnings
+  that `cmdStatus` prints today (`status.go:68-74`); and
+  `CleanOwedResp{Pruned, Remaining int}` (PLAN:361-365) loses the pruned refs
+  required by today's text and `--json` output (`clean.go:96-103,180-192`;
+  `clean_test.go:391-412`), so its unmodified-test done-when cannot pass. Fix:
+  enumerate `StatusAgent` + JSON tags, preserve the status warnings, return the
+  pruned refs and existing JSON semantics.
+- **R5 (codex #3) — PLAN and DESIGN disagree on two wire structs**, and DESIGN
+  says seam structs are serialized verbatim, so this is not packaging taste:
+  DESIGN:353-367 defines `RegisterReq` WITHOUT `HostProvided` (hub maps the
+  client-resolved Host to HostProvided:true) while PLAN:430-444 adds it;
+  DESIGN:435 defines `GateReq{Phase string}` while PLAN:336-343 adds
+  `RequireConfirm` and `AckStaleReg`. Fix: choose ONE exact schema and make both
+  documents say it — pick whichever preserves current CLI behavior, and check
+  the real flags before deciding.
+- **R6 (codex #4 = opus-xhigh N1) — `_test.go` helpers are not importable.**
+  The L/W assertions are pinned in `internal/spectest/lease_test.go` /
+  `wire_test.go`, but the M6 item imports `internal/spectest` and calls those
+  helpers — identifiers in `_test.go` compile only into that package's own test
+  binary. As pinned, the sshd driver cannot see them, so it fails to compile or
+  duplicates the assertions (the one thing the item forbids). Fix: pin the
+  transport-parameterized helpers in NON-test files
+  (`internal/spectest/lease.go`, `wire.go`), exported, taking the transport as
+  an interface (`io.ReadWriter` for the codec half, a small seam for the lease
+  half); `*_test.go` become thin drivers passing `net.Pipe`; the M6 item passes
+  the ssh transport to the same exported helpers.
+- **R7 (codex #5) — the canonical test-script change bypasses the env strip.**
+  PLAN:972-975 mandates the literal bare `cd conformance && go test ./...`
+  while E10 and PLAN:2090-2096 require every Go invocation to strip
+  `AGENTCHUTE_*`. Fix: use the script's existing `$strip_env` and preserve its
+  explicit failure reporting.
+
+## Non-blocking
+
+- **R8 (opus-xhigh N2)** Vectors path works only by depth coincidence
+  (`../../conformance/vectors/…` resolves from both packages only because both
+  sit two levels below the root). Fix: derive the directory once in the loader
+  from `runtime.Caller(0)` (stdlib; `go:embed` cannot reach a parent).
+- **R9 (opus-xhigh N3)** The identity-signature item names 5 files but there are
+  12 call sites (`check.go:87`, `ack.go:91`, `boot.go:78`, `pending.go:63`,
+  `send.go:127`, `gate.go:80`, `clean.go:80`, `register.go:254`,
+  `self_check.go:118` beyond the named five) — each already Discovers first, so
+  each just passes cfg. Matters because §2 rule 3 makes the (c) list the
+  authority for parallelism. Fix: list them, or state that a signature change
+  updates all callers and rule 3 reads the union.
+- **R10 (opus-xhigh N4)** The boot item's (b) cites "§10.3's four boot rows";
+  there are three (hub-reboot pid reuse; clock step does not steal; boot_ref
+  survives the heartbeat). Its own (e)/(f) list seven cases correctly — only the
+  pointer is wrong.
+- **R11 (opus-xhigh note 1)** The migration item's third attribution arm can
+  false-attribute after OS pid reuse (stale `runner.json` naming a pid that now
+  belongs to an unrelated flagless `agentchute serve`). It fails CLOSED and never
+  suggests a kill, so the direction is right — add one sentence so nobody later
+  "fixes" it into proceeding.
+- **R12 (opus-xhigh note 2)** `boot_id`/`kern.bootsessionuuid` are host-scoped,
+  so a container restart on an unrebooted host still wedges as today. §6.9's
+  stated scope ("after a hub reboot") is fine, but the M2 spec text should carry
+  the clause rather than imply pid reuse is solved generally.
+- **R13 (grok nit)** The M3 pool.id item's (d) says do not implement either
+  `E_POOL_MISMATCH` arm, but its (e) still asks for absent/malformed/
+  valid-but-different tests that already live on the handshake item's (e). Drop
+  the pool.id clause from that (e).
+- **R14 (opus-high D3 + codex cleanup) — stale notes now contradicting the
+  frozen amended DESIGN**: PLAN:159-167 (remote-send `E_NOT_REGISTERED`
+  divergence — fixed), PLAN:512-514 (DESIGN lacks `tick-ok.warnings` — fixed),
+  PLAN:2356-2358 and the revision log's "FLAGGED, not fixed" section (all six
+  are fixed in DESIGN @ 4600cd7c; opus-high verified each: warnings at
+  DESIGN:756/759/767, both not-registered texts + status.go:62 at :791/:2330,
+  ControlPath rule at :559-560/:2215-2216, shim row at :2655 with the fix at
+  :1440-1477, mixed-version row at :2654/:1542-1559, three latch sites at
+  :276-277/:1325/:2661). Retitle or delete so the DESIGN owner does not redo six
+  amendments.
+
+## Revision log (plan round 3)
+
+Applied to PLAN.md; DESIGN.md touched only for R5 and R12. All anchors below
+re-opened and verified at `1244ae4`.
+
+- **R1 — FIXED**, M1 preamble ("Ground rules for every M1 item") + WI-1.4(d),
+  WI-1.6, WI-1.7(d), WI-1.8(f). The criterion now reads "unmodified EXCEPT the
+  named list", and the list is a closed table: `send_a5_test.go:229-237`,
+  `send_b3_test.go:137-146`, `run_test.go:495-507` (`newPollTestRuntime`) —
+  three files, three hunks. (a) `type gateStatus = op.GateResp` **alias**
+  (verified: all 11 sites are `var … gateStatus` + `json.Unmarshal` on an
+  all-exported struct, `gate.go:271-286`). (b) `performRegister` stays in `cli`
+  as a **thin adapter** with its signature and both structs unchanged, so all
+  13 calls + 2 `registerOpts` literals compile untouched; it also owns the
+  `!HostProvided ⇒ os.Hostname()` substitution, which is where R5 needs it.
+  (c) `newPollTestRuntime` named as the third exception — one helper, one
+  hunk; `b1_convergence_test.go:36` calls it and is untouched, as is
+  `run_resize_unix_test.go:44`. The **move-set grep rule** is now a binding
+  preamble rule and a WI-1.8 done-when. Running it over the whole move set
+  found **two cases beyond R1's three**, both closed by preserving a signature
+  rather than adding an exception: `printStatus` (`status_test.go:35,77,126,181`
+  — WI-1.4 keeps it byte-identical and defers the render switch to M4) and
+  `refuseLiveRunnerCollision` (`run_test.go:130,140,159,170`, whose results feed
+  `loop.RenewLease`/`ReleaseLease` at `:147,164,167,172` — kept byte-unchanged
+  via the new `ChannelOpts.Lease` adoption arm, WI-1.7(d)).
+- **R2 — FIXED**, WI-1.3(d)/(e). The three lines are `Level:"info"` NoteEvents
+  at their production points: `(inbox empty)` at `check.go:200-202` (guard
+  `len(msgs)==0 && len(redelivered)==0`), the limit line at `:206-208` (emitted
+  mid-stream, between two message events — which is why no summary field can
+  reproduce it), the CLAIMED line at `:261-263` (guard `!noArchive && claimed>0`)
+  ahead of the expired-owed lines. `ClaimSummary` reverts to DESIGN §3.2's four
+  counts, which also removes a PLAN↔DESIGN divergence against `check-ok`
+  (`DESIGN.md:737`). The golden test now asserts **position**, not presence.
+- **R3 — FIXED**, WI-1.1(d) + WI-3.1a(d)/(e). Pinned arithmetic: op outputs
+  **9** (8 sentinels + the `E_HUB_IO` default), `internal/hubwire` adds **8**
+  (`E_ORDER` removed — it is an op sentinel), union = §4.4.2's **17** hub-side
+  rows exactly; client-only = **9** and disjoint. `E_POOL_MISMATCH` is an
+  explicit `both` row in a `codes.go` emitter-classification table instead of a
+  member of two lists.
+- **R4 — FIXED**, WI-1.4(d). `StatusAgent{Reg RegistrationView; InboxDepth int;
+  Status string; Claim *StatusClaim}` fully enumerated; `RegistrationView` is a
+  tagged mirror of `loop.Registration`'s eight fields because that struct
+  carries **no JSON tags** (`registration.go:58-68`) and `internal/loop` is
+  frozen in M1. `StatusResp` gains `Warnings []string` (the
+  `ReadRegistrationsLenient` channel, `status.go:67-70,91-92`) and `Now` (one
+  clock for AGE + label). `CleanOwedResp` = `cleanOwedResult` verbatim
+  (`clean.go:99-103`) — `{Agent string; Pruned []string; Applied bool}`, `Pruned`
+  non-nil so `--json` renders `[]` (`clean.go:121`), which is what
+  `clean_test.go:391-412` decodes; `Remaining` dropped (nothing prints it); the
+  request field is `Apply`, matching the shipped `--yes` polarity rather than an
+  invertible `DryRun`.
+- **R5 — FIXED, and the two structs went in opposite directions.**
+  **`RegisterReq`: DESIGN's schema wins — no `HostProvided`** (PLAN WI-1.6(d)
+  amended). Verified against the real path: `performRegister` substitutes
+  `os.Hostname()` only when `!HostProvided` (`register.go:80-87`), and every
+  local arm is reproduced by resolving client-side and treating the field as
+  provided — `--host X` ⇒ X, explicit `--host ""` ⇒ empty (`cmdRegister`'s
+  `fs.Visit` capture, `register.go:226-233`), absent ⇒ the caller's own
+  hostname, same warning on failure. Carrying `HostProvided:false` over the wire
+  is the one shape that lets the hub write the HUB's hostname onto a remote
+  lane's row, which is the bug D1a exists to prevent. **`GateReq`: PLAN's
+  schema wins — `{Phase, RequireConfirm, AckStaleReg}`** (DESIGN §3.6 amended).
+  Verified: both are real shipped flags parsed at `gate.go:55-56` and passed to
+  `evaluateGate` at `gate.go:97` (signature `gate.go:129`); dropping them makes
+  every remote `gate --require-confirm` stop refusing and every
+  `--ack-stale-reg` stop acknowledging — a silent verdict change.
+- **R6 — FIXED**, WI-3.5(c) + WI-4.10(c). Assertions move to NON-test files
+  `internal/spectest/lease.go` / `wire.go`, exported and transport-parameterized
+  (`io.ReadWriter` for the codec half, a small seam for the lease half);
+  `lease_test.go`/`wire_test.go` become thin `net.Pipe` drivers; WI-6.4 passes
+  the ssh transport to the same helpers, so one assertion implementation, two
+  transports.
+- **R7 — FIXED**, WI-3.5(c). The `tools/test.sh` addition is now
+  `(cd conformance && env $strip_env go test ./...) || { say "FAIL: conformance
+  go test"; exit 1; }` — the script's own strip list (`tools/test.sh:7`), its
+  own failure reporting (`:14-24`), and a subshell so `go build ./...` still
+  runs from the repo root.
+- **R8 — FIXED**, WI-3.5(c). The loader derives the vectors dir once from
+  `runtime.Caller(0)` + `filepath.Dir`, so it no longer depends on every
+  importing package sitting exactly two levels below the root.
+- **R9 — FIXED**, WI-4.8(c). All 12 `resolveAgentID` call sites enumerated
+  (`check.go:87`, `ack.go:91`, `boot.go:78`, `pending.go:63`, `send.go:127`,
+  `gate.go:80`, `clean.go:80`, `register.go:254`, `self_check.go:118`,
+  `serve.go:145`, `status.go:34`, `identity_cmd.go:24`), with the explicit rule
+  that a signature change updates every caller and §2 rule 3 reads the union.
+  `guard.go:175-189` is called out as a 13th, **inline** resolution that never
+  calls the function.
+- **R10 — FIXED**, WI-3.4(b). Three boot rows, not four, with anchors
+  (`DESIGN.md:2652`, `:2653`, `:2654`); (e)'s seven cases restated as the
+  authority.
+- **R11 — FIXED**, WI-5.3c(d). One paragraph on the third arm: it can
+  false-attribute after OS pid reuse, it fails CLOSED (a refusal, never a kill),
+  and it must not be "fixed" into proceeding.
+- **R12 — FIXED**, PLAN WI-2.2(d)/(f) + DESIGN §6.9 (Sources bullet) + DESIGN
+  §9.1's §5.4 amendment (two properties → three). The clause: both refs are
+  **host-scoped**, changing on a host reboot and nothing else, so a
+  container/VM/service restart on an unrebooted host is unchanged from today and
+  pid reuse is not solved generally.
+- **R13 — FIXED**, WI-3.2(e). The `pool.id` absent/malformed/valid-but-different
+  clause is dropped and the rows are pointed at WI-3.3a(e), which owns the J1
+  validation and the hub arm.
+- **R14 — FIXED in PLAN; one part is out of this round's write scope.** The
+  `E_NOT_REGISTERED` note (WI-1.1) and the `tick-ok.warnings` note (WI-1.7) now
+  cite the amended DESIGN (`:791`/`:2330`, `:756,759,767`) instead of flagging
+  it. PLAN's closing paragraph is replaced by an explicit **"the round-1
+  FLAGGED-not-fixed list is obsolete — do not re-amend"** block naming all six
+  with anchors (verified before deleting: `tick-ok.warnings` at `DESIGN.md:756,
+  759,767`; both not-registered texts + `status.go:62` at `:791`, `:2330`;
+  ControlPath rule at `:559-560`, `:2215-2216`; legacy-shim launcher row at
+  `:2655`; mixed-version parse-vs-persist row at `:2654`; the REDELIVERED-first
+  latch case at `:2661`). **Not done**: the heading inside
+  `plan-reviews-r1.md`'s own revision log — that file is outside this round's
+  authorized writes. PLAN no longer points at it, so nothing binding references
+  it.
+
+**New this round (knock-ons, flagged for reviewers):**
+
+1. **`op.RegisterResp` was too small for M1 to be invisible** (WI-1.6(d)).
+   Forced by R1b and independent of which R1b arm is chosen: `cmdRegister`
+   (`register.go:270,274,276`), `cmdBoot` (`boot.go:104,111,137-142,200`),
+   `selfRepairRegistration` (`self_check.go:79-80`) and `register_test.go`
+   (`:144,344,347,373,376,379`) all read fields that `{Created, AnnouncedTo,
+   Pending}` cannot supply. PLAN adds `Reg RegistrationView`, `InboxDir`,
+   `Refreshed`, `ExistingFound`, `ResolvedHost`, `Warnings`. ~~DESIGN §3.5's
+   Output line is a strict subset and needs the same five fields — flagged,
+   not edited (outside the R5/R12 authorization), together with the §4.4.3
+   question of whether `reg.body` rides in the control line or a trailer.~~
+   **STRUCK in round 4 (T7): both clauses are stale.** DESIGN §3.5's Output
+   line now carries the full set including `Announce *AnnounceView`, §4.4.1
+   shows the `register-ok` frame, and §4.4.3 answers the trailer question —
+   `reg.body` rides as that frame's trailer, never inside the control line.
+   PLAN's own closing block already says so; nothing here is still open.
+2. **`ChannelOpts.Lease`** (WI-1.7(d)) — a local adoption arm mirroring
+   `HeartbeatTemplate`'s two arms, so `refuseLiveRunnerCollision` keeps its
+   signature and the wire structs (`LeaseReq{}` / `LeaseResp{Token}`) are
+   unchanged. `ChannelOpts` is a constructor input, never serialized.
+3. **`note.level`'s `info` arm** (WI-1.1(d), WI-2.1(d)) — DESIGN §4.3's note
+   bullet (`:629-631`) illustrates only `warn`→stderr. R2's fix makes the
+   `info`→stdout arm load-bearing, so the M2 spec copy must spell out both arms
+   and their streams.
+4. **The 64-entry `status` cap applies locally too** (WI-1.4(d)) — a pool with
+   >64 rows would truncate where today it does not. No existing test has >64
+   rows, and capping only on the wire would make local and remote disagree;
+   recorded so it is a decision rather than an accident.
+
+Nothing was rejected.

--- a/proposal/ssh-hub/plan-reviews-r3.md
+++ b/proposal/ssh-hub/plan-reviews-r3.md
@@ -1,0 +1,466 @@
+# Plan review round 3 — PLAN.md @ e13f901b / DESIGN.md @ 34da31bd (2026-08-15)
+
+grok: **SHIP** (round 2). opus-xhigh: **SHIP** — all findings resolved; states it
+can execute its assigned items without asking a question. opus-high: **FIX** (1
+real + 1 nit). codex: **FIX** (4). Both opus lanes and codex independently
+recommend the same treatment for the DESIGN line-number drift (T1 below).
+
+Everything else in the round-3 delta was verified correct by at least two lanes,
+including all three follow-on defects and R1's two extra move-set cases. Do not
+revisit those.
+
+## Blocking
+
+- **T1 (opus-high N1 + codex #1) — the status shape is wrong in two ways, and
+  they interact. Fix them together.**
+  - (a) **Local-mode silent truncation.** The 64-entry cap on
+    `StatusResp.Agents` sits INSIDE the op (PLAN:418-426), and M1 wires the
+    local renderer as op → rebuild map → `printStatus` unchanged
+    (PLAN:459-461). `printStatus` (`status.go:97`, 4 test call sites) renders no
+    truncation notice, so a pool with >64 rows silently drops rows locally — a
+    behavior change inside the merge whose only acceptance criterion is that it
+    has none, and whose release notes say "no behavior change" (WI-1.9(d)).
+    The stated justification (uniformity per §4.4.3) does not hold: §4.4.3 is a
+    FRAMING rule downstream of the 64 KiB line cap, and there is no line in
+    local mode; local/remote already diverge here unavoidably, which is exactly
+    what `truncated:true` admits. **Fix: move the cap one layer out** — the op
+    returns every row and always reports `Truncated:false`; the hub dispatcher
+    applies the 64-entry cap and sets `truncated:true` when writing `status-ok`
+    (WI-3.3a dispatch, shape in WI-3.1a). Sorting stays in the op so truncation
+    stays deterministic. Delete WI-1.4(d)'s "the cap applies in LOCAL mode too"
+    paragraph.
+  - (b) **The row itself is unbounded on the wire.** `StatusAgent.Reg` is the
+    full eight-field `RegistrationView` including `Body` and `WorkingRepos`
+    (PLAN:417-455), DESIGN §4.4.1's "carry/return the §3 request/response
+    structs … verbatim" clause says status returns the seam struct as-is,
+    yet §4.4.3's `register-ok`/`status-ok` body bullet says status rows carry
+    no body — and a body may be
+    1 MiB (`registration.go:18`), which cannot ride a 64 KiB control line.
+    **Fix: define a status-specific row view containing only the fields status
+    actually renders** (check `printStatus` for the real set), and make DESIGN
+    and PLAN agree.
+  - (c) **`StatusResp.Warnings` is unbounded too** — `ReadRegistrationsLenient`
+    appends one error per malformed `*.md` (`registration.go:522-549`), and the
+    64-agent cap does not bound it. **Fix: stream status warnings as `note`
+    frames** (consistent with R2's note routing), or specify an explicit
+    deterministic cap + truncation contract.
+- **T2 (codex #2) — the signature-change inventory omits direct TEST callers.**
+  WI-4.8 (PLAN:1738-1753) claims every `resolveAgentID` caller is in scope, but
+  `internal/cli/identity_test.go:19,25,33,44,55` calls it directly; the
+  specified signature change leaves those five sites uncompilable. **Fix:** add
+  `identity_test.go` + its five call updates to WI-4.8's file list and
+  acceptance (or preserve the old signature behind a cfg-aware helper). **Also
+  widen R1's grep rule**: it currently covers identifiers the move set REMOVES;
+  it must equally cover identifiers whose SIGNATURE changes. Re-run that widened
+  grep across `internal/cli/*_test.go` for every such identifier in the plan and
+  close whatever else it catches.
+- **T3 (codex #3) — `RegisterReq` cannot express boot-only sweep semantics.**
+  The shipped code runs `SweepStaleRegistrations` only in boot, after
+  registration (`boot.go:94-101`), but DESIGN §3.5's **Wraps** bullet and its
+  `Warnings` bullet have the
+  shared register op wrap that sweep and return its warnings, while
+  PLAN:581-605 gives the request no discriminator. Always sweeping changes
+  register/self-check/serve behavior; never sweeping loses remote boot's
+  hub-side trigger. **Fix:** add `Sweep bool` set only by `cmdBoot`, executed
+  hub-side when true, with local AND remote warning propagation covered and no
+  double-sweep.
+- **T4 (codex #4) — remote vendor routing can render an empty vendor on
+  success.** Remote register callers correctly send `Vendor:nil` for hub-side
+  resolution (PLAN:596-600, DESIGN §3.5's `Vendor` bullet — its "Client call
+  sites, normative (S2)" paragraph), but the shipped renderers print
+  from the pre-wire `opts.Vendor` (`register.go:268-270`, `boot.go:134-143`,
+  `self_check.go:76-81`), and WI-4.5 plus the S2 row only assert nil-on-wire and
+  success (PLAN:1568-1617, 2268-2275) — never that callers render from the
+  response. **Fix:** each remote result path renders the resolved vendor from
+  `RegisterResp.Reg.Vendor`; assert text AND JSON output for a bare custom-id
+  `register`, `boot`, and `self-check`.
+
+## Non-blocking
+
+- **T5 (opus-high N2)** WI-1.7(d)'s parenthetical cites `run_test.go:147,164,
+  167,172` for the lease values passed to `RenewLease`/`ReleaseLease`; actual is
+  `:137,:147` (Release), `:163` (Renew), `:166,:174` (Release). Load-bearing
+  anchors in the same item are correct.
+- **T6 (all three lanes agree) — DELETE the `DESIGN.md:NNN` line suffixes; do
+  NOT regenerate them.** Section references are stable and were verified correct
+  throughout; line numbers point into a co-evolving document and are already
+  wrong — opus-xhigh followed three citations in the closing block and each
+  landed in a DIFFERENT section (`:756/:759/:767` → §4.3's version bullet;
+  `:791` → §4.4's header; `:2654-2655` → §9.1's amendment bullet), which reads
+  as support for a claim the target does not make. A wrong anchor is worse than
+  no anchor. Keep CODE anchors with line numbers (frozen at 1244ae4, verified
+  accurate — T5 is the only slip in three rounds). Where a DESIGN line number is
+  currently load-bearing, replace it with the stable row/section NAME (e.g. "the
+  boot_ref survives the heartbeat row", "the mixed-version parse-vs-persist
+  row"), which is greppable.
+- **T7 (opus-xhigh)** `plan-reviews-r2.md`'s "New this round" item 1 still says
+  DESIGN §3.5's Output "is a strict subset … flagged, not edited" — no longer
+  true (DESIGN §3.5's **Output** line carries the full set incl.
+  `Announce *AnnounceView`;
+  §4.4.1 shows the register-ok frame with the trailer; §4.4.3 states the
+  reg.body trailer rule). Strike that clause and the §4.4.3 open question, both
+  answered. PLAN's own closing block already says so correctly.
+
+## Revision log (plan round 4)
+
+Applied to PLAN.md; DESIGN.md touched for T1, T3, T4 (T6 required no DESIGN
+edit — the drifted anchors are all in PLAN). Every code anchor below was
+re-opened at `1244ae4` before it was used. Nothing was rejected; two sub-parts
+went further than the finding asked, both flagged below.
+
+- **T1 — FIXED, all three parts, one coupled change.** PLAN WI-1.4(b)(c)(d)(e),
+  WI-3.1a(d)(e), WI-3.3a(d), WI-4.5; DESIGN §3.5's `RegistrationView` bullet,
+  §3.6's Status bullet, §4.4.1, §4.4.3. Both documents now state the identical
+  shapes.
+  - **(a)** The cap left the op. `StatusResp{Agents, Truncated, Now}` — the op
+    returns every row, sorted by `loop.RegistrationsByAgentID`
+    (`status.go:111 @ 1244ae4`), and always reports `Truncated:false`; the
+    `status-ok` **producer** (WI-3.1a) writes at most 64 rows and is the only
+    writer of `truncated:true`, applied on the WI-3.3a dispatch path.
+    WI-1.4(d)'s "the cap applies in LOCAL mode too" paragraph is deleted and
+    replaced by the argument for its removal. New test rows on both sides: a
+    >64-row pool must render every row locally (WI-1.4(e)); 64-in/65-in
+    framing rows (WI-3.1a(e)).
+  - **(b)** `StatusAgent` is now the status-specific view itself — flat, with
+    no nested `Reg`: `{AgentID, LastSeen, Host, ProtocolVersion, InboxDepth,
+    Status}`, JSON `agent_id`/`last_seen`/`host`/`v`/`inbox_depth`/`status`.
+    The set is `printStatus`'s exact render surface, verified column by column
+    against `internal/cli/status.go:97-139,151-163,242-247 @ 1244ae4` (AGENT,
+    STATUS, INBOX, LAST_SEEN **and** AGE — both from `LastSeen` — HOST, PROTO,
+    plus the `PROTOCOL WARNINGS:` block, which needs only `AgentID` +
+    `ProtocolVersion`). `Vendor`/`ControlRepo`/`WorkingRepos`/`Body` are gone:
+    the header's `vendor:` line is `cfg.Vendor` (`status.go:100`), not a row's.
+    **Beyond the finding:** `Claim *StatusClaim` is cut too. No renderer reads
+    it — `registrationStatusLabel` consumes the claim hub-side
+    (`status.go:152-154`) and the only surviving fact is the `Status` label —
+    and the finding's own criterion is "only the fields status actually
+    renders"; on a row that is pool-visible to every member, that is the same
+    rule that already excludes `ServeClaim.ServeToken` (`lease.go:59`). Cut,
+    with an explicit "re-add it in the merge that ships a renderer for it".
+    `RegistrationView` (still eight fields) moves to WI-1.6(d), its only
+    remaining user, and the four shared JSON tags stay spelled identically.
+  - **(c)** Note frames, not a cap. The lenient-read warnings stream as
+    `NoteEvent{Level:"warn"}`, so `op.Status` gains the emitter parameter
+    `op.Claim`/`op.Pending` already have, and `StatusResp` has no `Warnings`
+    field. Chosen over a cap-and-truncate contract because the list is
+    genuinely unbounded and NOT bounded by the pool-scale assumption — it is
+    one error per malformed `*.md` under the agents dir
+    (`registration.go:522-549 @ 1244ae4`), and a malformed file is not a
+    registration — which is precisely §4.4.3's "unbounded lists never ride
+    inside one control frame"; because the pinned `warn`→stderr routing
+    already renders exactly today's `warning: %s` (`status.go:67-70`); and
+    because a note necessarily precedes the terminal frame, so the warnings
+    keep their position AHEAD of the table by construction, in both modes. A
+    cap would have needed a second truncation flag and would have restored the
+    silent-corrupt-row failure R4 opened.
+- **T2 — FIXED**, WI-4.8(c)/(f) + the M1 preamble's move-set rule.
+  `identity_test.go` is named in the file list with its five call sites
+  (`:19`, `:25`, `:33`, `:44`, `:55`), plus the constraint those sites impose:
+  a nil/pool-less cfg must resolve the candidate verbatim, so the traversal,
+  flag-beats-env, env-fallback and `missingAgentIdentityHint` assertions keep
+  their exact texts. The cfg-aware-helper alternative is rejected in-line: it
+  leaves two spellings of the identity choke point this item exists to unify.
+  The **rule itself is widened** to two populations — identifiers an item
+  REMOVES from `cli`, and identifiers it RE-SIGNATURES — and unscoped from M1
+  to every merge, which is where round 3's version failed: `resolveAgentID`
+  changes signature in M4, a merge the M1-only rule never reached. M1's own
+  exception table stays closed at three files / three hunks.
+  **Re-ran the widened grep** over `internal/cli/*_test.go` at `1244ae4` for
+  every identifier the plan moves or re-signatures (`evaluateGate`,
+  `finishGateClear`, `gateStatus`, `archiveAllClaimed`, `performRegister`,
+  `publishRegistrationOnce`, `registrationLiveElsewhere`, `hasPendingInboxMail`,
+  `sendTsMessageWithCommit`, `displayConsumed`, `printStatus`,
+  `registrationStatusLabel`, `countInbox`, `refuseLiveRunnerCollision`,
+  `resolveAgentID`, `resolveAgentIDRaw`, `resolveAgentVendor`,
+  `readRegistrations`, `selfRepairRegistration`, `registerOpts`,
+  `registerResult`, `cleanOwedResult`, `regTemplate`, `lastSweep`,
+  `heartbeatTemplate`). It closes with **no sixth case**: `resolveAgentID`'s
+  five sites are the only new code hits. `publishRegistrationOnce`
+  (`clean_test.go:476`), `hasPendingInboxMail` (`run_test.go:595,845`),
+  `displayConsumed` (`check_age_owed_test.go:241`), `performRegister`
+  (`hooks_sessionstart_test.go:11`, `turn_end_test.go:512`,
+  `register_test.go:32,52`) and `resolveAgentVendor`
+  (`turn_end_test.go:507,511,538`) are comment-only; `heartbeatTemplate`
+  (`run_test.go:505`) sits inside the already-named `newPollTestRuntime` hunk;
+  `evaluateGate`, `finishGateClear`, `archiveAllClaimed`,
+  `registrationLiveElsewhere`, `registrationStatusLabel`, `countInbox`,
+  `resolveAgentIDRaw`, `registerResult`, `selfRepairRegistration` and
+  `readRegistrations` have zero hits. One knock-on recorded from this sweep:
+  `readRegistrations` (`status.go:84-95`) is the one identifier WI-1.4 removes
+  that its (c) never named — now named, with its clean grep stated.
+- **T3 — FIXED**, PLAN WI-1.6(d)/(e) + WI-4.5 + WI-5.7(e); DESIGN §3.5's
+  `Sweep` bullet, its **Wraps** bullet, its `Warnings` bullet, and §10.3's
+  register-field-semantics row. `RegisterReq` gains `Sweep bool`.
+  **Verified against the shipped boot path first**: `cmdBoot` calls
+  `performRegister` (`boot.go:89 @ 1244ae4`) and only then
+  `loop.SweepStaleRegistrations(cfg, agentID, now)` (`boot.go:99-101`) — C11's
+  register-self-first-then-sweep order — appending
+  `sweep stale registrations: %v` to `result.Warnings` on failure and never
+  failing boot. The only other production caller is the runner's throttled
+  tick (`serve.go:640`), which is `op.Tick`'s and untouched. So: `Sweep:true`
+  from `cmdBoot` alone, executed hub-side AFTER the write, warning text
+  pinned verbatim (no `agentchute serve: ` prefix — that one belongs to the
+  tick). **Local arm**: `Sweep:false`, `cmdBoot` keeps its own call, M1's
+  adapter cannot even express `true` (`registerOpts` has no such field), so
+  M1 has no `true` caller and nothing local changes. **Remote arm** (WI-4.5):
+  `Sweep:true` **and** the local call is skipped — it would otherwise sweep
+  the mail-free shadow while the hub's pool went unswept. **No double-sweep**
+  anywhere: the channel's startup `register` sends `false` because that lane's
+  first tick sweeps immediately; `register`/`self-check`/`turn-end` send
+  `false` in both modes. Test rows assert the hub row is gone, the shadow row
+  is untouched (which is what proves "skipped", not merely "duplicated"), and
+  the failure warning renders.
+- **T4 — FIXED**, PLAN WI-4.5 (new "renders the RESOLVED vendor" block + two
+  test rows), WI-5.7(e), DESIGN §10.3's S2 row. All three renderers switch
+  from the pre-wire `opts.Vendor` to `result.Reg.Vendor`: `cmdRegister`
+  (`register.go:269 @ 1244ae4`), `cmdBoot` (`boot.go:136`, which feeds
+  `bootStatus.Vendor` and therefore all four boot emitters) and `cmdSelfCheck`
+  (`self_check.go:78`). Stated as ONE path, not a mode branch, because the two
+  values are provably equal locally: `publishRegistrationOnce` sets
+  `Vendor: opts.Vendor` unconditionally (`register.go:133`) and the merge arm
+  touches only `WorkingRepos` and `Body` (`register.go:140-149`) — so no local
+  test output moves. Output assertions are now required and are specific about
+  what exists: `register` is **text-only** (it has no `--json` flag,
+  `register.go:198-211`), while `boot` and `self-check` assert **text AND
+  `--json`** (`"vendor":"<resolved>"`), each byte-identical to the same pool
+  driven locally.
+- **T5 — FIXED**, WI-1.7(d). The anchors are now `loop.ReleaseLease` at
+  `run_test.go:147`, `loop.RenewLease` at `:163`, `loop.ReleaseLease` at
+  `:166` and `:174`. One refinement on the finding itself: its fifth anchor,
+  `:137`, releases a lease `refuseLiveRunnerCollision` never returned — it is
+  `loop.AcquireServeLease`'s own from `:126` — so it is cited as such rather
+  than folded into the helper's four.
+- **T6 — FIXED**, seven `DESIGN.md:NNN` citations removed from PLAN.md,
+  swept one at a time with each target re-opened, none regenerated. Section
+  refs (`§x.y`) and CODE anchors keep their line numbers. Where the number was
+  load-bearing it became a stable NAME: the `E_NOT_REGISTERED` registry row +
+  §7.5 catalog entry (WI-1.1); §4.4.1's `tick-ok` example + its "always
+  present" paragraph (WI-1.7); §4.3's "Hub→client `note` frames" bullet
+  (WI-1.1); §10.3's three boot rows by title, `hub-reboot pid reuse` /
+  `clock step does not steal a live lease` / `` `boot_ref` survives the
+  heartbeat `` (WI-3.4, §7); §10.3's `register field semantics (C2/D1)` row
+  (WI-4.5); and §7's obsolete-list block, now a six-row table of names
+  (`ControlPath length rule` → §4.2's normative block + §8 row 25 + its §10.3
+  row; the legacy-shim launcher → §6.8 rule 5 + `launcher preserves
+  remoteness`; mixed-version parse-vs-persist → the second half of the
+  `boot_ref` row; the three latch sites → §3.2's E1 bullet + §6.6 + `mid-stream
+  disconnect arms the latch (E1)`). The five `DESIGN:NNN` refs inside this
+  file's own findings were converted the same way, each verified first. Two
+  replacements re-read to confirm they land where the sentence claims: §4.3's
+  note bullet does carry the routing rule (it now carries BOTH arms, see the
+  knock-on below), and §4.4.2's `E_NOT_REGISTERED` row does name all three CLI
+  sites including `status.go:62`. **PLAN now contains zero `DESIGN.md:NNN`
+  suffixes** (`grep -E 'DESIGN[^ ]*\.md:[0-9]|DESIGN:[0-9]'` → no match).
+- **T7 — FIXED**, `plan-reviews-r2.md` "New this round" item 1. Both clauses
+  are struck (struck through, not deleted, so the record still reads as a
+  record) with the reason: DESIGN §3.5's Output line now carries the full set
+  including `Announce *AnnounceView`, §4.4.1 shows the `register-ok` frame,
+  and §4.4.3 answers the `reg.body` question — trailer, never the control
+  line.
+
+**Knock-ons this revision had to fix, and two flags for the reviewers:**
+
+1. **`RegistrationView` was homeless** once T1b took it off the status row —
+   WI-1.6 pointed at "WI-1.4's `RegistrationView`". Its definition (eight
+   fields, frontmatter tags, the no-JSON-tags rationale) moved into WI-1.6(d),
+   its only remaining user; WI-1.4 now points forward to it for the four tag
+   names `StatusAgent` shares. Side effect worth noting: WI-1.6 no longer
+   depends on a type WI-1.4 declares.
+2. **A stale claim about DESIGN §4.3's note bullet.** WI-1.1(d) and WI-2.1(d)
+   both said the bullet "illustrates only the `warn` arm". DESIGN has since
+   been amended — it carries both example frames, the "the level IS the
+   stream" rule, and the three `check` `info` lines — so both sentences were
+   corrected while T6 was rewriting that citation. Round 3's knock-on note 3
+   in `plan-reviews-r2.md` is the stale source; PLAN no longer repeats it.
+3. **FLAG — `plan-reviews-r2.md`'s knock-on item 4 is now superseded** ("The
+   64-entry `status` cap applies locally too"). T1a reverses exactly that
+   decision. This round's write scope for that file was T7 only, so it is left
+   standing and recorded here instead; the binding text is PLAN WI-1.4(d),
+   which now says the opposite and says why.
+4. **FLAG — the same stale lease anchors T5 corrects also appear in
+   `plan-reviews-r2.md`'s R1 revision-log entry** (`:147,164,167,172`). Same
+   scope limit, same treatment: PLAN is corrected, the record is not.
+
+## Revision log (plan round 5)
+
+Four findings, all applied; nothing rejected. R5-1/R5-2 were the round-5
+review proper; R5-3/R5-4 are the two narrow follow-ups from the fourth
+reviewer lane against the revised text. Every code anchor below was
+re-opened at `1244ae4` before it was used. PLAN.md and DESIGN.md state the
+identical `status-ok` rule, the identical fixture rule, and the identical
+output literals (the seam structs are the wire schema, so a divergence would
+be a real defect).
+
+- **R5-1 (the blocker) — a 64-ROW cap does not bound a 64 KiB LINE. FIXED**,
+  as specified: the producer now enforces BOTH limits against the **encoded**
+  response. DESIGN §3.6's Status bullet, §4.4.1's exception 2, §4.4.3's
+  `register-ok`/`status-ok` body bullet and its `status-ok` bullet, §4.4.3's
+  closing normative bullet, §10.2; PLAN WI-1.4(d)(e), WI-3.1a(d)(e),
+  WI-3.3a(d), WI-4.5.
+  - **The rule.** Rows are appended from the op's sorted slice **in order**,
+    kept only while (1) the complete encoded control line stays ≤ 64 KiB and
+    (2) the kept-row count stays ≤ 64. The first row failing either check ends
+    the append — prefix semantics, never skip-and-continue, which would omit a
+    middle row while showing later ones with no way to say which.
+    `"truncated":true` is written whenever **either** budget excluded a row; it
+    is no longer a row-cap flag.
+  - **Non-row fields COUNT against the byte budget** — decided and stated in
+    both documents. The budget is measured over the whole line: `t`, `re`,
+    `now`, `truncated`, the `agents` array's punctuation, and the terminating
+    LF. A rows-only budget would balance its own books and still emit an
+    over-cap line, which is the exact defect the rule exists to close; the
+    cost is one integer. Corollary pinned so the implementer needs no second
+    pass: measure with `"truncated":false` encoded — `true` is one byte
+    shorter, so a frame that fit before the flip still fits after it.
+  - **Degenerate case pinned**: if the FIRST row alone does not fit,
+    `agents:[]` with `truncated:true`. A valid response, not an error —
+    `status` is read-only and pool-wide, and refusing the listing over one
+    pathological row would lose every other agent's row.
+  - **The false claim is corrected.** DESIGN §4.4.3 said the status row "holds
+    six fields, none of them free-form". `Host` is free-form and
+    length-unbounded: `ReadRegistration` copies frontmatter `host` through
+    verbatim under only the 1 MiB whole-file cap
+    (`internal/loop/registration.go:72,88 @ 1244ae4`), `Registration.Validate`
+    imposes no length bound (`registration.go:217-241 @ 1244ae4`), and
+    `register --host` is an unconstrained string flag
+    (`internal/cli/register.go:206 @ 1244ae4`). The bullet now says dropping
+    `Body` removes the 1 MiB field but does **not** make the row a bounded
+    shape. **Beyond the finding**: `AgentID` is length-unbounded too
+    (`agentIDPattern = [a-z0-9][a-z0-9-]*`, `internal/loop/inbox.go:40 @
+    1244ae4`) — only the filesystem's `NAME_MAX` on `<id>.md` bounds it — so
+    the rule is written as "depend on NO field being bounded" rather than
+    "bound `Host`".
+  - **Streaming rejected, with the justification the finding asked for.** The
+    budget preserves the required behavior: status is a display table with a
+    truncation notice, no per-row delivery guarantee exists, and the only row
+    the byte budget drops that the row cap would not is one that cannot be
+    rendered into a table cell anyway (a 70 KiB HOST column). Streaming would
+    add a frame type, a second terminal-count contract, and a renderer that
+    must buffer the whole listing regardless to compute tabwriter column
+    widths — so unlike `msg`/`owed-item` it buys no memory bound here. Recorded
+    in DESIGN §4.4.3 as a rejected alternative, together with the real root
+    fix (a length bound on `host` at the registration layer), which is
+    shipped-code scope, deliberately out of this proposal, and which the hub
+    must not depend on landing.
+  - **Test rows added.** WI-3.1a(e) / DESIGN §10.2: the row cap (64 in ⇒ 64
+    out `truncated:false`; 65 in ⇒ first 64 `truncated:true`); **one valid
+    registration whose `host` alone exceeds 64 KiB in a THREE-row pool** ⇒ that
+    row excluded, `truncated:true`, emitted line ≤ 64 KiB measured whole
+    (fails a rows-only producer); the same oversized row placed FIRST ⇒
+    `agents:[]` and every later row dropped, placed LAST ⇒ earlier rows survive
+    (fails a skip-and-continue producer); a byte-exact boundary pair asserted
+    on the ENCODED length including the LF; and a flag-flip row proving the
+    measure-with-`false` rule needs no second pass. WI-1.4(e) gains the LOCAL
+    mirror: the same 64 KiB-`host` registration must come back from `op.Status`
+    intact with `Truncated:false` and must still print locally — the budget is
+    framing-only and must not leak into the op.
+  - **Notice text.** WI-4.5's trailing truncation line now names the WIRE limit
+    as well as the row cap: on a three-agent pool the binding budget is the
+    line, and a notice saying only "64 rows" would state something visibly
+    false. It deliberately states no total — `status-ok` carries only the kept
+    rows plus the flag, and a `total` field is a shape change no finding asked
+    for. (Its exact bytes were pinned in the R5-3 follow-up below.)
+- **R5-2 (non-blocking) — the status HEADER is local config, not row data.
+  FIXED by deciding it**, at the item that owns the renderer switch: **PLAN
+  WI-4.5** (new "The status HEADER is a decision this item owns" block, a test
+  row in (e), and a clause in (f)), mirrored in DESIGN §3.6's Status bullet as
+  a new header sub-bullet, plus a §10.3 row. Verified first that the header
+  really is config-sourced (`internal/cli/status.go:98-100 @ 1244ae4`).
+  **Decision: a remote lane prints the HUB's pointer, with the shadow marked
+  rather than hidden.**
+  - `control_repo:` ⇒ the canonical `ssh://` URL from `cfg.Remote`, never
+    `cfg.ControlRepo`, which under §6.8 rule 2 is only the nearest local
+    ancestor holding `AGENTCHUTE.md`. The rows below are the hub's; a header
+    naming a local directory holding none of them is §6.8 rule 5's failure one
+    command later. `formatOriginSuffix` (`status.go:210-215`) is kept and stays
+    truthful.
+  - `loop_dir:` ⇒ the local shadow, plus one parenthetical marker line in the
+    style of the existing `  (shadowed pointer: %s)` line
+    (`status.go:101-103`). It genuinely is this process's loop dir (guard
+    latch, `runner.json`, send spool), and the hub's loop dir is on another
+    filesystem and rides on **no** frame — `hello-ok` carries `pool`, a pool
+    path, not a loop dir — so printing it would mean a new wire field for a
+    path the operator cannot open. The defect is the shadow printed UNMARKED;
+    the marker is the whole fix.
+  - `vendor:` ⇒ unchanged, and it needs no branch: `cfg.Vendor` is the loop
+    dotdir namespace, vendor namespacing is gone (`fixedNamespace`,
+    `internal/loop/config.go:19-25,348-357 @ 1244ae4`), and §6.8 rule 3
+    deliberately gives the shadow the same `.agentchute/loop` shape — so both
+    modes print the same string. Explicitly do NOT retarget it at the actor's
+    registered vendor: `StatusAgent` has no `Vendor` (T1b cut it) and re-adding
+    one to feed a header line reopens a settled shape.
+  - `ShadowedPointers` ⇒ unchanged; a local-pointer diagnostic in both modes.
+  - No new wire field and no signature change: the branch keys on
+    `cfg.Remote != nil`, already in hand via the renderer's own `cfg`.
+  - **Test row** (WI-4.5(e), §10.3): a three-agent hub pool with the client
+    clock skewed and an empty shadow — STATUS/INBOX/AGE come from the response
+    byte-identically to a pinned-clock local run; `control_repo:` is the
+    `ssh://` URL with its `(via …)` suffix; `loop_dir:` is the shadow WITH its
+    marker; `vendor:` matches the local run; warnings land on stderr ahead of
+    the table. Then plant the 64 KiB-`host` row and re-run: the other two
+    agents still render and the notice names the wire limit — a notice naming
+    only "64 rows" fails the row on a three-agent pool. (The row now pins
+    WHERE that planted row sorts, and asserts both output lines byte-exact —
+    R5-3/R5-4 below.)
+- **R5-3 — the integration fixture contradicted PREFIX semantics. FIXED by
+  making it deterministic.** The row said a three-agent pool with one
+  64 KiB-`host` agent leaves "the other two agents still render", which holds
+  only if the oversized row sorts LAST: the producer stops at the FIRST row
+  that fails either budget and drops every row behind it, and the dedicated
+  producer-level row asserts exactly that (oversized row FIRST ⇒ `agents:[]`,
+  both later rows dropped). **Decision: pin the fixture, not the
+  expectation** — the oversized `host` belongs to the lexicographically LAST
+  of the three agent ids (`alpha` / `bravo` / `zulu`, huge host on `zulu`).
+  Weakening the expectation to "only the rows preceding it render" would have
+  been true but would have left the more valuable assertion (that a
+  pathological row costs the operator nothing but its own row) untested, and
+  the producer suite already covers the first-row case. Applied identically in
+  PLAN WI-4.5(e) and WI-5.7(e), and DESIGN §10.3's `remote status renders the
+  HUB` row. The §10.2 / WI-3.1a(e) producer rows already stated FIRST and LAST
+  explicitly and needed no change.
+- **R5-4 — two new user-visible lines had no literal. FIXED by pinning both
+  in BOTH documents**, with the test rows now asserting the bytes. Each was
+  modelled on shipped output re-opened at `1244ae4`, not invented:
+  - **Truncation notice** — PLAN WI-4.5(d), DESIGN §4.4.3 (with a pointer from
+    §3.6):
+
+    `note: listing truncated by the hub at the first row that would exceed 64 rows or a 64 KiB response; later agent ids are missing.`
+
+    One unindented stdout line, emitted only when `truncated` is true, LAST in
+    the output (after the table and any `PROTOCOL WARNINGS:` block), preceded
+    by one blank line. Modelled on `internal/cli/check.go:262 @ 1244ae4`
+    (lowercase `note: ` prefix, no indent, one sentence, semicolon before the
+    consequence). It names both budgets, says rows were withheld, states the
+    prefix rule, and still states no total.
+  - **`loop_dir:` shadow marker** — PLAN WI-4.5(d), DESIGN §3.6:
+    `  (local shadow: this process's own loop dir, not the hub's)`, two
+    leading spaces, printed immediately under `loop_dir:` and ahead of
+    `vendor:`, only when `cfg.Remote != nil`. Modelled on the marker already
+    in that header block, `  (shadowed pointer: %s)`
+    (`internal/cli/status.go:101-103 @ 1244ae4`), for indent and parenthesised
+    `label: value` form, and on `  (pull-only: senders deliver to your inbox;
+    you poll it yourself)` (`internal/cli/boot.go:204 @ 1244ae4`) for a label
+    followed by prose rather than by a path.
+
+**Noticed, not changed (for the reviewers):**
+
+1. **`host` has no length bound in shipped code** — `Registration.Validate`
+   (`registration.go:217-241 @ 1244ae4`) bounds `agent_id` (charset only),
+   `vendor`, `control_repo`, `working_repos` and `last_seen`, and says nothing
+   about `host`; `register --host` is a free string. That is the root cause of
+   R5-1, and it is shipped-code scope, outside this proposal's write scope. The
+   hub's rule is written so it does not depend on that ever being fixed.
+2. **`status-ok` carries no total**, so a truncated remote listing cannot say
+   "showing N of M". Deliberate (no finding asked for the field); recorded here
+   because it is the visible cost of the chosen notice text.
+3. **`status`'s local table has no truncation notice at all**, by design (T1a):
+   local mode never truncates. If a later merge ever adds a local cap, that
+   notice becomes a prerequisite, not a follow-up.
+4. **The producer-level "wire budget, the row the row-cap misses" row
+   (WI-3.1a(e) / §10.2) still does not pin its oversized row's sort
+   position**, and was deliberately left alone: unlike the integration
+   fixture, every assertion it makes (that row excluded, `truncated:true`,
+   emitted line ≤ 64 KiB measured whole) holds in every position, and the two
+   rows beside it pin FIRST and LAST explicitly. An implementer who wants one
+   less degree of freedom may reuse R5-3's `alpha`/`bravo`/`zulu` fixture
+   there too.

--- a/proposal/ssh-hub/reviews-external-r1.md
+++ b/proposal/ssh-hub/reviews-external-r1.md
@@ -1,0 +1,237 @@
+# External review round 1 — DESIGN.md @ sha256 f858d5dc… (2026-08-14)
+
+Both reviewers verified the freeze hashes and returned **FIX**. Both endorse
+the architecture (one hub, seam, forced-command pinning, no-auto-replay,
+channel/one-shot split) and explicitly warn against shrinking the code back
+toward a naive one-shot. Reviser: address every finding, log dispositions in
+the Revision log at the end.
+
+## codex (deep backstop, code-verified at HEAD 1244ae4). Verdict: FIX
+
+- **C1 (BLOCKER) §3/§5.3 — actor-free wire has no actor-bearing operation
+  API.** Ops (`check`/`ack`/`gate`/`pending`/`register`/`clean-owed`/`send`)
+  must be actor-scoped, but the sole seam signature is
+  `(*loop.Config, Request)` and requests carry no actor; `loop.Config` has
+  no identity (config.go:34-53; identity.go:13-38). "Hub passes its pinned
+  id into every call" is unimplementable without smuggling identity through
+  config/global state. Fix: explicit non-wire `op.Context{ActorID string}`
+  in every actor-scoped op signature; local CLI builds it from
+  `resolveAgentID`, hub session from the forced-command id; actor stays
+  absent from wire structs; test all actor-scoped ops through both callers.
+- **C2 (BLOCKER) §3.5/§6.6 — RegisterReq cannot preserve registration or
+  guarded lifecycle semantics.** (A) child one-shot `self-check`/`turn-end`
+  under a live channel lease: refresh requires ServeToken == claim
+  (register.go:118-149); RegisterReq has no token → "live elsewhere".
+  (B) current register distinguishes absent vs explicitly-empty
+  `--bio`/`--host`; wire omits Bio/BioProvided/HostProvided.
+  (C) remote turn-end spec omits current best-effort step-0 self-repair
+  (turn_end.go:15-39,83-90). Fix: add serve_token + bio + field-presence
+  (pointers or booleans) to the register wire contract; channel dispatch
+  injects its held token, one-shots send the inherited token; spec remote
+  turn-end step 0 as best-effort wire register continuing on failure; add
+  live-lease self-check/turn-end tests.
+- **C3 (BLOCKER) §7.4 — path-only E_SELF_POINTER rejects valid remote
+  joins.** Laptop and hub sharing the same absolute pool path (same
+  username/layout is common) → discovery refuses a genuinely remote URL.
+  Fix: require proof the URL HOST is the local host before refusing (host
+  identity + path), or drop discovery-time refusal for a non-mutating hello
+  identity check; test identical-paths-two-hosts and true-self-URL.
+- **C4 (MAJOR) §4.4.3 — streaming fixed the frames, not the producer.** The
+  seam still materializes unbounded slices (`ClaimResp.Items` with every
+  4 MiB body; check --limit 0) before the dispatcher can stream → N×4 MiB
+  hub buffering, OOM risk; Ack/Pending same shape. Fix: producer APIs
+  (emitter/callback/iterator + terminal counts), single codec writer
+  consuming incrementally; tests: many max-size messages; connection failure
+  after first emitted item.
+- **C5 (MAJOR) §5.1/§7.2 — shell-argument encoding is not general.**
+  Rejecting only `"`\newline doesn't protect spaces, `$()`, backticks,
+  `;`, `'` in binary/pool paths (login shell runs `command="…"`); the
+  auto-authorize "values are '-free" claim isn't guaranteed by the URL
+  grammar. Fix: one tested shell-word encoder for every forced-command and
+  interactive-ssh argument + separate authorized_keys-option-layer escaping;
+  OR pin an opaque binding id in authorized_keys with the validated
+  agent/pool mapping in a 0600 file. Test the full metacharacter set.
+- **C6 (MAJOR) §9/§11 — release ordering publishes a false capability.**
+  PR-0 (spec: "hub is a supported transport") lands before PR-1 (seam) tags
+  v1.6.0 → v1.6.0 ships hub spec with no hub. Fix: release seam-only v1.6.0
+  BEFORE PR-0, or tag nothing between PR-0 and complete v1.7.0.
+- **C7 (MAJOR) §9 — PR-0's spec delta isn't normative enough; conformance
+  gates late.** The AGENTCHUTE.md amendment list has no normative frame
+  schema, ordering, no-replay rule, disconnect-after-claim rule, remote
+  turn-end, timeout/size limits, or version policy — they live only in this
+  proposal, violating spec-is-source-of-truth; and §9.3's L/W vectors sit in
+  PR-8 AFTER v1.7.0 ships. Fix: PR-0 adds a normative hub-wire/lifecycle
+  section (or normative doc incorporated by reference); move L/W vectors
+  into PR-2/PR-3/PR-7 so they gate v1.7.0.
+- **C8 (MINOR) §6.9 — boot-corroboration ordering ambiguous.** Fresh
+  LastSeen refusal happens BEFORE the pid-proof (lease.go:205-244); a
+  pre-boot claim with fresh LastSeen still holds → contradicts "immediately
+  reclaimable". Fix: state+test the ordering (StartedAt<boot under lock
+  before freshness refusal, or keep the 10 s floor and delete "immediately"
+  everywhere); make the fixture's LastSeen explicitly fresh.
+- **C9 (MINOR) §6.7 — `--relaunch-args "<string>"` has no argv grammar.**
+  Fix: repeatable `--relaunch-arg` or a `--` argv tail; store []string; no
+  reparsing; argv-exact tests. (Interacts with grok m3: cut from v1.)
+- **C10 (MINOR) §6.1 — local-startup claim reversed.** Local runWrapper
+  acquires lease, starts wrapper, THEN registers (serve.go:363-400); the
+  design claims register-before-child as a mirror. Fix: state remote
+  register-before-child as a deliberate strengthening, not parity; don't
+  derive PR-1 zero-behavior tests from the wrong order.
+- Verified sound at this revision: spool placement vs rejectLoopStateBodyFile;
+  no-auto-replay; relaunch fences+stops old child fully before fresh child;
+  child env exports ssh URL / strips LOOP_DIR; filename-derived sender
+  identity canonical.
+
+## grok (outside view, simplicity+ops; walked both personas). Verdict: FIX
+
+- **G-B1 (BLOCKER) §7.2/§7.4 — re-join not specified idempotent.** Bare
+  re-run (which §7.3 recommends!) re-runs ssh-keygen → new key → duplicate-id
+  refusal or --replace-key evicts the live key. Happy-path self-lockout.
+  Fix: normative key reuse if `keys/<id>` exists; rotation only via explicit
+  `--rotate-key` (drives --replace-key); test join-twice → same pubkey, one
+  authorized_keys line.
+- **G-B2 (BLOCKER) §1/§7.2 — ssh-keygen argv unspecified.** Default prompts
+  for a passphrase → join hangs or a passphrase key kills every BatchMode op
+  as E_UNAUTHORIZED. Fix: exact argv `ssh-keygen -q -t ed25519 -N "" -f
+  <hubdir>/keys/<id>_ed25519 -C agentchute:<id>`; refuse passphrase-protected
+  keys (BatchMode probe).
+- **G-B3 (BLOCKER) §7.2+§6.7 — relaunch is opt-in; written next step is
+  still `ac serve codex`.** Daily lid-close = dead lane unless the user was
+  watching a TTY prompt. Fix: remote serve (Remote != nil) defaults relaunch
+  ON, `--relaunch=false` to opt out; §7.2 shows the default path.
+- **G-M1 (MAJOR) §5.1 — `--pool <path>` unquoted in command="…"** — space
+  in path splits argv. Fix: reject whitespace in pool/binary paths (extend
+  E_POOL_PATH_UNQUOTABLE) or quote; prefer reject. (Codex C5 generalizes
+  this — solve together.)
+- **G-M2 (MAJOR) §5.2 — `agentchute:<id>` marker global per hub user, not
+  per pool.** Two control repos on one hub account break authorize/--list/
+  --revoke. Fix: marker `agentchute:<id>:<canonical-pool>` (or hub-id);
+  duplicate-id keyed on (id, pool). Cheap now, expensive migration later.
+- **G-M3 (MAJOR) §7.5/§12.1 — offline laptop stalls 5 s per hook
+  invocation, several per turn.** Fix: 30 s negative cache in the shadow dir
+  (last E_CONNECT at T → skip dial until T+30 s, same warn-and-exit-0);
+  do NOT build the deferred pending cache.
+- **G-M4 (MAJOR) §9 — enrollment surface missing.** AGENTS.md/enrollment
+  templates must cover: remoteness is discovered; never replay
+  E_SEND_UNKNOWN; doctor after join.
+- **G-M5 (MAJOR) §7.2 — join never proves the hub session can WRITE the
+  pool.** Auto-authorize can succeed against another user's repo / 700
+  perms; first send is E_HUB_IO. Fix: post-auth probe checks Writable
+  (fold into hello-ok per G-m2), join fails naming hub-user/pool-path/perms.
+- **G-m1** Cut `poll` op — inject re-check always falls back to last-tick
+  counts. **G-m2** Cut `ping` op — fold Writable into hello-ok. **G-m3**
+  Cut `--relaunch-args`/RelaunchArgs from v1 (ships empty everywhere; see
+  C9). **G-m4** §7.7 "one paste per machine" stale vs zero-paste flow.
+  **G-m5** Catalog gaps: laptop ssh binary missing; authorized_keys not
+  0600 (sshd silently ignores); E_CHANNEL_LOST must echo the real
+  invocation, not hard-code `ac serve codex`. **G-m6** §7.2 next-command
+  must be runnable in the CURRENT shell (`agentchute serve …`). **G-m7**
+  Collapse the 10-PR plan to ~6 merges (2+3, 5+6, 9 with 7) — process
+  weight only, do not shrink code.
+- Keep (explicit): seam PR, channel/one-shot split, pinning, no-auto-replay,
+  §6.9 boot-proof, probe-before-pointer, shadow/no-LOOP_DIR contract, sshd
+  matrix. Hub-operator prereqs (sshd, Remote Login, stable binary path) as a
+  3-line first-time block; no `hub locate` in v1.
+
+## Revision log (round 2)
+
+- **C1** FIXED §3 conventions (new "Actor context" rule: every actor-scoped
+  op is `(*loop.Config, op.Context{ActorID}, Request)`; non-wire; CLI builds
+  it from `resolveAgentID`, hub session from the pinned `--agent`), §3.1,
+  §5.3, §4.4.1 note; both-constructor tests in §10.1.
+- **C2** FIXED §3.5 (RegisterReq gains `ServeToken` + pointer-typed
+  `Host`/`Bio` for field presence — verified against
+  `register.go:35-44,80-87,126-128,147-149,189-195,226-233`; channel injects
+  its held token, one-shots the inherited env token), §6.1 step 3, §6.6
+  (remote turn-end step 0 = best-effort wire register continuing on failure,
+  mirroring `turn_end.go:15-39,110-120`), §10.3 live-lease + field-presence
+  test rows.
+- **C3** FIXED §7.4: path-only refusal replaced by **join-state** refusal —
+  `E_SELF_POINTER` deleted; `E_NOT_JOINED` fires only when the per-hub
+  `config.json` is absent (pure local, offline-safe, guard unaffected since
+  an unjoined machine has no serve session); same-abs-path-two-hosts is
+  valid and tested; §7.5 text rewritten; §10.3 row.
+- **C4** FIXED §3 conventions + §3.2/§3.3/§3.6: `Claim`/`Ack`/`Pending` are
+  emitter-based streaming producers (summary-only returns); dispatcher's
+  emit writes each frame through the single codec writer (peak hub buffering
+  = one ≤4 MiB body); §4.4.3 producer rules tied to the seam; tests in
+  §10.1/§10.2 (max-size fleet, failure-after-first-item).
+- **C5+G-M1** FIXED §5.1 (one decision): **reject, never encode** — pool and
+  binary paths must match `^[A-Za-z0-9._/+-]+$` (whitespace and all shell
+  metachars refused via `E_POOL_PATH_UNSAFE`); every other value grammar-
+  validated; the pubkey is the sole single-quoted element, inert by charset.
+  The opaque-binding-id alternative was considered and DECLINED: it
+  reintroduces a second mapping store that can drift from the key line, for
+  a benefit (paths with spaces) the refusal already remediates. Full
+  metacharacter refusal matrix in §10.3.
+- **C6** FIXED §9 intro + §11: decision = **seam-only v1.6.0 tags BEFORE the
+  spec merge**; no tag between M2 and complete v1.7.0 — the spec never
+  describes a capability no release has.
+- **C7** FIXED §9.1 (M2 adds a normative "Hub wire & lifecycle" spec
+  section: frame grammar, limits, ordering, no-replay,
+  disconnect-after-claim, remote turn-end, timeouts, version policy,
+  pinning; spec-wins supremacy) + §9.3/§11 (L + fake-transport W vectors in
+  M3, sshd-backed W in M6 — all gating v1.7.0, never after it).
+- **C8** FIXED §6.9 (ordering stated exactly: freshness refusal at
+  `lease.go:230-232` precedes the pid branch at `lease.go:242-244`,
+  unchanged; boot corroboration lives inside branch (d) only), "immediately/
+  at once reclaimable" deleted in §6.7/§8 row 23; §10.3 fixture now stale-
+  LastSeen explicit plus a fresh-LastSeen still-held case.
+- **C9+G-m3** FIXED — `--relaunch-args` and `RelaunchArgs` cut from v1
+  entirely (§6.7, §7.3): relaunch reuses the original argv `[]string`
+  verbatim, no reparsing; a repeatable `--relaunch-arg` is named as the
+  future shape if ever wanted.
+- **C10** FIXED §6.1 step 3: local order is lease → child → register
+  (`serve.go:374,384,393`); remote register-before-child stated as a
+  deliberate strengthening, not parity; §10.1 pins the LOCAL order
+  unchanged.
+- **G-B1** FIXED §7.2/§7.3: key reuse is normative on re-join (existing
+  `keys/<id>` never regenerated); rotation only via explicit
+  `hub join --rotate-key` (drives `--replace-key`); join-twice test in
+  §10.3.
+- **G-B2** FIXED §7.2: exact argv `ssh-keygen -q -t ed25519 -N "" -C
+  agentchute:<id>:<pool12> -f <hubdir>/keys/<id>_ed25519`; pre-existing
+  passphrase-protected keys refused via `ssh-keygen -y -P ""` probe.
+- **G-B3** FIXED §6.7/§6.4/§7.3/§8 rows 2/22-24: relaunch is **default-on
+  for remote lanes** (`--relaunch=false` opts out; error on local lanes);
+  the TTY prompt was cut with the default flip; quickstart path is now the
+  self-healing path with no flag typed.
+- **G-M1** FIXED with C5 (whitespace in pool/binary paths is inside the
+  rejected set; refusal preferred over quoting, as grok asked).
+- **G-M2** FIXED §5.1/§5.2: marker is `agentchute:<id>:<pool12>`
+  (`sha256(abs pool path)[:12]`, computable independently on both sides);
+  authorize/--list/--revoke and duplicate-id detection keyed on (id, pool12).
+- **G-M3** FIXED §7.5 + §12.1: 30 s negative cache
+  (`~/.agentchute/hub/<hub-id>/hub-down.json`) — hook-context commands skip
+  the dial until T+30 s, success clears it; `turn-end` and human-typed
+  commands deliberately bypass the cache; the deferred pending-content cache
+  stays unbuilt; doctor reports cache state (§7.6).
+- **G-M4** FIXED §9.1: enrollment-surface bullet (AGENTS.md + wrapper
+  templates: remoteness is discovered; never replay `E_SEND_UNKNOWN`
+  without confirming; doctor after join/move) — lands in M2.
+- **G-M5** FIXED §7.2 + §3.6/§4.3: `writable` folded into `hello-ok`
+  (per-session temp-file probe); join fails on `writable:false` with the
+  exact three-part remediation text (hub user / pool path / perms).
+- **G-m1** FIXED — `poll` op cut (§3.4, §4.4, §6.5): pre-injection re-check
+  uses last-tick counts (≤5 s stale, fail-open); single-channel-writer is
+  now structural (only the tick loop writes).
+- **G-m2** FIXED — `ping` op cut (§3.6): payload folded into `hello-ok`;
+  doctor/join probe = one-shot hello.
+- **G-m4** FIXED §7.7: "one paste" → "one join command (zero pastes with own
+  SSH access)".
+- **G-m5** FIXED §7.5/§7.1/§7.6: `E_NO_SSH` row; authorize chmods
+  authorized_keys 0600 / ~/.ssh 0700 and --list/doctor FAIL on wrong perms
+  (StrictModes silent-ignore named); `E_CHANNEL_LOST` echoes the lane's own
+  launch argv, never a hard-coded example.
+- **G-m6** FIXED §7.2: next command is `agentchute serve codex` (runnable in
+  the current shell), with `ac serve codex` noted for after a new shell.
+- **G-m7** FIXED §11: 10 PRs → **6 merges** (M1 seam/tag, M2 spec, M3
+  codec+session+vectors, M4 client, M5 channel+join UX, M6 sshd matrix+docs/
+  tag) — process collapsed, all code deliverables retained, ≈9.2k LOC
+  unchanged.
+- Hub prereqs 3-line first-time block added to §7.1 (grok keep-list item);
+  no `hub locate` added.
+
+Rejections: none of the findings; one **sub-option** declined with argument —
+C5's opaque-binding-id alternative (see C5 entry above; §5.1 records the
+reasoning in the design itself).

--- a/proposal/ssh-hub/reviews-external-r2.md
+++ b/proposal/ssh-hub/reviews-external-r2.md
@@ -1,0 +1,136 @@
+# External review round 2 — DESIGN.md @ sha256 a1819217… (2026-08-15)
+
+grok: **SHIP** (all dispositions verified; laptop walk survives re-join,
+keygen, lid-close) with 2 nits. codex: **FIX** — 5 majors + 2 minors, all in
+the delta. codex confirms all other round-1 dispositions internally
+consistent (actor context, boot-proof ordering, reject-not-encode, release
+order, normative spec section, cuts, no-auto-replay, spool, child env).
+
+## codex findings (code-verified @ 1244ae4). Verdict: FIX
+
+- **D1 (MAJOR) §3.5 register semantics still wrong for host/vendor.**
+  (A) Host: current HostProvided=false does NOT preserve — performRegister
+  calls os.Hostname() and overwrites (register.go:72-87); mapping Host:nil
+  to "preserve" changes local behavior, and hub-side nil resolves the HUB's
+  hostname for a remote self-check. Fix: Host is CLIENT-resolved (omitted
+  flag ⇒ remote client's os.Hostname; explicit empty stays empty) — not a
+  preserve pointer. (B) Vendor: bare hooks carry no vendor; remote client's
+  registration reads hit the mail-free shadow, so resolveAgentVendor
+  (identity.go:72-82) can't recover a custom id's vendor → every step-0
+  repair fails. Fix: Vendor presence-sensitive; omitted vendor resolved
+  HUB-SIDE from the pinned actor's existing hub registration, then
+  canonical-id fallback. Tests: omitted host after machine move; omitted
+  vendor on existing custom-id row.
+- **D2 (MAJOR) §3 streaming — unbounded side channels + pending --show-body
+  unspecified.** ClaimSummary still carries ExpiredOwed[]/Notes[]; Claim has
+  only a ClaimedItem emitter so quarantine notes buffer until return (order
+  changes; notes lost on mid-stream failure). Pending: current code emits
+  every owed entry and supports --show-body (4 MiB bodies,
+  pending.go:127-150,269-288); wire has no owed-item stream or pending-item
+  body trailer — control-JSON recreates the 64 KiB failure; omission breaks
+  "works unchanged". Fix: ordered event stream (message/note/owed emitters
+  or one typed emitter); terminal summaries = counts + truncated metadata
+  only; pending-item body trailers with the 4 MiB cap. Tests: many notes,
+  many owed, one 4 MiB pending body, emit-failure after a note/item.
+- **D3 (MAJOR) §5.1-5.2 pool12 = sha256(abs path) is not a pool identity.**
+  Real path vs symlink path hash differently → two (id,pool12) markers, two
+  keys, same underlying loop; duplicate-id and revoke/list defeated. Lexical
+  cleaning alone insufficient (also grok nit 2: trailing slash). Fix: derive
+  marker HUB-SIDE from canonical resolved identity (Clean + EvalSymlinks),
+  authorize writes/returns the marker; client never derives identity from
+  raw URL text. Tests: realpath-vs-symlink authorize, duplicate refusal,
+  list, revoke.
+- **D4 (MAJOR) §7.2 key lifecycle unsafe for URL alias + failed rotation.**
+  (A) Re-join via a different SSH host alias for the same hub/path → new
+  hub-id → new key → duplicate-id rejection, contradicting "different URL
+  replaces the pointer". Fix: same-hub migration defined explicitly —
+  verified host-key fingerprint + canonical pool identity. (B) --rotate-key
+  has no staging/commit order → self-lock on either side of the boundary.
+  Fix: crash-recoverable staged rotation (fsynced staged key → remote
+  replace → durable local promotion + recovery marker; old key retained
+  until safe). Tests: failure injection before/after remote replace;
+  same-hub-alias rejoin.
+- **D5 (MAJOR) §10.3 relaunch gate tests the opt-in path.** Integration row
+  launches "a --relaunch lane" but the load-bearing change is BARE
+  `agentchute serve` relaunching by default; an implementation keeping the
+  old false default passes. Fix: primary case flagless, assert fresh
+  token/pid after reconnect; separate --relaunch=false case asserting
+  old-child stop and no new child.
+- **D6 (MINOR) §7.5 negative cache omits the SessionStart boot hook.**
+  boot --context-only (boot.go:15-24) dials outside the cache participant
+  list → two 5 s stalls per offline session. Fix: hook-mode boot joins the
+  cache; interactive boot bypasses like other human commands. Test:
+  SessionStart boot then pending inside 30 s ⇒ one dial.
+- **D7 (MINOR) stale plan labels + parity claim.** §3/§10 still say
+  PR-1/PR-2/PR-7 (plan is M1-M6); §6.1 opens "mirrors local runWrapper"
+  before correctly explaining it doesn't. Fix: relabel; opener becomes
+  "derived from local runWrapper, with the deliberate registration
+  reordering below."
+
+## grok nits (SHIP already given; apply, no re-gate needed)
+
+- **D8** §1 non-goals still says "opt-in full-lane relaunch" — flip to match
+  default-on §6.7.
+- **D9** pool12 trailing-slash canonicalization — subsumed by D3's
+  hub-side canonical identity.
+
+## Revision log (round 3)
+
+- **D1** FIXED §3.5: `Host` is a plain string, CLIENT-resolved (flag value
+  or the remote's own `os.Hostname()`; hub maps to `HostProvided:true` so
+  `register.go:80-87`'s hub-hostname substitution never runs) — verified
+  there is no local host-preserve semantic to mirror; `Vendor` is a
+  presence pointer, resolved HUB-SIDE when nil from the pinned actor's
+  existing hub registration then the canonical-id fallback (client-side
+  `resolveAgentVendor`, `identity.go:72-82`, reads the mail-free shadow and
+  cannot); `Bio` keeps pointer-presence (that one matches `BioProvided`).
+  §10.3 row: machine-move host test + custom-id bare-vendor test.
+- **D2** FIXED §3 conventions + §3.2/§3.3/§3.6 + §4.4/§4.4.1/§4.4.3: one
+  typed emitter `emit func(op.Event)` (Message/Note/Owed/AckItem arms),
+  events interleaved in production order, terminal summaries counts +
+  truncation metadata only (`ClaimSummary` slices deleted); wire gains
+  `owed-item`, drops `pending-item` (pending reuses `msg`); pending
+  `show_body` bodies are ≤4 MiB trailers, never control JSON; owed entries
+  stream (cap removed). §10.2 tests: many notes, many owed, one 4 MiB
+  pending body, emit-failure after an item AND after a note.
+- **D3** FIXED §5.1/§5.2/§4.3/§7.2/§7.4/§7.5: `pool12` derived HUB-SIDE
+  from `EvalSymlinks(Clean(abs(--pool)))`; authorize computes, writes,
+  prints the marker; keygen comment is client-known `agentchute:<id>` only;
+  hello-ok reports canonical `pool` + `pool12`; the client RECORDS them at
+  join and compares later sessions against the record — never derives
+  identity from URL text; `E_POOL_MISMATCH` reworded accordingly. §10.3:
+  realpath/symlink/trailing-slash → one marker, duplicate refusal, list,
+  revoke.
+- **D4** FIXED §7.2: (a) same-hub URL migration — pre-keygen host-key
+  fingerprint scan across existing hub dirs, then hello-with-existing-key +
+  recorded-pool12 equality ⇒ migrate (reuse key, move dir, rewrite pointer;
+  crash-idempotent); fingerprint-match/different-pool12 ⇒ fresh join;
+  "different URL replaces the pointer" now routes through this check.
+  (b) staged `--rotate-key` with exact commit order: staged keypair+fsync →
+  `rotate.json{stage:"staged"}` → remote `--replace-key` (idempotent) →
+  local promotion (`.prev` retained) + `stage:"promoted"` → verify hello →
+  delete marker+`.prev`; recovery resumes from the recorded stage. §10.3:
+  failure injection before/after remote replace; alias rejoin.
+- **D5** FIXED §10.3: primary relaunch row is a BARE `agentchute serve`
+  (flagless) asserting fresh token + fresh child pid — an opt-in
+  implementation fails it; separate `--relaunch=false` row asserts
+  old-child stop, no new child, argv-echoing `E_CHANNEL_LOST`; the
+  `E_FENCED` row de-flagged too.
+- **D6** FIXED §7.5: hook-mode `boot` (`--context-only` /
+  `--codex-hook SessionStart`, boot.go:15-40) joins the 30 s negative
+  cache; interactive boot bypasses like other human commands. §10.3 row:
+  SessionStart boot then pending inside 30 s ⇒ one dial.
+- **D7** FIXED: all PR-* labels in §3/§6.1/§6.9/§7.3/§10 relabeled to M*
+  (plus the doc header); §6.1 opener now "derived from local runWrapper,
+  with the deliberate registration reordering noted at step 3".
+- **D8** FIXED §1: non-goal bullet now says default-on for remote lanes
+  (`--relaunch=false` opts out), matching §6.7.
+- **D9** FIXED — subsumed by D3 (Clean+EvalSymlinks kills the
+  trailing-slash split).
+
+Rejections: none. Out-of-delta touches, flagged: D2 required small
+consistency edits in §3 conventions' "Wire shape" bullet (Notes[] →
+NoteEvent stream) and the §4.4.1 check example; D3 required the §7.1
+authorize output example and §7.4 config.json layout line to show the
+hub-returned marker/recorded identity — all direct consequences of the
+named findings, no independent design changes.

--- a/proposal/ssh-hub/reviews-external-r3.md
+++ b/proposal/ssh-hub/reviews-external-r3.md
@@ -1,0 +1,88 @@
+# External review round 3 — DESIGN.md @ sha256 b438482a… (2026-08-15)
+
+codex: **FIX** — 2 blockers + 3 majors, all in the round-3 delta. grok's SHIP
+stands. Reviser: address all five, log dispositions below.
+
+- **E1 (BLOCKER, D2 §3.2)** Lines 262-264 arm the guard latch only after
+  Claim RETURNS, but current check arms inside the loop before each display
+  (check.go:243/256). Disconnect after one emitted msg ⇒ displayed/claimed
+  mail with NO local latch. Fix: client emitter arms on the FIRST msg,
+  before rendering, both normal and --no-archive paths; test mid-stream
+  failure leaves the latch armed.
+- **E2 (BLOCKER, D4a §6.8/§7.2)** Alias migration moves the state dir to the
+  new hub-id and removes the old (1355-1367) while a live child's
+  AGENTCHUTE_CONTROL_REPO still carries the OLD URL (1202-1213) → child ops
+  E_NOT_JOINED, guard discovery can fail open; the pointer rewrite can't
+  override child env. Fix: refuse migration while the old runner is live,
+  OR retain a durable old-hub-id alias/state dir until that lane is
+  stopped/relaunched and latch/spool state reconciled. Test: live latched
+  lane + alias rejoin.
+- **E3 (MAJOR, D4b §7.2)** Staged-rotation recovery not executable: the old
+  agent key is forced to `hub session` so it can NEVER run
+  `hub authorize --replace-key`; and after a crash post-replacement the old
+  key is revoked yet stage:"staged" resumes over it (1380-1391). Fix:
+  recovery FIRST tries hello with the staged key — success proves remote
+  replacement, permit promotion; failure routes through unrestricted
+  operator SSH/paste (or a specified authenticated self-rotation op). Test
+  post-replace/pre-promotion crash without assuming another credential.
+- **E4 (MAJOR, D2 §3.6)** Pending fidelity: OwedEvent{Ref,ExpiredAgo}
+  (253-256) can't reproduce the full OwedEntry JSON
+  (to/from/seq|stamp/suffix/by/recorded_at, pending.go:269-287); summary
+  386-395 omits NeedsBoot/boot-hint semantics (pending.go:71-95,
+  enforced_enrollment_test.go:158-193) which the remote shadow can't derive
+  locally. Fix: owed events carry the full entry fields; terminal result
+  gains NeedsBoot; client keeps boot hint/--fail-if-any behavior.
+- **E5 (MAJOR, D3 §5.1)** EvalSymlinks(Clean(abs)) is not a filesystem
+  identity: Unix EvalSymlinks preserves non-symlink component spelling —
+  macOS APFS case aliases (/Users vs /users) hash differently though
+  os.SameFile is true; Linux bind mounts split too. Fix: durable pool
+  identity, or compare candidate pool against EXISTING marked pools with
+  os.SameFile and reuse the matching marker. Add macOS case-alias test next
+  to the symlink/trailing-slash row.
+
+## Revision log (round 4)
+
+- **E1** FIXED §3.2 + §6.6 + §10.3: the client emitter arms the local guard
+  latch on the FIRST MessageEvent, BEFORE rendering, in both normal and
+  `--no-archive` paths — matching the local per-message
+  `setLatch()`-before-display (verified `check.go:243,256`), never after
+  the op returns; new §10.3 row: disconnect after the first `msg` frame ⇒
+  latch armed, claim persists, remainder redelivers.
+- **E2** FIXED §7.2 — chose the REFUSE option: migration refuses while any
+  lane of the old hub dir is live (local check: `joined_as` ×
+  `runner.json` pid probe, `config.go:149-151`), with an exact refusal text
+  naming the serve pid and the stop-then-rejoin procedure. Justification
+  recorded in-text: the live child's env is immutable (§6.8) so no
+  reconciliation can fix it — the lane must relaunch anyway; a durable
+  alias dir would keep two names for one hub's latch/spool/cache state,
+  the double-source drift this design deletes everywhere else. §10.3:
+  live-latched-lane rejoin refused; post-stop rejoin migrates with
+  latch/spool residue intact.
+- **E3** FIXED §7.2: step 2 corrected — remote replace runs ONLY via
+  operator SSH/paste (the pinned agent key structurally cannot run
+  `authorize`, its forced command is `hub session`); recovery now probes
+  hello with the STAGED key FIRST: success ⇒ replacement landed ⇒ promote +
+  verify (never re-drives step 2 over a revoked key); staged-fail +
+  old-key-works ⇒ resume step 2 via operator path; neither ⇒ print the
+  paste line. No new self-rotation op (the existing authorize paths cover
+  every branch — spec'd in one paragraph). §10.3 post-replace crash case
+  asserts recovery with the old key already revoked.
+- **E4** FIXED §3.2 + §3.6 + §4.4.1: `OwedEvent` now carries the full
+  `loop.OwedEntry` fields (To/From/Seq/Stamp/Suffix/By/RecordedAt + Ref
+  convenience; verified `owed.go:114-122`, `pending.go:269-287`);
+  `PendingSummary` gains hub-derived `NeedsBoot` (verified
+  `pending.go:77-97` — registration stat + ErrInboxMissing are hub facts);
+  client keeps the boot hint (`pending.go:182`) and `--fail-if-any` exit-2
+  semantics (`pending.go:167-169`); `owed-item` wire example updated to
+  full fields.
+- **E5** FIXED §5.1 + §4.3 + §10.3 — chose the SameFile-with-marker-reuse
+  option: normalization (`EvalSymlinks(Clean(abs))`) is only a
+  pre-processing step; identity continuity is `os.SameFile` against every
+  existing marked line's `--pool`, reusing the matching marker; a fresh
+  `pool12` is minted only when nothing matches (precedent cited:
+  `send.go:590-599`'s directory-identity-over-path-strings rationale).
+  `hub authorize` additionally bakes `--pool-id <pool12>` into the forced
+  command so `hello-ok.pool12` is echoed verbatim — session and marker can
+  never disagree. §10.3 row gains the macOS case-alias spelling.
+
+Rejections: none.

--- a/proposal/ssh-hub/reviews-external-r4.md
+++ b/proposal/ssh-hub/reviews-external-r4.md
@@ -1,0 +1,69 @@
+# External review round 4 — DESIGN.md @ sha256 4d932e22… (2026-08-15)
+
+codex: **FIX** — 1 blocker + 2 majors, all in the round-4 delta.
+
+- **F1 (BLOCKER, E5 §4.3/§5.1)** hello-ok.pool12 blindly echoes the
+  forced-command `--pool-id` (568-580, 893-896) — so editing only `--pool`
+  to point at another pool leaves the echoed id unchanged and
+  E_POOL_MISMATCH never fires, contradicting §4.3's edited-line detection
+  and the test at 1910. Fix: session start re-derives/validates the marker
+  from the actual normalized `--pool` (SameFile against the recorded
+  identity), or a durable identity stored IN the pool validated against
+  `--pool-id`. Add the exact `--pool`-only edit test.
+- **F2 (MAJOR, E2 §7.2)** Migration treats a live numeric pid from stale
+  runner.json as proof and prints `kill <pid>` (1409-1414) — pid reuse can
+  target an unrelated process. Existing precedent requires command
+  attribution and refuses ambiguity (setup_reset.go:207-217,
+  setup_wipe.go:560-570). Fix: same attribution/start-time proof; on
+  alive-but-unattributed pid fail closed with inspection guidance, never a
+  kill command. Test: stale runner.json whose pid was reused.
+- **F3 (MAJOR, E3 §7.2)** Local promotion not crash-idempotent: step 3 does
+  active→prev, staged→active, then marker rewrite (1440-1441); a crash
+  between renames leaves stage:"staged" with staged absent / active already
+  new, contradicting staged-key-first recovery (1445-1456). Fix: specify
+  recovery for EVERY rename boundary, or versioned keypairs + one atomic
+  active pointer; inject failures at each local transition, not only around
+  the remote replace.
+
+## Revision log (round 5)
+
+- **F1** FIXED §5.1/§4.3/§5.2/§7.4-layout/§10.3 — chose the
+  durable-identity-in-the-pool option (it stays one small file):
+  `<pool>/.agentchute/loop/state/pool.id`, one line, written atomically
+  0600 by `hub authorize` at first mint, reused on every later authorize
+  (this also replaces round-4's SameFile scan — the file travels with the
+  directory, so symlink/case-alias/bind-mount/moved-pool spellings all
+  read one identity with no stat comparison). `hub session` no longer
+  echoes argv: at startup it re-reads `pool.id` from the actual `--pool`
+  and refuses with `E_POOL_MISMATCH` when absent or ≠ `--pool-id`;
+  `hello-ok.pool12` always carries the pool-read value. New explicit §10.3
+  row: `--pool`-only edit ⇒ hub-side refusal before any op; the
+  consistent-re-point (both flags) case remains the client-side
+  recorded-identity layer. §5.2 notes pool.id is a name tag in the pool,
+  not a mapping store.
+- **F2** FIXED §7.2 + §10.3 — migration liveness mirrors the existing
+  attribution pattern (verified `setup_reset.go:196-224`,
+  `setup_wipe.go:553-570`): runner.json binds pid→id, host must match, pid
+  alive, AND the process command line must attribute as an `agentchute
+  serve` for this hub. Attributed ⇒ refusal naming the session with
+  stop-then-rejoin guidance and NO kill command; alive-but-unattributed ⇒
+  fail closed with the ambiguous-pid text (`ps -p` inspection + stale
+  runner.json removal guidance), never a kill suggestion; dead/no-file ⇒
+  proceed. New §10.3 row: stale runner.json with a reused pid ⇒ refused
+  closed, migrates after the stale file is removed.
+- **F3** FIXED §7.2 (+§7.4 layout, keygen argv) — chose versioned keypairs
+  + one atomic active pointer: `keys/<id>_ed25519.v<N>` files with
+  `keys/<id>_ed25519` as a SYMLINK to the active version (the §4.2 `-i`
+  path unchanged — ssh follows it); promotion is a single temp-symlink +
+  `rename()`; `rotate.json` deleted — a version newer than the symlink's
+  target IS the staged state; first-join keygen mints `.v1` + symlink.
+  Recovery (staged-key-first hello, E3) now covers every crash point
+  because no multi-rename boundary exists; a mid-promote temp symlink is
+  inert and cleaned. §10.3 row expanded to failure injection at all six
+  transitions, post-replace cases with the old key revoked.
+
+Rejections: none. Out-of-delta touches, flagged: F3 required the §7.4
+layout block's keys lines and the §7.2 keygen argv (`-f …v1` + symlink
+note) to match the versioned scheme; F1 required the §5.2 single-source
+clause and the §7.4 layout unchanged otherwise — all direct consequences
+of the named findings.

--- a/proposal/ssh-hub/reviews-external-r5.md
+++ b/proposal/ssh-hub/reviews-external-r5.md
@@ -1,0 +1,56 @@
+# External review round 5 — DESIGN.md @ sha256 1959c113… (2026-08-15)
+
+codex: **FIX** — 1 blocker + 2 majors, all in the round-5 delta.
+
+- **H1 (BLOCKER, F1 §5.1)** `state/pool.id` is not durable against the
+  shipped wipe: `setup --reset --wipe-state` deletes every state/ entry
+  except setup.json (setup_wipe.go:295-315) and the post-wipe rescan
+  rejects other survivors (setup_wipe.go:527-533) → next session
+  E_POOL_MISMATCH until re-authorize; a pool move + remint changes the id
+  and invalidates every binding. Fix: pool.id becomes preserved non-runtime
+  scaffold in the wipe plan, rescan, dry-run/output, and tests (or an
+  equivalently preserved location).
+- **H2 (MAJOR, F1 §5.1)** First mint described only as atomic write
+  (878-885), not create-once: two concurrent authorizes via case/bind
+  aliases can both see no file, compute different hashes, both replace →
+  one authorized_keys line instantly inconsistent. Fix: exclusive-create
+  mint (loser re-reads) or one lock spanning pool-id creation +
+  authorized_keys mutation; concurrent alias-first-authorize test.
+- **H3 (MAJOR, F3 §7.2)** Version state machine misses two crash states:
+  (a) first-join crash after keygen mints .v1 but before the initial
+  symlink (1384-1390) — rerun sees no stable key, re-runs ssh-keygen onto
+  existing .v1, which can prompt/hang; (b) post-promotion crashes before
+  verify/cleanup (1481-1498) leave old-version residue indistinguishable
+  from completed rotation, and the recovery branch never verifies-then-
+  cleans. Fix: recovery for version-files-with-no-pointer (validate/create
+  initial pointer) and older-versions-beside-active (verify active before
+  pruning); failure injection between first keygen and initial symlink;
+  the promised post-promote/cleanup assertions.
+
+## Revision log (round 6)
+
+- **H1** FIXED §5.1 + §9.1 + §10.3: `state/pool.id` declared preserved
+  non-runtime scaffold alongside `setup.json` in the wipe plan, the
+  post-wipe rescan, and the dry-run/preserved output (verified the shipped
+  behavior at `setup_wipe.go:295-316` — only setup.json survives — and
+  `setup_wipe.go:519-536` — rescan flags other survivors); named in the
+  §9.1 spec delta (M2 text, behavior lands in M5 with authorize); §10.3
+  row asserts survive + not-flagged + post-wipe session validation.
+- **H2** FIXED §5.1 + §10.3 — took the exclusive-create option: first mint
+  is `O_EXCL`/link-no-clobber (the codebase's first-writer-wins idiom,
+  `registration.go:133-169`), loser re-reads and adopts the winner's
+  value; concurrent alias-first-authorize test row (one pool.id, both
+  lines share one marker).
+- **H3** FIXED §7.2 + §10.3: (a) no-pointer branch — a rerun never re-runs
+  `ssh-keygen` onto an existing versioned path (`-q` still prompts
+  Overwrite? and hangs scripts); it adopts the orphan after the
+  passphrase-free `ssh-keygen -y -P ""` probe or retires it
+  (`.invalid.<ts>`) and remints; the keygen note points at this branch.
+  (b) residue branch — older-versions-beside-active now verifies the
+  ACTIVE key via hello BEFORE pruning; on active-hello failure nothing is
+  pruned and the active-key paste line prints (converging remediation for
+  both late-revoke and half-landed replace). Injection rows added for the
+  first-keygen→symlink gap and the promised post-promote/cleanup
+  assertions.
+
+Rejections: none.

--- a/proposal/ssh-hub/reviews-external-r6.md
+++ b/proposal/ssh-hub/reviews-external-r6.md
@@ -1,0 +1,147 @@
+# External review round 6 — DESIGN.md @ sha256 b3ae0db4… (2026-08-15)
+
+codex: **FIX** — 1 blocker + 1 major, both in the round-6 delta.
+
+- **J1 (BLOCKER, H2/F1 §5.1)** pool.id is reused and interpolated into the
+  forced-command line (878-915) with no bounded parser/validation: a
+  corrupt or peer-written value (whitespace, quotes, newline, shell syntax)
+  escapes the inert-value grammar; a symlink lets authorize read an
+  arbitrary file. Fix: pool.id is exactly one regular non-symlink 0600 file
+  containing `[0-9a-f]{12}\n`, small read cap; validated on authorize
+  (including the loser-re-read path) AND session startup before any
+  comparison/interpolation; malformed state refused. Tests: oversized,
+  symlinked, newline, quote, `$()`, wrong-length — none may alter
+  authorized_keys.
+- **J2 (MAJOR, H3b §7.2)** Residue branch maps EVERY active-hello failure
+  to the reauthorize paste line (1524-1532), but hello can fail as
+  E_CONNECT / E_HOSTKEY_CHANGED / E_VERSION / E_IDENTITY /
+  E_POOL_MISMATCH — reauthorization is right only for E_UNAUTHORIZED and
+  misleading otherwise. Fix: preserve all versions on every failure;
+  offer/run authorization recovery only on the explicit auth-refusal
+  class; propagate each other error's existing remediation. Tests:
+  E_UNAUTHORIZED vs E_CONNECT/E_HOSTKEY_CHANGED residue cases.
+
+## Revision log (round 7)
+
+- **J1** FIXED §5.1 + §4.4.2 + §7.5 + §10.3: pool.id gets an exact
+  validation contract — exactly one regular non-symlink 0600 file, content
+  `^[0-9a-f]{12}\n$`, read via the bounded no-follow reader
+  (`ReadFileLimit`/`openRegularNoFollow`, `registration.go:34-48`) with a
+  64-byte cap; validated at `hub authorize` (fresh-read AND the H2
+  loser-re-read path) and at `hub session` startup, before any comparison
+  or interpolation; malformed state refused with the new named
+  `E_POOL_ID_INVALID` (wire registry row + authorize CLI text — authorize
+  writes nothing to authorized_keys). Only a grammar-passing value (inert
+  in the authorized_keys/shell/JSON layers) can ever reach the key line.
+  §10.3 row: oversized / symlink / newline / quote / `$()` / whitespace /
+  wrong-length, asserting authorized_keys byte-identical, both consumer
+  paths.
+- **J2** FIXED §7.2 + §10.3: the residue branch preserves ALL version
+  files on EVERY active-hello failure, and the remediation now splits by
+  error class — the active-key reauthorize paste line only on
+  `E_UNAUTHORIZED`; `E_CONNECT` / `E_HOSTKEY_CHANGED` / `E_VERSION` /
+  `E_IDENTITY` / `E_POOL_MISMATCH` / `E_HUB_NO_BINARY` propagate their own
+  §7.5 remediation unchanged (a reauthorize hint on a network failure
+  would send the operator to fix an unbroken key; a host-key stop is never
+  overlaid with rotation advice). Contrast tests added: deauthorized vs
+  hub-down vs rotated-host-key residue, all preserving every version.
+
+Rejections: none.
+
+## Revision log (round 8) — operator-directed naming default (Alex, post-SHIP; own codex delta gate pending)
+
+- §7.2: new Naming block — `hub join --name <local>` mints the pool id
+  `<local-name>-<hostname>` (`--as` stays the verbatim, never-suffixed
+  override): local name canonicalized via the wrapper-token table
+  (`wrapperForToken`, dispatch.go:132-137) when applicable; hostname = the
+  first DNS label of `os.Hostname()`; exact sanitization to the id grammar
+  (`agentIDPattern` verified at inbox.go:40; ValidateAgentID
+  inbox.go:496-504): lowercase → non-`[a-z0-9-]` → `-` → collapse runs →
+  trim edges → empty = error. Minted ONCE at join, recorded in
+  `config.json.names` (§7.4); hostname changes never re-derive; `serve`
+  resolves the same default via `ensureDispatchIdentity`
+  (dispatch.go:269-278) consulting the names map, so `ac serve codex` ⇒
+  `codex-tiny` with nothing retyped; `agentchute identity` lists the
+  machine's local-name → joined-id map (no new command).
+- Rationale recorded verbatim in-doc, both halves: operators think in local
+  names / hostname suffix = automatic pool-wide uniqueness; and
+  hostname-suffixed ids make message traffic human-legible — every inbox
+  filename, roster row, and archive entry shows the origin machine in the
+  sender slug (`from-codex-tiny`), so who-talks-to-whom-from-where reads
+  off the pool with no lookup (Alex addendum).
+- Edge cases specified: shared hostname ⇒ duplicate-id refusal at
+  authorize, its §7.5 text now carrying the hostname-collision `--as`
+  hint; explicit `--as` vs auto name elsewhere ⇒ same normal refusal;
+  post-join hostname change ⇒ recorded id wins.
+- §7.1 + §7.2 quickstarts updated to the `--name codex` / `codex-tiny`
+  flow (key paths, authorize line, join output, serve resolution); §7.3
+  join row and the §7.5 bare-join usage text gained `--name`; §7.4
+  config.json example gains `names`; §10.3 row added (two-host distinct
+  ids; same-hostname refusal with hint; sanitization cases).
+
+## Revision log (round 9) — grok fixes to the naming default
+
+- RESOLVER FIXED §7.2: the round-8 "consult names only when nothing is
+  set" rule was wrong for the real launch path (enrollment exports
+  `AGENTCHUTE_AGENT_ID=codex`; `ensureDispatchIdentity`,
+  dispatch.go:269-278, injects `--as <canonical>` — every joined lane
+  would hello as `codex` against the pinned `codex-tiny` ⇒ `E_IDENTITY`
+  on first launch). New rule, exactly as grok specified, applied at the
+  single identity choke point (`resolveAgentID`, identity.go:13) in
+  remote mode: a candidate id from `--as`/env/wrapper-default that is a
+  LOCAL NAME in the `names` map resolves to the joined id; it is a pool
+  id only when not in the map or already equal to the joined id. Guard
+  latch/spool/hello agree by construction (choke point). `doctor` +
+  `hub join` warn when env is set and resolves differently (mirror of the
+  CONTROL_REPO-mismatch warning). Explicitly stated: NO send-side peer
+  aliasing — `--to` is never mapped; peers address the full `codex-tiny`.
+  Join-time `--as` verbatim-minting clarified as a separate rule to avoid
+  reading as a contradiction.
+- STALE EXAMPLES FIXED: §7.2 auto-authorize interactive ssh now
+  `--agent codex-tiny`; §7.7 Tailscale recipe now `--name codex`.
+- §10.3 row added: `ac serve codex` with `AGENTCHUTE_AGENT_ID=codex`
+  exported resolves to `codex-tiny` and hellos clean; unmapped candidate
+  passes verbatim; `--to` unmapped.
+
+## Revision log (round 9b) — codex round-8 gate overlap
+
+- BLOCKER (direct-serve path) CONFIRMED COVERED and made explicit:
+  verified in code that `cmdServe` reaches `resolveAgentID` after
+  discovery (`serve.go:135,145`) on the direct `agentchute serve` path
+  that never touches the dispatcher, and that `ac serve` merely injects
+  `--as <canonical>` (`ensureDispatchIdentity`, dispatch.go:269-278)
+  before exec-ing that same serve — §7.2 now states the lookup lives
+  INSIDE `resolveAgentID` (identity.go:13-38) and therefore covers BOTH
+  launch paths. Honest addition beyond the finding: `guard` resolves its
+  id inline (`evaluateGuardInvocation`, guard.go:169-189, not via
+  resolveAgentID) — named in §7.2 with M4 routing it through the same
+  map so the latch path cannot diverge. §10.3 resolver row now launches
+  BOTH ways after `hub join --name codex`.
+- MAJOR (hostname-change invariant untested) FIXED: §10.3 row added —
+  join as `codex-tiny`, change the injected hostname, re-run
+  join/identity/serve → id, `names` map, and key files remain
+  `codex-tiny`; no newly derived id, key, or authorized_keys line.
+
+## Revision log (round 10) — codex combined-gate findings on naming
+
+- BLOCKER (no candidate on the direct env-unset path) FIXED §7.2 + §10.3:
+  verified `cmdServe` keeps the wrapper canonical only in
+  `launchedWrapper` (serve.go:122-129) and `resolveAgentIDRaw` has only
+  flag/env sources (identity.go:27-38), so the two-command quickstart's
+  bare `agentchute serve codex` had NO candidate; design now wires
+  `launchedWrapper` in as the fallback candidate when both flag and env
+  are absent, resolved through `names` like any other. The §10.3 resolver
+  row was split exactly as directed: a direct-launch case with env
+  explicitly UNSET (the prior row false-greened by exporting it) and a
+  separate exported-env case covering both launch paths.
+- MAJOR (local-name/pool-id shadowing) FIXED §7.2 + §10.3 — took the
+  refuse-at-join option: a join whose id (verbatim `--as` or minted local
+  name) collides with the other namespace on this machine is refused
+  BEFORE keygen/authorize, with exact error texts naming the existing
+  mapping and the way out, both orders; §10.3 row covers both orders and
+  asserts no key/authorize/config side effects.
+- MINOR (stale §7.6 + unspecified warning) FIXED: doctor sample updated to
+  `codex-tiny` (config/key/pinned lines, versioned-key symlink shown); the
+  `AGENTCHUTE_AGENT_ID`-disagreement warning §7.2 referenced is now
+  actually specified in §7.6 with exact text, plus a §10.3 row (warning
+  fires on a mapped local name, silent on an unmapped id).

--- a/proposal/ssh-hub/reviews-internal.md
+++ b/proposal/ssh-hub/reviews-internal.md
@@ -1,0 +1,209 @@
+# Internal critic reports — DESIGN.md round 1 (2026-08-14)
+
+Two independent claude-side critics reviewed `DESIGN.md` (authored against HEAD
+1244ae4). Both returned NEEDS-WORK. Findings below are verbatim-condensed; the
+reviser must address every BLOCKER and MAJOR, and record a disposition
+(FIXED §x / REJECTED because …) per finding in the Revision log at the end.
+
+## Critic A — end-user seamlessness. Verdict: NEEDS-WORK
+
+- **A-B1 (BLOCKER)** Laptop sleep/wake and hub reboot kill remote lanes daily;
+  design never says "sleep" or "reboot"; recovery is a human retyping
+  `ac serve` per machine per event. Consensus only vetoes resuming the SAME
+  child on a dropped channel — a supervised full-lane relaunch (fence old
+  child → fresh channel/lease/token/child, vendor resume args where the
+  wrapper supports them) is consensus-compatible. Fix: matrix rows
+  "remote sleeps/wakes" + "hub reboots (N lanes)"; opt-in relaunch
+  (`--relaunch` or prompt on E_CHANNEL_LOST); if deferred, price it out loud.
+- **A-M1** `hub authorize` paste runs from $HOME; pool resolution unspecified;
+  URL path vs forced-command pool never reconciled → silent wrong-pool join.
+  Fix: URL path authoritative end-to-end; authorize line includes `--pool`;
+  authorize fails loudly on non-pool path; client hard-errors on
+  hello-ok.pool != url.path (E_POOL_MISMATCH).
+- **A-M2** Join can be ONE command, zero cross-machine pastes, in the common
+  case: §7.1 already presupposes ordinary SSH access, so `hub join` should
+  attempt `ssh user@hub agentchute hub authorize ...` itself (interactive
+  auth), falling back to print-and-paste. Record why if rejected.
+- **A-M3** `.agentchute-control-repo` not gitignored → `git add -A` on laptop
+  commits it; hub pulling it redirects hub discovery to ssh-to-itself. Fix:
+  join writes pointer AND ensures ignore entry; hub refuses a pointer whose
+  URL resolves to its own pool.
+- **A-M4** Typo'd URL poisons checkout: pointer written before probing;
+  re-join/undo semantics unspecified; stale shadow dirs accumulate. Fix:
+  probe before writing pointer; re-join replaces pointer with notice;
+  E_CONNECT mentions un-join.
+- **A-M5** No hub-side health surface for broken authorized_keys lines. Fix:
+  `hub authorize --list` validates each line (binary exists/executable, pool
+  resolves) PASS/FAIL; hub-side doctor runs same check.
+- **A-M6** Error-catalog gaps: duplicate-id authorize refusal text (row 12
+  promises it, absent — spell the codex/codex-laptop fork), E_POOL_PATH_
+  UNQUOTABLE text, row-21 turn-end-failure text naming the hub, bare
+  `hub join` with no args.
+- **A-m1** §7.2 quickstart fails verbatim on fresh laptop: missing
+  install+clone prereq line; `ac` shim not on PATH in same shell — use
+  `agentchute serve` or print "open a new shell".
+- **A-m2** E_UNAUTHORIZED should embed the complete ready-to-paste authorize
+  line (client has its own pubkey), not send user to another command.
+- **A-m3** Cut `hub join --verify` (redundant once A-m2 lands; bare re-join
+  verifies).
+- **A-m4** Map fast ssh exec-failure (127) to immediate "hub binary not
+  found at <path>" instead of burning the 10s hello timeout.
+- **A-m5** `--revoke` should detect a live session via serve.claim pid and
+  print the kill line.
+- **A-m6** "Two commands per side" claim is off by 2× as designed (4 actions
+  + paste); land A-M2 or reword.
+- **A-n1** Pool-path inconsistent across examples (agentchute vs
+  coordination) — one story-wide path. **A-n2** "5 s worst-case hook delay"
+  is per invocation, not per turn. **A-n3** authorize must run as the ssh
+  login user; macOS hub needs Remote Login — one clause each. **A-n4** note
+  in §7.2 the URL path is the pool's absolute path on the hub (`pwd` there).
+
+## Critic B — adversarial correctness (verified against code @ 1244ae4). Verdict: NEEDS-WORK
+
+- **B-B1 (BLOCKER)** Child env/discovery contract unspecified. Real serve
+  exports AGENTCHUTE_CONTROL_REPO + AGENTCHUTE_LOOP_DIR verbatim
+  (serve.go:512-514); env outranks pointer (config.go:208-258). With §7.4's
+  config: (1) CONTROL_REPO=local-repo-root resolves LOCAL → children mail a
+  dead shadow/local pool silently; (2) LOOP_DIR=shadow can't resolve —
+  vendorFromLoopDir requires dotdir parent (config.go:331-357); (3) guard
+  fails OPEN on Discover error (guard.go:195-204) → latch permanently inert
+  on every remote lane. Fix (normative subsection): serve exports
+  CONTROL_REPO=<canonical ssh:// URL>, never exports LOOP_DIR; Discover's
+  ssh:// arm derives the shadow LoopDir itself (or shadow path gains a
+  dotdir segment); integration test: hook-context guard resolves shadow
+  latch, child send reaches hub.
+- **B-M1** E_SEND_UNKNOWN retry command as printed is REFUSED by the shipped
+  --body-file state-tree guard (send.go:600-632 rejects any path under
+  <LoopDir>/state/; spool lives there per §7.4). Fix: move spool to
+  ~/.agentchute/hub/<hub-id>/spool/ (simpler) or carve out spool subdir.
+- **B-M2** tick heartbeat has no registration-template source: TickReq{} is
+  empty but HeartbeatRegistration needs a validating template (Vendor,
+  ControlRepo…, registration.go:192-240); hub session knows only id+pool.
+  Fix: add `register` to channel startup (after lease-acquire, before child,
+  mirroring serve.go:374-393); session caches it as tick template; tick
+  refused before it arrives.
+- **B-M3** 64 KiB control-line cap vs legitimately large aggregate responses
+  (ack-ok acked[] for 200+ messages, check-ok quarantined[], pending-ok,
+  status-ok) — and oversize is spec'd session-fatal, after ack already
+  committed hub-side. Fix: stream aggregates as per-item frames (msg
+  pattern) or bound + truncated-count and exempt hub-composed responses
+  from violation-closes-session.
+- **B-M4** Hub reboot/SIGKILL: serve.claim survives; reclaim needs stale ≥10s
+  AND pidAlive false; OS pid reuse after reboot → ErrLeaseHeld forever until
+  manual delete (lease.go:236-244). Matrix has no hub-reboot row;
+  E_LEASE_HELD "clears within ~20s" is false here. Fix: add matrix rows;
+  branch remediation text on claim age; optionally StartedAt < hub boot
+  time ⇒ dead (flag as spec decision touching lease.go).
+- **B-m1** Two channel producers (tick loop + inject loop's poll) can
+  interleave frames → E_MALFORMED_FRAME → spurious child fence. Specify
+  single channel-writer; contended poll falls back to last-tick counts.
+- **B-m2** §4.5.1 "piped body untouched on preflight failure" overstated on
+  the wire path (stdin drained before hub verdict; spool compensates) —
+  reword honestly; note code reads --body-file BEFORE preflights
+  (send.go:114-125), design defers to after hello.
+- **B-m3** Hub `agentchute update` invalidates ALL serve leases
+  (lease.go:371-373) → fleet-wide E_FENCED + relaunch; name it in the
+  matrix; note live sessions keep executing the old binary inode.
+- **B-m4** Stale AGENTCHUTE_CONTROL_REPO env silently defeats the join
+  pointer (env outranks, config.go:218-225; env-leak incidents are in this
+  project's history). hub join + doctor warn when env disagrees with
+  pointer.
+- **B-m5** hub session must build Config directly from --pool, both arms —
+  hub user's env (bashrc sourced under Debian sshd) still outranks
+  otherwise (config.go:299-329).
+- **B-n1** Sanitize SSH_ORIGINAL_COMMAND control bytes before logging.
+  **B-n2** Latch arms at first claim locally (check.go:168-193), not
+  "exactly" as today remotely — drop "exactly".
+
+### Verified-sound (do NOT churn these)
+Hub-side pid lease reclaim; token-checked early release; in-lock fence
+checks (floor.go:127-131, seq.go:328-332); disconnect-after-claim
+redelivery (inbox.go:328-381); no-auto-replay semantics (no interleaving
+double-sends or loses body); ack/turn-end crash recovery (turn_end.go:
+120-163); disk-full behavior; version handshake all skew directions;
+actor-free wire identity incl. owed/floor/gate; restrict/forced-command +
+accept-new + ControlMaster facts; 4 MiB cap = MaxInboxMessageBytes (wire
+stricter than local today — a plus); conformance lease-gap response;
+consensus compliance incl. all vetoes (one-shot mux'd FRAMED sessions do
+not violate the one-shot veto — it targets shell-text re-parsing).
+
+## Revision log (round 1)
+
+- **A-B1** FIXED §6.7 (new) + §1 non-goal reworded + §6.4 step 3 + §8 rows
+  22–24 + §7.3 tally + §10.3 relaunch tests + §11 PR-5 (+250 LOC). Supervised
+  full-lane relaunch: `serve --relaunch` (+`--relaunch-args`), TTY prompt
+  fallback, backoff 1→60 s ±20 % jitter unbounded, transport-loss trigger set,
+  single attempt on `E_FENCED` (hub-update case), never on
+  identity/version/pool/hostkey errors; hub-reboot N-lane recovery designed.
+- **A-M1** FIXED §4.3 (pool check bullet, `E_POOL_MISMATCH`), §5.1 (authorize
+  validates pool + `--pool` mandatory in line), §7.1, §7.5 texts, §10.3 rows.
+  URL path authoritative end-to-end.
+- **A-M2** FIXED §7.2: join auto-runs authorize over the operator's own
+  interactive ssh (per-argument single-quoting, values `'`-free by grammar),
+  falls back to print-and-paste; §7.1/§1 claims updated.
+- **A-M3** FIXED §7.4 pointer lifecycle: `.git/info/exclude` entry (warn if
+  pointer already tracked) + `E_SELF_POINTER` refusal when the ssh arm's URL
+  path resolves to a local pool (the committed-pointer-on-hub accident).
+- **A-M4** FIXED §7.4 (probe-before-pointer: hello-ok or auth-refusal writes;
+  connect/DNS/hostkey failures write nothing) + §7.2 (re-join replaces with
+  notice; un-join documented) + `E_CONNECT` un-join hint.
+- **A-M5** FIXED §7.1 (`--list` PASS/FAIL validation) + §7.6 (hub-side doctor
+  runs the same audit) + §10.3 authorize-validation row.
+- **A-M6** FIXED §7.5: duplicate-id refusal text (spells `codex-laptop`),
+  unquotable-pool text, exact turn-end-unreachable text (row 21 now cites
+  it), bare `hub join` usage text.
+- **A-m1** FIXED §7.2 (prereq line; "open a new shell" note on `ac`).
+- **A-m2** FIXED `E_UNAUTHORIZED` embeds the complete ready-to-paste line.
+- **A-m3** FIXED — `--verify` cut (§7.3, §3.6); bare re-join verifies.
+- **A-m4** FIXED — `E_HUB_NO_BINARY` from ssh exit 127, no 10 s wait (§4.4.2,
+  §7.5).
+- **A-m5** FIXED §7.1 — `--revoke` reads `serve.claim`, prints `kill <pid>`.
+- **A-m6** FIXED — claims reworded everywhere ("one command … one paste when
+  an admin sits in the middle"): §1, §7.1, §7.2.
+- **A-n1** FIXED — `/home/alex/code/agentchute` unified across §4.3, §5.1,
+  §7.5, §7.6, §7.7.
+- **A-n2** FIXED — "per hook invocation" wording in §7.5 and §12.
+- **A-n3** FIXED §5.1 + §7.1 (login user; macOS Remote Login).
+- **A-n4** FIXED §7.2 ("absolute path on the hub — run `pwd` there").
+- **B-B1** FIXED §6.8 (new, normative): serve exports
+  `AGENTCHUTE_CONTROL_REPO=<ssh URL>`, never `AGENTCHUTE_LOOP_DIR` (strips
+  inherited, mirroring the AGENTCHUTE_GUARD hygiene); ssh:// arm branches
+  before `validateExplicitControlRepo`, derives the shadow locally (offline-
+  safe, so guard can never fail open from remoteness); shadow moved to
+  `~/.agentchute/hub/<hub-id>/.agentchute/loop/` so the dotdir-parent loop-dir
+  invariant holds; explicit `--loop-dir`+ssh:// is a hard error; §10.3 gains
+  the child-env/guard-shadow/child-send integration row. §7.4 updated.
+- **B-M1** FIXED — spool relocated to `~/.agentchute/hub/<hub-id>/spool/`
+  (outside the shadow loop tree; `rejectLoopStateBodyFile` verified at
+  send.go:600-633); §4.5.3 + §7.4 specify it and the `--body-file` retry.
+- **B-M2** FIXED — `register` is a mandatory channel-startup step between
+  `lease-acquire` and child start (§6.1 step 3, §3.4, §3.5); session caches
+  it as the tick heartbeat template; `tick` before `register` → `E_ORDER`
+  (new code, §4.4.2).
+- **B-M3** FIXED §4.4.3 (new producer rules): `ack-item`/`pending-item`
+  streaming frames (vocab + example updated), quarantined→count,
+  status-ok/expired_owed caps with `truncated`, and violation-closes-session
+  scoped to received frames only (§4.3) — a post-commit response can never
+  kill the session.
+- **B-M4** FIXED §6.9 (new): boot-time corroboration of the same-host
+  pid-proof (StartedAt < boot ⇒ dead; /proc/stat btime, sysctl kern.boottime;
+  unreadable ⇒ unchanged fail-closed), flagged as the one internal/loop
+  change and added to the §9.1 spec delta; §8 rows 23–24; `E_LEASE_HELD`
+  text branched fresh-vs-stale-claim in §7.5; §10.3 pid-reuse row; §11 PR-3.
+- **B-m1** FIXED §6.5 single-channel-writer bullet (poll goroutine owns the
+  pipe; inject's poll answered from last-tick counts when a tick is in
+  flight) + §4.3 note.
+- **B-m2** FIXED §4.5.1 honesty rewrite (partial survival, spool
+  compensation, and the send.go:114-125 calibration note).
+- **B-m3** FIXED §8 row 24 + §6.7 trigger set (single `E_FENCED` relaunch
+  attempt) + old-binary-inode note.
+- **B-m4** FIXED §7.2 + §7.4 + §7.6: join and doctor warn on
+  env-vs-pointer disagreement.
+- **B-m5** FIXED §5.1: hub session builds Config directly from `--pool`,
+  both arms; discovery cascade never runs hub-side.
+- **B-n1** FIXED §5.1: SSH_ORIGINAL_COMMAND logged only after C0/C1 strip.
+- **B-n2** FIXED §6.6: "exactly" dropped; local-vs-remote arm timing stated.
+
+Rejections: none — every finding was accepted. (A-M2's security note is
+recorded in §7.2: the auto-authorize ssh uses the human's own interactive
+credentials, deliberately not BatchMode and not the pinned key.)


### PR DESCRIPTION
Program docs only — **no code changes, nothing implemented yet.** This lands the reviewed design and implementation plan for the next reference implementation so they stop living as untracked local files.

## What it is

An **SSH hub**: one host keeps today's file pool, and remote lanes reach it over a long-lived SSH subsystem connection — one per agent, with each key pinned by forced command to exactly one agent id. Because the operation executes on the hub, `flock`, link-no-clobber delivery, rename-based claim and lease fencing all keep running on a single kernel, unchanged. No new Go dependencies.

Joining a machine is `agentchute hub join ssh://user@host/path` then the usual `agentchute serve <wrapper>`; ids default to `<local-name>-<hostname>` so the operator only thinks in local names and message traffic stays legible (`from-codex-tiny`).

## Contents

| file | what |
|---|---|
| `DESIGN.md` | architecture, operation seam, wire protocol, identity/security, lease and liveness, end-user flows, failure matrix, spec delta, test plan |
| `PLAN.md` | 6 merges, 45 work items — each with goal, design pointers, files, fixed shapes, tests, done-when, size |
| `BRIEF.md`, `operator-qa-2026-08-15.md` | the binding brief and the operator Q&A that settled naming and topology |
| `reviews-internal.md`, `reviews-external-r1..r6.md`, `plan-reviews-r1..r3.md` | every review round with its per-finding disposition log |

## Release shape

`v1.6.0` tags after M1 (the operation seam — a pure internal refactor) and **before** the spec merge, so no release ever advertises a capability it does not ship. `v1.7.0` gates on M6's real-sshd CI matrix plus the conformance vectors.

## Review status

Unanimous across all four lanes. Design: grok SHIP r2, codex SHIP r7. Plan: grok SHIP r2, opus-xhigh SHIP r3, opus-high SHIP r4, codex SHIP r6.

Every plan round found real defects introduced by the previous round's fixes — a silent-truncation fix that reordered output, a struct pinned to satisfy one finding that turned out to be a strict subset of what callers render, a row cap that could not bound a frame because `host` has no length limit. Delta re-gates on pinned content hashes are what caught them.

## Notes for review

- Markdown only, so `go test ./...` does not reach it (E10).
- The review records are kept deliberately: they are the reason each decision went the way it did, and the plan's work items cite them.
- `DESIGN.md` line-number citations were removed on purpose — they drift and start pointing into the wrong section. Section references and frozen code anchors are authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
