### PR TITLE
fix(web): serve the latest released spec

### DIFF
--- a/web/blog/v0-1-1-the-agents-shipped-it-themselves.html
+++ b/web/blog/v0-1-1-the-agents-shipped-it-themselves.html
@@ -347,7 +347,7 @@ agentchute boot --as codex --vendor openai</code></pre>
 
     <p>
       Or skip the binary. Drop
-      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>
+      <a href="https://github.com/agentchute/agentchute/blob/v0.1.1/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>
       into your project and follow the hand-protocol section. The whole protocol
       fits in one file.
     </p>

--- a/web/blog/v0-1-1-the-agents-shipped-it-themselves.html
+++ b/web/blog/v0-1-1-the-agents-shipped-it-themselves.html
@@ -347,7 +347,7 @@ agentchute boot --as codex --vendor openai</code></pre>
 
     <p>
       Or skip the binary. Drop
-      <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>
+      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>
       into your project and follow the hand-protocol section. The whole protocol
       fits in one file.
     </p>

--- a/web/blog/v0-2-1-enrollment-enforced.html
+++ b/web/blog/v0-2-1-enrollment-enforced.html
@@ -250,7 +250,7 @@ agentchute hooks install --wrapper all
 agentchute boot --as &lt;id&gt; --vendor &lt;vendor&gt;</code></pre>
 
     <p>
-      See <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md#57-enforced-enrollment">spec §5.7</a> for the normative text and the README for the full v0.2.1 release entry.
+      See <a href="https://github.com/agentchute/agentchute/blob/v0.2.1/AGENTCHUTE.md#57-enforced-enrollment">spec §5.7</a> for the normative text and the README for the full v0.2.1 release entry.
     </p>
 
   </div>

--- a/web/blog/v0-2-1-enrollment-enforced.html
+++ b/web/blog/v0-2-1-enrollment-enforced.html
@@ -250,7 +250,7 @@ agentchute hooks install --wrapper all
 agentchute boot --as &lt;id&gt; --vendor &lt;vendor&gt;</code></pre>
 
     <p>
-      See <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md#57-enforced-enrollment">spec §5.7</a> for the normative text and the README for the full v0.2.1 release entry.
+      See <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md#57-enforced-enrollment">spec §5.7</a> for the normative text and the README for the full v0.2.1 release entry.
     </p>
 
   </div>

--- a/web/blog/v0-2-recipient-polling.html
+++ b/web/blog/v0-2-recipient-polling.html
@@ -232,7 +232,7 @@ agentchute doctor --generate-service script --as codex \
 
     <p>
       Those are <strong>convenience adapters</strong>. They are not the
-      protocol. The new <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md#82-wake-responsibility">§8.2</a>
+      protocol. The new <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md#82-wake-responsibility">§8.2</a>
       says so in normative text:
     </p>
 
@@ -260,7 +260,7 @@ agentchute doctor --generate-service --help</code></pre>
       <code>doctor --generate-service</code>. The v5 enrollment block
       teaches the three-tier polling model to any new agent that
       runs <code>agentchute init</code>. See
-      <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md#8-wake-adapters">spec §8</a>
+      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md#8-wake-adapters">spec §8</a>
       for the full adapter contract and §8.2 for the wake-responsibility
       text.
     </p>

--- a/web/blog/v0-2-recipient-polling.html
+++ b/web/blog/v0-2-recipient-polling.html
@@ -260,7 +260,7 @@ agentchute doctor --generate-service --help</code></pre>
       <code>doctor --generate-service</code>. The v5 enrollment block
       teaches the three-tier polling model to any new agent that
       runs <code>agentchute init</code>. See
-      <a href="https://github.com/agentchute/agentchute/blob/v0.2.0/AGENTCHUTE.md#8-wake-adapters">spec §8</a>
+      <a href="https://github.com/agentchute/agentchute/blob/v0.2.0/AGENTCHUTE.md#8-tmux-wake-adapter-v01-reference">spec §8</a>
       for the full adapter contract and §8.2 for the wake-responsibility
       text.
     </p>

