### PR TITLE
docs(playbooks): say whose actions a playbook governs

### DIFF
--- a/docs/internal/PLAYBOOKS.md
+++ b/docs/internal/PLAYBOOKS.md
@@ -1,6 +1,6 @@
 # Playbooks — the recurring bus rituals
 
-Companion to the **Working efficiently on this bus** rules in [`AGENTS.md`](../../AGENTS.md) (E1–E10). Each playbook is the step sequence; the E-rules say when it's mandatory. `$ID` is your pinned lane id.
+Companion to the **Working efficiently on this bus** rules in [`AGENTS.md`](../../AGENTS.md) (E1–E10). Each playbook is the step sequence; the E-rules say when it's mandatory. `$ID` is your pinned lane id. **Each playbook binds only the lane performing that role** — a step in `gate-review` governs the reviewer's own actions and never tells the implementer when to commit, push, or hold, and vice versa; if a rule seems to constrain the other side of a gate, you are reading it wrong.
 
 ## bus-turn (per wake cue — E8)
 

--- a/docs/internal/PLAYBOOKS.md
+++ b/docs/internal/PLAYBOOKS.md
@@ -1,6 +1,6 @@
 # Playbooks — the recurring bus rituals
 
-Companion to the **Working efficiently on this bus** rules in [`AGENTS.md`](../../AGENTS.md) (E1–E10). Each playbook is the step sequence; the E-rules say when it's mandatory. `$ID` is your pinned lane id. **Each playbook binds only the lane performing that role** — a step in `gate-review` governs the reviewer's own actions and never tells the implementer when to commit, push, or hold, and vice versa; if a rule seems to constrain the other side of a gate, you are reading it wrong.
+Companion to the **Working efficiently on this bus** rules in [`AGENTS.md`](../../AGENTS.md) (E1–E10). Each playbook is the step sequence; the E-rules say when it's mandatory. `$ID` is your pinned lane id. **Each playbook's imperative actions bind the lane performing that role** — in `gate-review`, the pre-verdict refresh governs reviewer-side verdict timing and never tells the implementer when to commit, push, or hold. A playbook may still state conditions on the *ask* it receives (pinned SHAs, an `AUTHORIZATION:` line, a delta pinned to the reviewer's named surface); those bind the asker.
 
 ## bus-turn (per wake cue — E8)
 


### PR DESCRIPTION
One sentence in the `PLAYBOOKS.md` header. Docs-only, no Go, no embedded asset.

## Why

The `gate-review` step-5 rule added in #147 was misread as an implementer push-hold within an hour of landing: an implementer withheld an already-committed fix so a reviewer's head "wouldn't move mid-read", citing that rule. It is reviewer-side verdict timing and says nothing about when to push.

E3 freezes a review to a **SHA**, which stays fetchable wherever the branch tip goes — so a push cannot disturb a review in progress, while holding one leaves a known-defective commit as the PR head and invites the second gate to file a FIX for something already fixed. That is the #146 round-trip again.

The defect was in how the rule was written, not only in how it was read, so the fix goes in the header where it governs every playbook rather than as another step.

## The line

Appended to the header paragraph:

> **Each playbook binds only the lane performing that role** — a step in `gate-review` governs the reviewer's own actions and never tells the implementer when to commit, push, or hold, and vice versa; if a rule seems to constrain the other side of a gate, you are reading it wrong.

## Scope

base `a86b622` (main, #147's merge) → head `a93d475`. One file, one line changed, no step renumbering, every existing step pointer untouched.

Requested by the coordinator; gate routed to grok and codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)