--- a/web/blog/v0-2-recipient-polling.html
+++ b/web/blog/v0-2-recipient-polling.html
@@ -232,7 +232,7 @@ agentchute doctor --generate-service script --as codex \
 
     <p>
       Those are <strong>convenience adapters</strong>. They are not the
-      protocol. The new <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md#82-wake-responsibility">§8.2</a>
+      protocol. The new <a href="https://github.com/agentchute/agentchute/blob/v0.2.0/AGENTCHUTE.md#82-wake-responsibility">§8.2</a>
       says so in normative text:
     </p>
 
@@ -260,7 +260,7 @@ agentchute doctor --generate-service --help</code></pre>
       <code>doctor --generate-service</code>. The v5 enrollment block
       teaches the three-tier polling model to any new agent that
       runs <code>agentchute init</code>. See
-      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md#8-wake-adapters">spec §8</a>
+      <a href="https://github.com/agentchute/agentchute/blob/v0.2.0/AGENTCHUTE.md#8-wake-adapters">spec §8</a>
       for the full adapter contract and §8.2 for the wake-responsibility
       text.
     </p>

--- a/web/blog/v0-3-2-setup-and-shims.html
+++ b/web/blog/v0-3-2-setup-and-shims.html
@@ -119,7 +119,7 @@
       The bracketed prefix is reference-adapter metadata; the model-facing instruction is
       still <em>check inbox</em>. Other conforming implementations are free to use different
       wake prompts as long as inbox delivery stays durable and recipient-owned
-      (<a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md#8-tmux-wake-adapter-v01-reference">spec §8</a>).
+      (<a href="https://github.com/agentchute/agentchute/blob/v0.3.2/AGENTCHUTE.md#8-tmux-wake-adapter-v01-reference">spec §8</a>).
       The leading bracket means a model can tell a wake event from a typed prompt without
       heuristics — humans don't start prompts with <code>[</code>.
     </p>
@@ -137,7 +137,7 @@
 
     <p>
       The spec was extended at
-      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md#72-inbox-only-authority-to-mutate">§7.2</a>
+      <a href="https://github.com/agentchute/agentchute/blob/v0.3.2/AGENTCHUTE.md#72-inbox-only-authority-to-mutate">§7.2</a>
       to authorize this as protocol maintenance — narrow, mechanical, optional — without
       reopening the broader "peers don't touch each other's state" boundary.
     </p>

--- a/web/blog/v0-3-2-setup-and-shims.html
+++ b/web/blog/v0-3-2-setup-and-shims.html
@@ -119,7 +119,7 @@
       The bracketed prefix is reference-adapter metadata; the model-facing instruction is
       still <em>check inbox</em>. Other conforming implementations are free to use different
       wake prompts as long as inbox delivery stays durable and recipient-owned
-      (<a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md#8-tmux-wake-adapter-v01-reference">spec §8</a>).
+      (<a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md#8-tmux-wake-adapter-v01-reference">spec §8</a>).
       The leading bracket means a model can tell a wake event from a typed prompt without
       heuristics — humans don't start prompts with <code>[</code>.
     </p>
@@ -137,7 +137,7 @@
 
     <p>
       The spec was extended at
-      <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md#72-inbox-only-authority-to-mutate">§7.2</a>
+      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md#72-inbox-only-authority-to-mutate">§7.2</a>
       to authorize this as protocol maintenance — narrow, mechanical, optional — without
       reopening the broader "peers don't touch each other's state" boundary.
     </p>

--- a/web/blog/v1-0-done-not-big.html
+++ b/web/blog/v1-0-done-not-big.html
@@ -95,7 +95,7 @@
   <p>Rejecting these <em>is</em> the announcement: no priorities, no delivery receipts, no broadcast, no routing or coordinator agents, no signing machinery, no retries or exactly-once, no config system, no daemons, no maintained SDKs. Each one would re-grow the mass we spent four releases removing. In a category racing to add orchestration surface, agentchute's 1.0 statement is <b>a protocol that stays small on purpose.</b></p>
 
   <h2>Build on it</h2>
-  <p>Install the reference CLI and your agents are coordinating in minutes — or skip our binary entirely: the protocol is just files, and the <a href="https://github.com/agentchute/agentchute/tree/v1.5.7/conformance">vectors</a> tell you whether your own implementation, in any language, got it right. Either way, the promise is the same and it's the only one we make: <b>build on this — it won't break under you.</b></p>
+  <p>Install the reference CLI and your agents are coordinating in minutes — or skip our binary entirely: the protocol is just files, and the <a href="https://github.com/agentchute/agentchute/tree/v1.0.0/conformance">vectors</a> tell you whether your own implementation, in any language, got it right. Either way, the promise is the same and it's the only one we make: <b>build on this — it won't break under you.</b></p>
 
   <div class="next"><a href="/blog/after-done-roadmap.html">Next: after 1.0 — the roadmap around a stable core →</a></div>
 

--- a/web/blog/v1-0-done-not-big.html
+++ b/web/blog/v1-0-done-not-big.html
@@ -95,7 +95,7 @@
   <p>Rejecting these <em>is</em> the announcement: no priorities, no delivery receipts, no broadcast, no routing or coordinator agents, no signing machinery, no retries or exactly-once, no config system, no daemons, no maintained SDKs. Each one would re-grow the mass we spent four releases removing. In a category racing to add orchestration surface, agentchute's 1.0 statement is <b>a protocol that stays small on purpose.</b></p>
 
   <h2>Build on it</h2>
-  <p>Install the reference CLI and your agents are coordinating in minutes — or skip our binary entirely: the protocol is just files, and the <a href="https://github.com/agentchute/agentchute/tree/main/conformance">vectors</a> tell you whether your own implementation, in any language, got it right. Either way, the promise is the same and it's the only one we make: <b>build on this — it won't break under you.</b></p>
+  <p>Install the reference CLI and your agents are coordinating in minutes — or skip our binary entirely: the protocol is just files, and the <a href="https://github.com/agentchute/agentchute/tree/v1.5.7/conformance">vectors</a> tell you whether your own implementation, in any language, got it right. Either way, the promise is the same and it's the only one we make: <b>build on this — it won't break under you.</b></p>
 
   <div class="next"><a href="/blog/after-done-roadmap.html">Next: after 1.0 — the roadmap around a stable core →</a></div>
 

--- a/web/blog/you-are-the-message-bus.html
+++ b/web/blog/you-are-the-message-bus.html
@@ -118,7 +118,7 @@
     <p>
       <a href="https://github.com/agentchute/agentchute">agentchute</a> is a small
       Markdown protocol for shared inboxes between AI agents. The spec is one file:
-      <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>.
+      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>.
       The reference CLI is optional. The core idea is that every agent has a
       recipient-owned inbox, and messages are plain Markdown files with a small amount
       of optional metadata.
@@ -423,7 +423,7 @@
 
     <p>
       Or skip the binary — drop
-      <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>
+      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>
       into your project and follow the enrollment block. The whole protocol fits in one
       file.
     </p>

--- a/web/blog/you-are-the-message-bus.html
+++ b/web/blog/you-are-the-message-bus.html
@@ -118,7 +118,7 @@
     <p>
       <a href="https://github.com/agentchute/agentchute">agentchute</a> is a small
       Markdown protocol for shared inboxes between AI agents. The spec is one file:
-      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>.
+      <a href="https://github.com/agentchute/agentchute/blob/v0.1.0/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>.
       The reference CLI is optional. The core idea is that every agent has a
       recipient-owned inbox, and messages are plain Markdown files with a small amount
       of optional metadata.
@@ -423,7 +423,7 @@
 
     <p>
       Or skip the binary — drop
-      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>
+      <a href="https://github.com/agentchute/agentchute/blob/v0.1.0/AGENTCHUTE.md"><code>AGENTCHUTE.md</code></a>
       into your project and follow the enrollment block. The whole protocol fits in one
       file.
     </p>

--- a/web/index.html
+++ b/web/index.html
@@ -321,7 +321,7 @@
       <p class="lbl">code, but not the protocol</p>
       <h2>A real implementation — that you're free to replace.</h2>
       <p style="color:var(--muted);max-width:64ch;font-size:1.04rem;margin:0">
-        agentchute ships a faithful reference implementation: a small Go CLI and a per-agent supervisor that handle delivery, registration, presence, and ordering for you. It is <b style="color:var(--ink)">not</b> the protocol. The protocol is the <a href="#protocol">spec</a> — a directory layout and a filename grammar — and anyone is welcome to write another implementation, in any language, over any transport. The <a href="https://github.com/agentchute/agentchute/tree/main/conformance">conformance vectors</a> are how you prove yours; ours and yours interoperate because both just read and write the same files.
+        agentchute ships a faithful reference implementation: a small Go CLI and a per-agent supervisor that handle delivery, registration, presence, and ordering for you. It is <b style="color:var(--ink)">not</b> the protocol. The protocol is the <a href="#protocol">spec</a> — a directory layout and a filename grammar — and anyone is welcome to write another implementation, in any language, over any transport. The <a href="https://github.com/agentchute/agentchute/tree/v1.5.7/conformance">conformance vectors</a> are how you prove yours; ours and yours interoperate because both just read and write the same files.
       </p>
     </section>
 

--- a/web/spec.html
+++ b/web/spec.html
@@ -20,7 +20,7 @@
     <nav>
       <a href="./">home</a>
       <a href="blog/">blog</a>
-      <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md">full spec</a>
+      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md">full spec</a>
       <a href="https://github.com/agentchute/agentchute">github</a>
     </nav>
   </div>
@@ -32,8 +32,8 @@
   <div class="wrap">
     <h1>The protocol spec</h1>
     <p class="lede">
-      Protocol v2.5 deliberately changes the identity wire while retaining the pull-only primitives. The canonical version is
-      <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md"><code>AGENTCHUTE.md</code> in the repo</a>
+      Protocol v2.5 deliberately changes the identity wire while retaining the pull-only primitives. The latest released version is
+      <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md"><code>AGENTCHUTE.md</code> at v1.5.7</a>
       — it renders cleanly on GitHub with the right anchor links, table of contents, and code highlighting.
       The summary below is a reading guide for what's in each section.
     </p>
@@ -66,14 +66,14 @@
   <div class="wrap">
     <h2>Reading the spec</h2>
     <p>
-      Open <a href="https://github.com/agentchute/agentchute/blob/main/AGENTCHUTE.md"><code>AGENTCHUTE.md</code> on GitHub</a>
+      Open <a href="https://github.com/agentchute/agentchute/blob/v1.5.7/AGENTCHUTE.md"><code>AGENTCHUTE.md</code> on GitHub</a>
       for the full text with anchor links and code highlighting. Or grab it locally:
     </p>
-    <pre><code>curl -fsSL https://raw.githubusercontent.com/agentchute/agentchute/main/AGENTCHUTE.md -O</code></pre>
+    <pre><code>curl -fsSL https://raw.githubusercontent.com/agentchute/agentchute/v1.5.7/AGENTCHUTE.md -O</code></pre>
     <p>
       If you're implementing agentchute in another language or with a non-filesystem
       inbox transport, the protocol primitives in §1 are the contract, and the
-      <a href="https://github.com/agentchute/agentchute/tree/main/conformance">conformance suite</a>
+      <a href="https://github.com/agentchute/agentchute/tree/v1.5.7/conformance">conformance suite</a>
       is the executable spec — any implementation that passes it is conformant. The filesystem
       sections show how the reference CLI maps those primitives to disk. Coordination is
       pull-only: inbox delivery is durable; the recipient discovers messages by polling its


### PR DESCRIPTION
## Summary

- pin the current `web/*.html` spec/conformance links to latest release `v1.5.7`
- pin dated `web/blog/` spec/conformance links to the release contemporaneous with each article
- remove every `main`-pinned spec/conformance URL from the published web surface
- label the spec page target as the latest released version instead of the repository tip

## Decision

Chose option (a), the small hardcoded-tag fix. GitHub's generic latest-release URL redirects to an HTML release page, while `releases/latest/download/...` serves only attached assets; v1.5.7 has binary archives and checksums but no `AGENTCHUTE.md` asset. Option (c) therefore cannot repair today's published link without retroactively mutating the v1.5.7 release.

The sweep found 15 spec/conformance references across eight `web/` files, not only `web/spec.html:72`. The six references in current root pages now resolve through v1.5.7. The nine references in dated blog posts resolve through their contemporaneous releases so historical anchors and claims remain stable. `main`-pinned installer links are intentionally unchanged because they are not spec/protocol publication.

## Anti-rot handoff for PLAN section 5

Add this as a blocking post-release step, after the GitHub Release exists and before declaring the release complete or beginning rollout:

> Update every spec/conformance URL in current root pages (`web/*.html`) to the just-published release tag. Preserve dated `web/blog/` URLs at their contemporaneous release tags. Then run all three checks below. Any `main` spec/conformance target, any root-page target that differs from the latest release, or any unresolved spec fragment blocks release completion and rollout.

```sh
test -z "$(rg -n 'github\.com/agentchute/agentchute/blob/main/AGENTCHUTE\.md|raw\.githubusercontent\.com/agentchute/agentchute/main/AGENTCHUTE\.md|github\.com/agentchute/agentchute/tree/main/conformance' web --glob '*.html' || true)"

latest=$(gh release view --repo agentchute/agentchute --json tagName --jq .tagName)
refs=$(rg -o --no-filename 'https://[^" <]+' web/*.html |
  rg 'raw\.githubusercontent\.com/agentchute/agentchute/[^/]+/AGENTCHUTE\.md|github\.com/agentchute/agentchute/(blob/[^/]+/AGENTCHUTE\.md|tree/[^/]+/conformance)')
test -n "$refs"
bad=$(printf '%s\n' "$refs" | grep -Fv "/$latest/" || true)
test -z "$bad"

anchors=$(rg -o --no-filename 'https://github\.com/agentchute/agentchute/blob/[^/]+/AGENTCHUTE\.md#[^" <]+' web --glob '*.html')
test -n "$anchors"
printf '%s\n' "$anchors" |
while IFS= read -r url; do
  tagged=${url#*blob/}
  tag=${tagged%%/*}
  anchor=${url##*#}
  gh api "repos/agentchute/agentchute/contents/AGENTCHUTE.md?ref=$tag" \
    -H 'Accept: application/vnd.github.html+json' |
    rg -Fq "href=\"#$anchor\"" || {
      printf 'broken spec anchor: %s\n' "$url" >&2
      exit 1
    }
done
```

These checks were executed against the branch: no `main` spec/conformance targets under `web/`; `latest=v1.5.7`; six current-page references with zero mismatches; five versioned spec fragments all resolve in GitHub's rendered HTML.

## Verification

- `git diff --check`
- no `main`-pinned spec/conformance reference remains under `web/`
- historical tags and named anchors resolve for all dated blog targets
- GitHub contents API resolves both `AGENTCHUTE.md` and `conformance/` at v1.5.7
- `sh tools/fact-sweep.sh`
- `sh tools/test.sh`

Refs #154.
