### PR TITLE
feat: add SSH hub wire session

### DIFF
--- a/conformance/CONFORMANCE.md
+++ b/conformance/CONFORMANCE.md
@@ -14,6 +14,14 @@ Four deliverables in one package:
 
 Pure stdlib, no dependencies.
 
+## Lease and hub-wire vectors
+
+`vectors/lease.json` and `vectors/wire.json` extend the executable contract
+with lease/fencing and session-lifecycle cases. Their reference drivers live in
+the root module under `internal/spectest`, because the standalone conformance
+module cannot import the reference implementation's `internal/*` packages.
+Other bindings should drive the same JSON through their own harness.
+
 ## Run
 
 ```sh

--- a/conformance/vectors/lease.json
+++ b/conformance/vectors/lease.json
@@ -1,0 +1,9 @@
+{
+  "schema": "agentchute-lease-vectors-v1",
+  "vectors": [
+    {"id":"L1","kind":"fresh_acquire_fails_closed","name":"a second acquire while fresh fails closed"},
+    {"id":"L2","kind":"fenced_holder_writes_nothing","name":"a fenced holder cannot heartbeat or mint"},
+    {"id":"L3","kind":"release_token_checked","name":"release never deletes a successor claim"},
+    {"id":"L4","kind":"stale_reclaim_fences_old","name":"stale pid-dead reclaim succeeds and kills the old token"}
+  ]
+}

--- a/conformance/vectors/wire.json
+++ b/conformance/vectors/wire.json
@@ -1,0 +1,11 @@
+{
+  "schema": "agentchute-wire-vectors-v1",
+  "vectors": [
+    {"id":"W1","kind":"disconnect_after_claim","name":"disconnect after claim leaves residue that redelivers"},
+    {"id":"W2","kind":"disconnect_after_send","name":"response loss after send leaves exactly one delivery"},
+    {"id":"W3","kind":"reclaim_during_send","name":"reclaim before the send fence check writes nothing"},
+    {"id":"W4","kind":"identity_mismatch","name":"identity mismatch closes during hello"},
+    {"id":"W5","kind":"version_mismatch","name":"version mismatch closes during hello"},
+    {"id":"W6","kind":"unreadable_claimed_residue","name":"unreadable claimed residue reports claimed_held"}
+  ]
+}

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -41,6 +41,7 @@ func init() {
 		"hooks":        cmdHooks,
 		"clean":        cmdClean,
 		"guard":        cmdGuard,
+		"hub":          cmdHub,
 		"turn-end":     cmdTurnEnd,
 	}
 }
@@ -304,6 +305,9 @@ func extractGlobalFlag(args []string, name string) (value string, rest []string,
 func commandNamesSorted() []string {
 	out := make([]string, 0, len(commandHandlers))
 	for name := range commandHandlers {
+		if name == "hub" {
+			continue
+		}
 		out = append(out, name)
 	}
 	sort.Strings(out)

--- a/internal/cli/hub.go
+++ b/internal/cli/hub.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+)
+
+func cmdHub(args []string) error {
+	if len(args) == 0 {
+		return hubUsage(fmt.Errorf("expected hub subcommand: session"))
+	}
+	switch args[0] {
+	case "session":
+		return cmdHubSession(args[1:])
+	case "-h", "--help", "help":
+		return hubUsage(flag.ErrHelp)
+	default:
+		return hubUsage(fmt.Errorf("unknown hub subcommand %q", args[0]))
+	}
+}
+
+func cmdHubSession(args []string) error {
+	fs := flag.NewFlagSet("hub session", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var agent, pool, poolID string
+	fs.StringVar(&agent, "agent", "", "agent id pinned by the authorized key")
+	fs.StringVar(&pool, "pool", "", "absolute hub control-repo path")
+	fs.StringVar(&poolID, "pool-id", "", "pool identity pinned by the authorized key")
+	if err := fs.Parse(args); err != nil {
+		return hubSessionUsage(err)
+	}
+	if fs.NArg() != 0 {
+		return hubSessionUsage(fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")))
+	}
+	if agent == "" || pool == "" || poolID == "" {
+		return hubSessionUsage(fmt.Errorf("--agent, --pool, and --pool-id are required"))
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGHUP)
+	defer stop()
+	transport := &stdioHubTransport{in: os.Stdin, out: os.Stdout}
+	return serveHubSession(ctx, transport, hubSessionOptions{
+		Agent:  agent,
+		Pool:   pool,
+		PoolID: poolID,
+		HubBin: version,
+	})
+}
+
+func hubUsage(err error) error {
+	return fmt.Errorf("%w\n\nUsage:\n  agentchute hub session --agent <id> --pool <absolute-path> --pool-id <12-hex>", err)
+}
+
+func hubSessionUsage(err error) error {
+	return fmt.Errorf("%w\n\nUsage:\n  agentchute hub session --agent <id> --pool <absolute-path> --pool-id <12-hex>", err)
+}

--- a/internal/cli/hub_session.go
+++ b/internal/cli/hub_session.go
@@ -1,0 +1,516 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/hubwire"
+	"github.com/agentchute/agentchute/internal/loop"
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+// HubSessionTransport is the carriage contract shared by the in-process M3
+// conformance driver and M6's sshd-backed driver.
+type HubSessionTransport interface {
+	io.ReadWriter
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
+	Close() error
+}
+
+type hubSessionTransport = HubSessionTransport
+
+// HubSessionConfig is the forced-command identity pinned by authorized_keys.
+// It intentionally contains no discovery inputs or client-selected actor.
+type HubSessionConfig struct {
+	Agent  string
+	Pool   string
+	PoolID string
+	HubBin string
+}
+
+// ServeHubSession runs one forced-command session through the production
+// dispatcher. The internal-only export lets transport conformance tests reuse
+// the exact session implementation without copying it.
+func ServeHubSession(ctx context.Context, transport HubSessionTransport, cfg HubSessionConfig) error {
+	return serveHubSession(ctx, transport, hubSessionOptions{Agent: cfg.Agent, Pool: cfg.Pool, PoolID: cfg.PoolID, HubBin: cfg.HubBin})
+}
+
+type stdioHubTransport struct {
+	in, out *os.File
+}
+
+func (s *stdioHubTransport) Read(p []byte) (int, error)  { return s.in.Read(p) }
+func (s *stdioHubTransport) Write(p []byte) (int, error) { return s.out.Write(p) }
+func (s *stdioHubTransport) SetReadDeadline(t time.Time) error {
+	return s.in.SetReadDeadline(t)
+}
+func (s *stdioHubTransport) SetWriteDeadline(t time.Time) error {
+	return s.out.SetWriteDeadline(t)
+}
+func (s *stdioHubTransport) Close() error {
+	errIn := s.in.Close()
+	errOut := s.out.Close()
+	return errors.Join(errIn, errOut)
+}
+
+type hubSessionOptions struct {
+	Agent  string
+	Pool   string
+	PoolID string
+	HubBin string
+	Timing hubSessionTiming
+
+	// afterAcquire is an invocation-scoped failure-injection hook used to prove
+	// panic cleanup. It is nil in production and never shared across sessions.
+	afterAcquire func()
+}
+
+type hubSessionTiming struct {
+	Hello           time.Duration
+	ChannelRead     time.Duration
+	OneShotRead     time.Duration
+	Write           time.Duration
+	OneShotLifetime time.Duration
+}
+
+func (t hubSessionTiming) withDefaults() hubSessionTiming {
+	if t.Hello == 0 {
+		t.Hello = 10 * time.Second
+	}
+	if t.ChannelRead == 0 {
+		t.ChannelRead = 20 * time.Second
+	}
+	if t.OneShotRead == 0 {
+		t.OneShotRead = 30 * time.Second
+	}
+	if t.Write == 0 {
+		t.Write = 30 * time.Second
+	}
+	if t.OneShotLifetime == 0 {
+		t.OneShotLifetime = 10 * time.Minute
+	}
+	return t
+}
+
+type hubSession struct {
+	transport    hubSessionTransport
+	reader       *hubwire.Reader
+	writer       *hubwire.Writer
+	cfg          *loop.Config
+	ctx          op.Context
+	channel      *op.Channel
+	timing       hubSessionTiming
+	lastID       int64
+	mode         string
+	afterAcquire func()
+	oneShotTimer *time.Timer
+}
+
+func serveHubSession(ctx context.Context, transport hubSessionTransport, opts hubSessionOptions) (returnErr error) {
+	timing := opts.Timing.withDefaults()
+	s := &hubSession{transport: transport, reader: hubwire.NewReader(transport), writer: hubwire.NewWriter(transport), timing: timing, afterAcquire: opts.afterAcquire}
+	defer func() {
+		if s.channel != nil {
+			if err := s.channel.ReleaseLease(); err != nil && !errors.Is(err, op.ErrFenced) && returnErr == nil {
+				returnErr = err
+			}
+		}
+		_ = transport.Close()
+		if recovered := recover(); recovered != nil {
+			returnErr = fmt.Errorf("hub session panic: %v", recovered)
+		}
+	}()
+
+	pool, cfg, pool12, err := validateHubPool(opts.Pool, opts.PoolID)
+	if err != nil {
+		_ = s.writeError(0, err)
+		return nil
+	}
+	if err := loop.ValidateAgentID(opts.Agent); err != nil {
+		err = &hubwire.ProtocolError{Code: hubwire.CodeIdentity, Msg: fmt.Sprintf("invalid pinned agent id: %v", err)}
+		_ = s.writeError(0, err)
+		return nil
+	}
+	s.cfg = cfg
+	s.ctx = op.Context{ActorID: opts.Agent}
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = transport.Close()
+		case <-done:
+		}
+	}()
+	s.oneShotTimer = time.AfterFunc(timing.OneShotLifetime, func() { _ = transport.Close() })
+	defer s.oneShotTimer.Stop()
+
+	if err := s.setReadDeadline(timing.Hello); err != nil {
+		return err
+	}
+	raw, err := s.reader.Read()
+	if err != nil {
+		if !errors.Is(err, io.EOF) {
+			_ = s.writeError(0, err)
+		}
+		return nil
+	}
+	if raw.T != "hello" || raw.HasBody {
+		_ = s.writeError(raw.ID, &hubwire.ProtocolError{Code: hubwire.CodeMalformedFrame, Msg: "hello must be the first frame and cannot carry a body"})
+		return nil
+	}
+	var hello hubwire.Hello
+	if err := raw.Decode(&hello); err != nil {
+		_ = s.writeError(raw.ID, err)
+		return nil
+	}
+	helloOK, err := hubwire.NegotiateHello(hello, hubwire.HandshakeOptions{
+		PinnedAgent: opts.Agent,
+		Pool:        pool,
+		Pool12:      pool12,
+		HubBin:      opts.HubBin,
+	})
+	if err != nil {
+		_ = s.writeError(hello.ID, err)
+		return nil
+	}
+	s.lastID = hello.ID
+	if err := s.write(helloOK, nil); err != nil {
+		return err
+	}
+
+	for {
+		readFor := timing.OneShotRead
+		if s.mode == "channel" {
+			readFor = timing.ChannelRead
+		}
+		if err := s.setReadDeadline(readFor); err != nil {
+			return err
+		}
+		raw, err := s.reader.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) || ctx.Err() != nil {
+				return nil
+			}
+			_ = s.writeError(raw.ID, err)
+			return nil
+		}
+		if raw.ID <= s.lastID {
+			if err := s.writeError(raw.ID, op.ErrOrder); err != nil {
+				return err
+			}
+			continue
+		}
+		s.lastID = raw.ID
+		terminal, err := s.dispatch(raw)
+		if err != nil {
+			return err
+		}
+		if terminal {
+			return nil
+		}
+	}
+}
+
+func (s *hubSession) dispatch(raw hubwire.RawFrame) (bool, error) {
+	if raw.T == "lease-acquire" {
+		if raw.HasBody || s.mode != "" {
+			return false, s.writeError(raw.ID, op.ErrOrder)
+		}
+		var req hubwire.LeaseAcquire
+		if err := raw.Decode(&req); err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		s.mode = "channel"
+		s.oneShotTimer.Stop()
+		s.channel = op.NewChannel(s.cfg, s.ctx, op.ChannelOpts{HeartbeatTemplate: nil})
+		resp, err := s.channel.AcquireLease(op.LeaseReq{})
+		if err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		if err := s.write(hubwire.LeaseOK{ResponseBase: hubwire.ResponseBase{T: "lease-ok", Re: raw.ID}, Token: resp.Token}, nil); err != nil {
+			return true, err
+		}
+		if s.afterAcquire != nil {
+			s.afterAcquire()
+		}
+		return false, nil
+	}
+	if raw.T == "tick" || raw.T == "lease-release" {
+		if raw.HasBody || s.mode != "channel" || s.channel == nil {
+			return false, s.writeError(raw.ID, op.ErrOrder)
+		}
+	}
+	if s.mode == "channel" && raw.T != "register" && raw.T != "tick" && raw.T != "lease-release" {
+		if raw.T == "hello" {
+			return false, s.writeError(raw.ID, op.ErrOrder)
+		}
+		return false, s.unsupported(raw.ID, raw.T)
+	}
+
+	switch raw.T {
+	case "send":
+		if !raw.HasBody {
+			return true, s.writeError(raw.ID, &hubwire.ProtocolError{Code: hubwire.CodeMalformedFrame, Msg: "send requires a body trailer"})
+		}
+		var req hubwire.Send
+		if err := raw.Decode(&req); err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		resp, err := op.Send(s.cfg, s.ctx, op.SendReq{To: req.To, Content: raw.Body, Ask: req.Ask, ReplyBy: time.Duration(req.ReplyByS) * time.Second, ServeToken: req.ServeToken})
+		if err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		return true, s.write(hubwire.SendOK{ResponseBase: hubwire.ResponseBase{T: "send-ok", Re: raw.ID}, Filename: resp.Filename, Ref: resp.Ref, Committed: resp.Committed, DurabilityNote: resp.DurabilityNote, OwedNote: resp.OwedNote}, nil)
+	case "check":
+		if raw.HasBody {
+			return true, s.malformed(raw.ID, "check cannot carry a body")
+		}
+		var req hubwire.Check
+		if err := raw.Decode(&req); err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		sum, err := op.Claim(s.cfg, s.ctx, op.ClaimReq{Limit: req.Limit, NoArchive: req.NoArchive}, s.emitter(raw.ID, false))
+		if err != nil {
+			if sum.Redelivered > 0 {
+				err = &hubwire.ProtocolError{Code: hubwire.CodeFor(err), Msg: err.Error(), ClaimedHeld: true}
+			}
+			return true, s.writeError(raw.ID, err)
+		}
+		return true, s.write(hubwire.CheckOK{ResponseBase: hubwire.ResponseBase{T: "check-ok", Re: raw.ID}, Claimed: sum.Claimed, Redelivered: sum.Redelivered, Quarantined: sum.Quarantined, OwedExpired: sum.OwedExpired}, nil)
+	case "ack":
+		if raw.HasBody {
+			return true, s.malformed(raw.ID, "ack cannot carry a body")
+		}
+		sum, err := op.Ack(s.cfg, s.ctx, op.AckReq{}, s.emitter(raw.ID, false))
+		if err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		return true, s.write(hubwire.AckOK{ResponseBase: hubwire.ResponseBase{T: "ack-ok", Re: raw.ID}, Acked: sum.Acked, GateClear: sum.GateClear, BlockReasons: sum.BlockReasons}, nil)
+	case "register":
+		if raw.HasBody {
+			return true, s.malformed(raw.ID, "register request cannot carry a body")
+		}
+		var req hubwire.Register
+		if err := raw.Decode(&req); err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		opReq := op.RegisterReq{Vendor: req.Vendor, Host: req.Host, Bio: req.Bio, WorkingRepos: req.WorkingRepos, Announce: req.Announce, Sweep: req.Sweep, ServeToken: req.ServeToken}
+		var resp op.RegisterResp
+		var err error
+		if s.mode == "channel" {
+			resp, err = s.channel.Register(opReq)
+		} else {
+			resp, err = op.Register(s.cfg, s.ctx, opReq, time.Now().UTC())
+		}
+		if err != nil {
+			return s.mode != "channel", s.writeError(raw.ID, err)
+		}
+		wireResp, body := registerResponse(raw.ID, resp)
+		return s.mode != "channel", s.write(wireResp, body)
+	case "status":
+		if raw.HasBody {
+			return true, s.malformed(raw.ID, "status cannot carry a body")
+		}
+		resp, err := op.Status(s.cfg, s.ctx, op.StatusReq{}, s.emitter(raw.ID, false))
+		if err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		if err := s.setWriteDeadline(); err != nil {
+			return true, err
+		}
+		return true, s.writer.WriteStatus(raw.ID, resp)
+	case "gate":
+		if raw.HasBody {
+			return true, s.malformed(raw.ID, "gate cannot carry a body")
+		}
+		var req hubwire.Gate
+		if err := raw.Decode(&req); err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		resp, err := op.Gate(s.cfg, s.ctx, op.GateReq{Phase: req.Phase, RequireConfirm: req.RequireConfirm, AckStaleReg: req.AckStaleReg})
+		if err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		return true, s.write(hubwire.GateOK{ResponseBase: hubwire.ResponseBase{T: "gate-ok", Re: raw.ID}, GateResp: resp}, nil)
+	case "pending":
+		if raw.HasBody {
+			return true, s.malformed(raw.ID, "pending cannot carry a body")
+		}
+		var req hubwire.Pending
+		if err := raw.Decode(&req); err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		resp, err := op.Pending(s.cfg, s.ctx, op.PendingReq{ShowBody: req.ShowBody}, s.emitter(raw.ID, req.ShowBody))
+		if err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		return true, s.write(hubwire.PendingOK{ResponseBase: hubwire.ResponseBase{T: "pending-ok", Re: raw.ID}, Unread: resp.Unread, Owed: resp.Owed, Malformed: resp.Malformed, NeedsBoot: resp.NeedsBoot}, nil)
+	case "clean-owed":
+		if raw.HasBody {
+			return true, s.malformed(raw.ID, "clean-owed cannot carry a body")
+		}
+		var req hubwire.CleanOwed
+		if err := raw.Decode(&req); err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		resp, err := op.CleanOwed(s.cfg, s.ctx, op.CleanOwedReq{Apply: req.Apply})
+		if err != nil {
+			return true, s.writeError(raw.ID, err)
+		}
+		return true, s.write(hubwire.CleanOwedOK{ResponseBase: hubwire.ResponseBase{T: "clean-owed-ok", Re: raw.ID}, Agent: resp.Agent, Pruned: resp.Pruned, Applied: resp.Applied}, nil)
+	case "tick":
+		resp, err := s.channel.Tick(op.TickReq{})
+		if err != nil {
+			return errors.Is(err, op.ErrFenced), s.writeError(raw.ID, err)
+		}
+		return false, s.write(hubwire.TickOK{ResponseBase: hubwire.ResponseBase{T: "tick-ok", Re: raw.ID}, Pending: resp.Pending, Skipped: resp.Skipped, Swept: resp.Swept, Warnings: resp.Warnings}, nil)
+	case "lease-release":
+		err := s.channel.ReleaseLease()
+		if err != nil && !errors.Is(err, op.ErrFenced) {
+			return true, s.writeError(raw.ID, err)
+		}
+		return true, s.write(hubwire.ReleaseOK{ResponseBase: hubwire.ResponseBase{T: "release-ok", Re: raw.ID}}, nil)
+	case "hello":
+		return false, s.writeError(raw.ID, op.ErrOrder)
+	default:
+		return false, s.unsupported(raw.ID, raw.T)
+	}
+}
+
+func (s *hubSession) emitter(re int64, pendingBody bool) func(op.Event) error {
+	return func(event op.Event) error {
+		if !event.Valid() {
+			return fmt.Errorf("invalid op event union")
+		}
+		switch {
+		case event.Message != nil:
+			m := event.Message
+			body := []byte(nil)
+			if pendingBody || m.Body != nil {
+				body = m.Body
+			}
+			return s.write(hubwire.Message{ResponseBase: hubwire.ResponseBase{T: "msg", Re: re}, Filename: m.Filename, Sender: m.Sender, Stamp: m.Stamp, Redelivered: m.Redelivered, ReplyRequired: m.ReplyRequired, ReplyRef: m.ReplyRef}, body)
+		case event.Note != nil:
+			if err := hubwire.ValidateNoteLevel(event.Note.Level); err != nil {
+				return err
+			}
+			return s.write(hubwire.Note{ResponseBase: hubwire.ResponseBase{T: "note", Re: re}, Level: event.Note.Level, Msg: event.Note.Msg}, nil)
+		case event.Owed != nil:
+			o := event.Owed
+			return s.write(hubwire.OwedItem{ResponseBase: hubwire.ResponseBase{T: "owed-item", Re: re}, To: o.To, From: o.From, Seq: o.Seq, Stamp: o.Stamp, Suffix: o.Suffix, By: o.By, RecordedAt: o.RecordedAt, Ref: o.Ref}, nil)
+		default:
+			a := event.Ack
+			return s.write(hubwire.AckItem{ResponseBase: hubwire.ResponseBase{T: "ack-item", Re: re}, Filename: a.Filename, ArchivePath: a.ArchivePath}, nil)
+		}
+	}
+}
+
+func registerResponse(re int64, resp op.RegisterResp) (hubwire.RegisterOK, []byte) {
+	warnings := append([]string(nil), resp.Warnings...)
+	if warnings == nil {
+		warnings = []string{}
+	}
+	var announce *hubwire.Announce
+	if resp.Announce != nil {
+		aw := append([]string(nil), resp.Announce.Warnings...)
+		if aw == nil {
+			aw = []string{}
+		}
+		announce = &hubwire.Announce{Sent: resp.Announce.Sent, Total: resp.Announce.Total, Warnings: aw}
+	}
+	return hubwire.RegisterOK{
+		ResponseBase: hubwire.ResponseBase{T: "register-ok", Re: re},
+		Announce:     announce, Pending: resp.Pending,
+		Reg:      hubwire.Registration{AgentID: resp.Reg.AgentID, ProtocolVersion: resp.Reg.ProtocolVersion, Vendor: resp.Reg.Vendor, ControlRepo: resp.Reg.ControlRepo, WorkingRepos: resp.Reg.WorkingRepos, Host: resp.Reg.Host, LastSeen: resp.Reg.LastSeen},
+		InboxDir: resp.InboxDir, Refreshed: resp.Refreshed, ExistingFound: resp.ExistingFound, ResolvedHost: resp.ResolvedHost, Warnings: warnings,
+	}, []byte(resp.Reg.Body)
+}
+
+func (s *hubSession) malformed(re int64, msg string) error {
+	return s.writeError(re, &hubwire.ProtocolError{Code: hubwire.CodeMalformedFrame, Msg: msg})
+}
+
+func (s *hubSession) unsupported(re int64, t string) error {
+	return s.writeError(re, &hubwire.ProtocolError{Code: hubwire.CodeUnsupported, Msg: fmt.Sprintf("unsupported frame type %q", t)})
+}
+
+func (s *hubSession) writeError(re int64, err error) error {
+	return s.write(hubwire.NewError(re, err), nil)
+}
+
+func (s *hubSession) write(frame any, body []byte) error {
+	if err := s.setWriteDeadline(); err != nil {
+		return err
+	}
+	return s.writer.Write(frame, body)
+}
+
+func (s *hubSession) setReadDeadline(after time.Duration) error {
+	err := s.transport.SetReadDeadline(time.Now().Add(after))
+	if errors.Is(err, os.ErrNoDeadline) {
+		return nil
+	}
+	return err
+}
+
+func (s *hubSession) setWriteDeadline() error {
+	err := s.transport.SetWriteDeadline(time.Now().Add(s.timing.Write))
+	if errors.Is(err, os.ErrNoDeadline) {
+		return nil
+	}
+	return err
+}
+
+var poolIDPattern = regexp.MustCompile(`^[0-9a-f]{12}\n$`)
+
+func validateHubPool(poolArg, expectedID string) (string, *loop.Config, string, error) {
+	abs, err := filepath.Abs(poolArg)
+	if err != nil {
+		return "", nil, "", &hubwire.ProtocolError{Code: hubwire.CodePoolNotFound, Msg: fmt.Sprintf("hub: the authorized pool path %s no longer resolves on the hub", poolArg)}
+	}
+	pool := filepath.Clean(abs)
+	if resolved, err := filepath.EvalSymlinks(pool); err == nil {
+		pool = resolved
+	}
+	spec, specErr := os.Stat(filepath.Join(pool, "AGENTCHUTE.md"))
+	loopDir := filepath.Join(pool, ".agentchute", "loop")
+	loopInfo, loopErr := os.Stat(loopDir)
+	if specErr != nil || loopErr != nil || !spec.Mode().IsRegular() || !loopInfo.IsDir() {
+		return "", nil, "", &hubwire.ProtocolError{Code: hubwire.CodePoolNotFound, Msg: fmt.Sprintf("hub: the authorized pool path %s no longer resolves on the hub", poolArg)}
+	}
+	cfg := &loop.Config{ControlRepo: pool, LoopDir: loopDir, Vendor: "agentchute", ControlRepoOrigin: "hub", LoopDirOrigin: "hub"}
+	identityPath := filepath.Join(loopDir, "state", "pool.id")
+	data, err := loop.ReadFileLimit(identityPath, 64)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil, "", poolMismatch(pool, expectedID, "<absent>")
+	}
+	if err != nil {
+		return "", nil, "", invalidPoolID(identityPath)
+	}
+	info, err := os.Lstat(identityPath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 || !poolIDPattern.Match(data) {
+		return "", nil, "", invalidPoolID(identityPath)
+	}
+	actual := string(data[:12])
+	if actual != expectedID {
+		return "", nil, "", poolMismatch(pool, expectedID, actual)
+	}
+	return pool, cfg, actual, nil
+}
+
+func invalidPoolID(path string) error {
+	return &hubwire.ProtocolError{Code: hubwire.CodePoolIDInvalid, Msg: fmt.Sprintf("hub: %s is not a valid pool identity (must be a regular 0600 file containing exactly 12 lowercase hex characters)", path)}
+}
+
+func poolMismatch(pool, expected, actual string) error {
+	return &hubwire.ProtocolError{Code: hubwire.CodePoolMismatch, Msg: fmt.Sprintf("hub: this key is authorized for pool id %s, but %s on the hub reports pool id %s (or has no state/pool.id at all)", expected, pool, actual)}
+}

--- a/internal/cli/hub_session.go
+++ b/internal/cli/hub_session.go
@@ -304,12 +304,17 @@ func (s *hubSession) dispatch(raw hubwire.RawFrame) (bool, error) {
 			return true, s.writeError(raw.ID, err)
 		}
 		opReq := op.RegisterReq{Vendor: req.Vendor, Host: req.Host, Bio: req.Bio, WorkingRepos: req.WorkingRepos, Announce: req.Announce, Sweep: req.Sweep, ServeToken: req.ServeToken}
+		validateResponse := func(resp op.RegisterResp) error {
+			wireResp, body := registerResponse(raw.ID, resp)
+			_, err := hubwire.Encode(wireResp, body)
+			return err
+		}
 		var resp op.RegisterResp
 		var err error
 		if s.mode == "channel" {
-			resp, err = s.channel.Register(opReq)
+			resp, err = s.channel.RegisterWithPrecommitValidation(opReq, validateResponse)
 		} else {
-			resp, err = op.Register(s.cfg, s.ctx, opReq, time.Now().UTC())
+			resp, err = op.RegisterWithPrecommitValidation(s.cfg, s.ctx, opReq, time.Now().UTC(), validateResponse)
 		}
 		if err != nil {
 			return s.mode != "channel", s.writeError(raw.ID, err)

--- a/internal/cli/hub_session_test.go
+++ b/internal/cli/hub_session_test.go
@@ -1,0 +1,734 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/hubwire"
+	"github.com/agentchute/agentchute/internal/loop"
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+const fixturePoolID = "0123456789ab"
+
+type runningHubSession struct {
+	conn   net.Conn
+	reader *hubwire.Reader
+	writer *hubwire.Writer
+	done   <-chan error
+	cancel context.CancelFunc
+}
+
+func newHubPool(t *testing.T) (string, *loop.Config) {
+	t.Helper()
+	pool := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pool, "AGENTCHUTE.md"), []byte("# spec\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loopDir := filepath.Join(pool, ".agentchute", "loop")
+	if err := os.MkdirAll(filepath.Join(loopDir, "state"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeFixturePoolID(t, pool)
+	return pool, &loop.Config{ControlRepo: pool, LoopDir: loopDir, Vendor: "agentchute"}
+}
+
+// writeFixturePoolID is the sole M3 fixture writer. Production does not mint
+// pool.id until M5.
+func writeFixturePoolID(t *testing.T, poolDir string) string {
+	t.Helper()
+	path := filepath.Join(poolDir, ".agentchute", "loop", "state", "pool.id")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(f, fixturePoolID+"\n"); err != nil {
+		_ = f.Close()
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return fixturePoolID
+}
+
+func enrollHubAgent(t *testing.T, cfg *loop.Config, id string) {
+	t.Helper()
+	vendor := "test"
+	if _, err := op.Register(cfg, op.Context{ActorID: id}, op.RegisterReq{Vendor: &vendor, Host: "laptop"}, time.Now().UTC()); err != nil {
+		t.Fatalf("enroll %s: %v", id, err)
+	}
+}
+
+func deliverHubMessage(t *testing.T, cfg *loop.Config, from, to, body string) loop.TsID {
+	t.Helper()
+	id, _, err := loop.SendTsMessageWithCommit(cfg, from, to, loop.ComposeMessage(from, "", body), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+func startHubSession(t *testing.T, pool, agent string, timing hubSessionTiming, mutate func(net.Conn) hubSessionTransport, afterAcquire func()) *runningHubSession {
+	t.Helper()
+	server, client := net.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	var transport hubSessionTransport = server
+	if mutate != nil {
+		transport = mutate(server)
+	}
+	go func() {
+		done <- serveHubSession(ctx, transport, hubSessionOptions{Agent: agent, Pool: pool, PoolID: fixturePoolID, HubBin: "test", Timing: timing, afterAcquire: afterAcquire})
+	}()
+	s := &runningHubSession{conn: client, reader: hubwire.NewReader(client), writer: hubwire.NewWriter(client), done: done, cancel: cancel}
+	t.Cleanup(func() {
+		cancel()
+		_ = client.Close()
+	})
+	return s
+}
+
+func helloHub(t *testing.T, s *runningHubSession, agent string, minV int) hubwire.HelloOK {
+	t.Helper()
+	if err := s.writer.Write(hubwire.Hello{RequestBase: hubwire.RequestBase{T: "hello", ID: 1}, Proto: hubwire.Protocol, V: 1, MinV: minV, Agent: agent, Bin: "test"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := s.reader.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw.T == "error" {
+		var e hubwire.Error
+		_ = raw.Decode(&e)
+		t.Fatalf("hello error: %+v", e)
+	}
+	var resp hubwire.HelloOK
+	if err := raw.Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func readUntil(t *testing.T, s *runningHubSession, terminal string) []hubwire.RawFrame {
+	t.Helper()
+	var frames []hubwire.RawFrame
+	for {
+		raw, err := s.reader.Read()
+		if err != nil {
+			t.Fatalf("read until %s: %v", terminal, err)
+		}
+		frames = append(frames, raw)
+		if raw.T == terminal || raw.T == "error" {
+			return frames
+		}
+	}
+}
+
+func TestHubSessionChannelHappyPathAndOrder(t *testing.T) {
+	pool, cfg := newHubPool(t)
+	s := startHubSession(t, pool, "codex", hubSessionTiming{}, nil, nil)
+	hello := helloHub(t, s, "codex", 1)
+	resolvedPool, err := filepath.EvalSymlinks(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hello.Pool12 != fixturePoolID || hello.Pool != resolvedPool || !hello.Writable {
+		t.Fatalf("hello = %+v", hello)
+	}
+
+	if err := s.writer.Write(hubwire.LeaseAcquire{RequestBase: hubwire.RequestBase{T: "lease-acquire", ID: 2}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := s.reader.Read()
+	if err != nil || raw.T != "lease-ok" {
+		t.Fatalf("lease = %s, %v", raw.T, err)
+	}
+
+	// A tick before this channel's own register is E_ORDER and the session
+	// survives so the client can complete the required startup sequence.
+	if err := s.writer.Write(hubwire.Tick{RequestBase: hubwire.RequestBase{T: "tick", ID: 3}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = s.reader.Read()
+	if err != nil || raw.T != "error" {
+		t.Fatalf("early tick = %s, %v", raw.T, err)
+	}
+	var order hubwire.Error
+	_ = raw.Decode(&order)
+	if order.Code != "E_ORDER" {
+		t.Fatalf("early tick code = %s", order.Code)
+	}
+
+	vendor := "openai"
+	if err := s.writer.Write(hubwire.Register{RequestBase: hubwire.RequestBase{T: "register", ID: 4}, Vendor: &vendor, Host: "m5"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = s.reader.Read()
+	if err != nil || raw.T != "register-ok" || !raw.HasBody {
+		t.Fatalf("register = %s body=%v, %v", raw.T, raw.HasBody, err)
+	}
+	if _, err := loop.ReadRegistration(cfg.AgentRegistrationPath("codex")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.writer.Write(hubwire.Tick{RequestBase: hubwire.RequestBase{T: "tick", ID: 5}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = s.reader.Read()
+	if err != nil || raw.T != "tick-ok" {
+		t.Fatalf("tick = %s, %v", raw.T, err)
+	}
+	var tick hubwire.TickOK
+	_ = raw.Decode(&tick)
+	if tick.Warnings == nil {
+		t.Fatal("tick warnings must be present")
+	}
+
+	if err := s.writer.Write(hubwire.LeaseRelease{RequestBase: hubwire.RequestBase{T: "lease-release", ID: 6}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = s.reader.Read()
+	if err != nil || raw.T != "release-ok" {
+		t.Fatalf("release = %s, %v", raw.T, err)
+	}
+	if err := <-s.done; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(cfg.AgentStateDir("codex"), "serve.claim")); !os.IsNotExist(err) {
+		t.Fatalf("claim remains: %v", err)
+	}
+}
+
+func TestHubSessionEveryOneShotOp(t *testing.T) {
+	pool, cfg := newHubPool(t)
+	enrollHubAgent(t, cfg, "codex")
+	enrollHubAgent(t, cfg, "grok")
+
+	run := func(agent string, request any, body []byte, terminal string) []hubwire.RawFrame {
+		t.Helper()
+		s := startHubSession(t, pool, agent, hubSessionTiming{}, nil, nil)
+		helloHub(t, s, agent, 1)
+		if err := s.writer.Write(request, body); err != nil {
+			t.Fatal(err)
+		}
+		frames := readUntil(t, s, terminal)
+		if frames[len(frames)-1].T == "error" {
+			var e hubwire.Error
+			_ = frames[len(frames)-1].Decode(&e)
+			t.Fatalf("%s error: %+v", terminal, e)
+		}
+		return frames
+	}
+
+	run("codex", hubwire.Send{RequestBase: hubwire.RequestBase{T: "send", ID: 2}, To: "grok"}, loop.ComposeMessage("codex", "", "hello"), "send-ok")
+	msgs, _, err := loop.ListInboxMessagesWithSkipped(cfg.AgentInboxDir("grok"))
+	if err != nil || len(msgs) != 1 {
+		t.Fatalf("send state: %d, %v", len(msgs), err)
+	}
+	frames := run("grok", hubwire.Check{RequestBase: hubwire.RequestBase{T: "check", ID: 2}}, nil, "check-ok")
+	if frames[0].T != "msg" || !frames[0].HasBody {
+		t.Fatalf("check stream = %v", frameTypes(frames))
+	}
+	frames = run("grok", hubwire.Ack{RequestBase: hubwire.RequestBase{T: "ack", ID: 2}}, nil, "ack-ok")
+	if frames[0].T != "ack-item" {
+		t.Fatalf("ack stream = %v", frameTypes(frames))
+	}
+	run("codex", hubwire.Status{RequestBase: hubwire.RequestBase{T: "status", ID: 2}}, nil, "status-ok")
+	run("codex", hubwire.Gate{RequestBase: hubwire.RequestBase{T: "gate", ID: 2}, Phase: op.GatePhaseFinish}, nil, "gate-ok")
+	deliverHubMessage(t, cfg, "grok", "codex", "pending")
+	frames = run("codex", hubwire.Pending{RequestBase: hubwire.RequestBase{T: "pending", ID: 2}, ShowBody: true}, nil, "pending-ok")
+	if frames[0].T != "msg" || !frames[0].HasBody {
+		t.Fatalf("pending stream = %v", frameTypes(frames))
+	}
+	run("codex", hubwire.CleanOwed{RequestBase: hubwire.RequestBase{T: "clean-owed", ID: 2}}, nil, "clean-owed-ok")
+
+	vendor := "openai"
+	run("new-agent", hubwire.Register{RequestBase: hubwire.RequestBase{T: "register", ID: 2}, Vendor: &vendor, Host: "laptop"}, nil, "register-ok")
+	if _, err := loop.ReadRegistration(cfg.AgentRegistrationPath("new-agent")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func frameTypes(frames []hubwire.RawFrame) []string {
+	out := make([]string, len(frames))
+	for i := range frames {
+		out[i] = frames[i].T
+	}
+	return out
+}
+
+func TestHubSessionUnknownTypeSurvives(t *testing.T) {
+	pool, cfg := newHubPool(t)
+	enrollHubAgent(t, cfg, "codex")
+	s := startHubSession(t, pool, "codex", hubSessionTiming{}, nil, nil)
+	helloHub(t, s, "codex", 1)
+	if _, err := s.conn.Write([]byte("{\"t\":\"future-op\",\"id\":2,\"future\":true}\n")); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := s.reader.Read()
+	if err != nil || raw.T != "error" {
+		t.Fatalf("unknown response = %s, %v", raw.T, err)
+	}
+	var unsupported hubwire.Error
+	_ = raw.Decode(&unsupported)
+	if unsupported.Code != hubwire.CodeUnsupported {
+		t.Fatalf("code = %s", unsupported.Code)
+	}
+	if err := s.writer.Write(hubwire.Status{RequestBase: hubwire.RequestBase{T: "status", ID: 3}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if frames := readUntil(t, s, "status-ok"); frames[len(frames)-1].T != "status-ok" {
+		t.Fatalf("session did not survive: %v", frameTypes(frames))
+	}
+}
+
+func TestHubSessionStartupValidationOrderAndHandshakeFailures(t *testing.T) {
+	t.Run("pool not found precedes pool id", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing")
+		server, client := net.Pipe()
+		done := make(chan error, 1)
+		go func() {
+			done <- serveHubSession(context.Background(), server, hubSessionOptions{Agent: "codex", Pool: missing, PoolID: fixturePoolID})
+		}()
+		raw, err := hubwire.NewReader(client).Read()
+		if err != nil {
+			t.Fatal(err)
+		}
+		var e hubwire.Error
+		_ = raw.Decode(&e)
+		if e.Code != hubwire.CodePoolNotFound {
+			t.Fatalf("code = %s", e.Code)
+		}
+		_ = client.Close()
+		<-done
+	})
+
+	t.Run("missing pool id is mismatch", func(t *testing.T) {
+		pool, _ := newHubPool(t)
+		if err := os.Remove(filepath.Join(pool, ".agentchute", "loop", "state", "pool.id")); err != nil {
+			t.Fatal(err)
+		}
+		assertStartupCode(t, pool, hubwire.CodePoolMismatch)
+	})
+
+	for _, tc := range []struct {
+		name string
+		set  func(t *testing.T, path string)
+	}{
+		{"wrong mode", func(t *testing.T, path string) { t.Helper(); mustChmod(t, path, 0o644) }},
+		{"wrong content", func(t *testing.T, path string) { t.Helper(); hubMustWrite(t, path, []byte("not-an-id\n"), 0o600) }},
+		{"uppercase", func(t *testing.T, path string) { t.Helper(); hubMustWrite(t, path, []byte("0123456789AB\n"), 0o600) }},
+		{"quote", func(t *testing.T, path string) { t.Helper(); hubMustWrite(t, path, []byte("0123456789a\"\n"), 0o600) }},
+		{"shell syntax", func(t *testing.T, path string) { t.Helper(); hubMustWrite(t, path, []byte("012345678$()\n"), 0o600) }},
+		{"whitespace", func(t *testing.T, path string) { t.Helper(); hubMustWrite(t, path, []byte("0123456789a \n"), 0o600) }},
+		{"wrong length", func(t *testing.T, path string) { t.Helper(); hubMustWrite(t, path, []byte("0123456789a\n"), 0o600) }},
+		{"oversize", func(t *testing.T, path string) { t.Helper(); hubMustWrite(t, path, bytesOf('x', 65), 0o600) }},
+		{"embedded newline", func(t *testing.T, path string) { t.Helper(); hubMustWrite(t, path, []byte("012345\n6789ab\n"), 0o600) }},
+		{"symlink", func(t *testing.T, path string) {
+			t.Helper()
+			target := path + ".target"
+			hubMustWrite(t, target, []byte(fixturePoolID+"\n"), 0o600)
+			if err := os.Remove(path); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, path); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"directory", func(t *testing.T, path string) {
+			t.Helper()
+			if err := os.Remove(path); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Mkdir(path, 0o700); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pool, _ := newHubPool(t)
+			path := filepath.Join(pool, ".agentchute", "loop", "state", "pool.id")
+			tc.set(t, path)
+			assertStartupCode(t, pool, hubwire.CodePoolIDInvalid)
+		})
+	}
+
+	t.Run("valid different pool id is mismatch", func(t *testing.T) {
+		pool, _ := newHubPool(t)
+		path := filepath.Join(pool, ".agentchute", "loop", "state", "pool.id")
+		hubMustWrite(t, path, []byte("fedcba987654\n"), 0o600)
+		assertStartupCode(t, pool, hubwire.CodePoolMismatch)
+	})
+
+	t.Run("identity mismatch", func(t *testing.T) {
+		pool, _ := newHubPool(t)
+		s := startHubSession(t, pool, "codex", hubSessionTiming{}, nil, nil)
+		if err := s.writer.Write(hubwire.Hello{RequestBase: hubwire.RequestBase{T: "hello", ID: 1}, Proto: hubwire.Protocol, V: 1, MinV: 1, Agent: "grok"}, nil); err != nil {
+			t.Fatal(err)
+		}
+		raw, err := s.reader.Read()
+		if err != nil {
+			t.Fatal(err)
+		}
+		var e hubwire.Error
+		_ = raw.Decode(&e)
+		if e.Code != hubwire.CodeIdentity {
+			t.Fatalf("code = %s", e.Code)
+		}
+	})
+
+	t.Run("version mismatch", func(t *testing.T) {
+		pool, _ := newHubPool(t)
+		s := startHubSession(t, pool, "codex", hubSessionTiming{}, nil, nil)
+		if err := s.writer.Write(hubwire.Hello{RequestBase: hubwire.RequestBase{T: "hello", ID: 1}, Proto: hubwire.Protocol, V: 2, MinV: 2, Agent: "codex"}, nil); err != nil {
+			t.Fatal(err)
+		}
+		raw, err := s.reader.Read()
+		if err != nil {
+			t.Fatal(err)
+		}
+		var e hubwire.Error
+		_ = raw.Decode(&e)
+		if e.Code != hubwire.CodeVersion {
+			t.Fatalf("code = %s", e.Code)
+		}
+	})
+}
+
+func assertStartupCode(t *testing.T, pool, want string) {
+	t.Helper()
+	server, client := net.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		done <- serveHubSession(context.Background(), server, hubSessionOptions{Agent: "codex", Pool: pool, PoolID: fixturePoolID})
+	}()
+	raw, err := hubwire.NewReader(client).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var e hubwire.Error
+	_ = raw.Decode(&e)
+	if e.Code != want {
+		t.Fatalf("code = %s, want %s", e.Code, want)
+	}
+	_ = client.Close()
+	<-done
+}
+
+func hubMustWrite(t *testing.T, path string, data []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustChmod(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func bytesOf(b byte, n int) []byte { return []byte(strings.Repeat(string(b), n)) }
+
+func TestHubSessionReleasesLeaseOnEveryExitPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		exit  func(t *testing.T, s *runningHubSession)
+		after func()
+	}{
+		{"EOF", func(t *testing.T, s *runningHubSession) { t.Helper(); _ = s.conn.Close() }, nil},
+		{"read deadline", func(t *testing.T, _ *runningHubSession) { t.Helper() }, nil},
+		{"signal cancellation", func(t *testing.T, s *runningHubSession) { t.Helper(); s.cancel() }, nil},
+		{"framing violation", func(t *testing.T, s *runningHubSession) {
+			t.Helper()
+			_, _ = s.conn.Write([]byte("not-json\n"))
+			_, _ = s.reader.Read()
+		}, nil},
+		{"panic recovery", func(t *testing.T, _ *runningHubSession) { t.Helper() }, func() { panic("forced") }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pool, cfg := newHubPool(t)
+			timing := hubSessionTiming{ChannelRead: 25 * time.Millisecond, Write: 10 * time.Millisecond}
+			s := startHubSession(t, pool, "codex", timing, nil, tc.after)
+			helloHub(t, s, "codex", 1)
+			if err := s.writer.Write(hubwire.LeaseAcquire{RequestBase: hubwire.RequestBase{T: "lease-acquire", ID: 2}}, nil); err != nil {
+				t.Fatal(err)
+			}
+			raw, err := s.reader.Read()
+			if err != nil || raw.T != "lease-ok" {
+				t.Fatalf("lease = %s, %v", raw.T, err)
+			}
+			tc.exit(t, s)
+			select {
+			case <-s.done:
+			case <-time.After(time.Second):
+				t.Fatal("session did not exit")
+			}
+			if _, err := os.Stat(filepath.Join(cfg.AgentStateDir("codex"), "serve.claim")); !os.IsNotExist(err) {
+				t.Fatalf("serve claim survived %s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+type failingWriteTransport struct {
+	net.Conn
+	mu     sync.Mutex
+	writes int
+	failAt int
+}
+
+func (t *failingWriteTransport) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.writes++
+	if t.writes >= t.failAt {
+		return 0, io.ErrClosedPipe
+	}
+	return t.Conn.Write(p)
+}
+
+func TestHubW1DisconnectAfterClaimRedelivers(t *testing.T) {
+	pool, cfg := newHubPool(t)
+	enrollHubAgent(t, cfg, "codex")
+	enrollHubAgent(t, cfg, "grok")
+	deliverHubMessage(t, cfg, "grok", "codex", "one")
+	deliverHubMessage(t, cfg, "grok", "codex", "two")
+
+	// hello line, first msg control, first msg body succeed; the next control
+	// write fails and every later write stays failed (no terminal error frame).
+	s := startHubSession(t, pool, "codex", hubSessionTiming{Write: 20 * time.Millisecond}, func(c net.Conn) hubSessionTransport {
+		return &failingWriteTransport{Conn: c, failAt: 4}
+	}, nil)
+	helloHub(t, s, "codex", 1)
+	if err := s.writer.Write(hubwire.Check{RequestBase: hubwire.RequestBase{T: "check", ID: 2}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	first, err := s.reader.Read()
+	if err != nil || first.T != "msg" {
+		t.Fatalf("first = %s, %v", first.T, err)
+	}
+	select {
+	case <-s.done:
+	case <-time.After(time.Second):
+		t.Fatal("failed session did not exit")
+	}
+
+	s2 := startHubSession(t, pool, "codex", hubSessionTiming{}, nil, nil)
+	helloHub(t, s2, "codex", 1)
+	if err := s2.writer.Write(hubwire.Check{RequestBase: hubwire.RequestBase{T: "check", ID: 2}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	frames := readUntil(t, s2, "check-ok")
+	redelivered := 0
+	for _, f := range frames {
+		if f.T == "msg" {
+			var m hubwire.Message
+			_ = f.Decode(&m)
+			if m.Redelivered {
+				redelivered++
+			}
+		}
+	}
+	var summary hubwire.CheckOK
+	_ = frames[len(frames)-1].Decode(&summary)
+	if redelivered != 2 || summary.Redelivered != 2 {
+		t.Fatalf("redelivered frames=%d summary=%d types=%v", redelivered, summary.Redelivered, frameTypes(frames))
+	}
+}
+
+func TestHubW2SendResponseFailureDoesNotReplay(t *testing.T) {
+	pool, cfg := newHubPool(t)
+	enrollHubAgent(t, cfg, "codex")
+	enrollHubAgent(t, cfg, "grok")
+	s := startHubSession(t, pool, "codex", hubSessionTiming{}, func(c net.Conn) hubSessionTransport {
+		return &failingWriteTransport{Conn: c, failAt: 2}
+	}, nil)
+	helloHub(t, s, "codex", 1)
+	if err := s.writer.Write(hubwire.Send{RequestBase: hubwire.RequestBase{T: "send", ID: 2}, To: "grok"}, loop.ComposeMessage("codex", "", "once")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-s.done:
+	case <-time.After(time.Second):
+		t.Fatal("send session did not exit")
+	}
+	msgs, _, err := loop.ListInboxMessagesWithSkipped(cfg.AgentInboxDir("grok"))
+	if err != nil || len(msgs) != 1 {
+		t.Fatalf("recipient files = %d, err=%v", len(msgs), err)
+	}
+}
+
+func TestHubW3ReclaimBeforeSendFenceCheckWritesNothing(t *testing.T) {
+	pool, cfg := newHubPool(t)
+	enrollHubAgent(t, cfg, "codex")
+	enrollHubAgent(t, cfg, "grok")
+	channel := startHubSession(t, pool, "codex", hubSessionTiming{}, nil, nil)
+	helloHub(t, channel, "codex", 1)
+	if err := channel.writer.Write(hubwire.LeaseAcquire{RequestBase: hubwire.RequestBase{T: "lease-acquire", ID: 2}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := channel.reader.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lease hubwire.LeaseOK
+	_ = raw.Decode(&lease)
+	claimPath := filepath.Join(cfg.AgentStateDir("codex"), "serve.claim")
+	claimBytes, err := os.ReadFile(claimPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claim map[string]any
+	if err := json.Unmarshal(claimBytes, &claim); err != nil {
+		t.Fatal(err)
+	}
+	claim["serve_token"] = "new-owner-token"
+	claimBytes, _ = json.MarshalIndent(claim, "", "  ")
+	claimBytes = append(claimBytes, '\n')
+	if err := os.WriteFile(claimPath, claimBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	send := startHubSession(t, pool, "codex", hubSessionTiming{}, nil, nil)
+	helloHub(t, send, "codex", 1)
+	if err := send.writer.Write(hubwire.Send{RequestBase: hubwire.RequestBase{T: "send", ID: 2}, To: "grok", ServeToken: lease.Token}, loop.ComposeMessage("codex", "", "fenced")); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = send.reader.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var e hubwire.Error
+	_ = raw.Decode(&e)
+	if e.Code != "E_FENCED" {
+		t.Fatalf("code = %s", e.Code)
+	}
+	msgs, _, err := loop.ListInboxMessagesWithSkipped(cfg.AgentInboxDir("grok"))
+	if err != nil || len(msgs) != 0 {
+		t.Fatalf("recipient files = %d, err=%v", len(msgs), err)
+	}
+	_ = channel.conn.Close()
+}
+
+func TestHubW6UnreadableResidueSetsClaimedHeld(t *testing.T) {
+	pool, cfg := newHubPool(t)
+	enrollHubAgent(t, cfg, "codex")
+	enrollHubAgent(t, cfg, "grok")
+	deliverHubMessage(t, cfg, "grok", "codex", "held")
+	msgs, _, err := loop.ListInboxMessagesWithSkipped(cfg.AgentInboxDir("codex"))
+	if err != nil || len(msgs) != 1 {
+		t.Fatalf("msgs=%d err=%v", len(msgs), err)
+	}
+	claimedPath, err := loop.ClaimMessage(msgs[0], cfg.AgentClaimedDir("codex"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(claimedPath, 0); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(claimedPath, 0o600) })
+
+	s := startHubSession(t, pool, "codex", hubSessionTiming{}, nil, nil)
+	helloHub(t, s, "codex", 1)
+	if err := s.writer.Write(hubwire.Check{RequestBase: hubwire.RequestBase{T: "check", ID: 2}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := s.reader.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var e hubwire.Error
+	_ = raw.Decode(&e)
+	if raw.T != "error" || !e.ClaimedHeld {
+		t.Fatalf("error = %+v", e)
+	}
+}
+
+func TestHubSessionDeadlines(t *testing.T) {
+	t.Run("hello", func(t *testing.T) {
+		pool, _ := newHubPool(t)
+		s := startHubSession(t, pool, "codex", hubSessionTiming{Hello: 20 * time.Millisecond, Write: 10 * time.Millisecond}, nil, nil)
+		select {
+		case <-s.done:
+		case <-time.After(time.Second):
+			t.Fatal("hello deadline did not close")
+		}
+	})
+	t.Run("one-shot idle", func(t *testing.T) {
+		pool, _ := newHubPool(t)
+		s := startHubSession(t, pool, "codex", hubSessionTiming{OneShotRead: 20 * time.Millisecond, Write: 10 * time.Millisecond}, nil, nil)
+		helloHub(t, s, "codex", 1)
+		select {
+		case <-s.done:
+		case <-time.After(time.Second):
+			t.Fatal("one-shot idle deadline did not close")
+		}
+	})
+	t.Run("one-shot lifetime", func(t *testing.T) {
+		pool, _ := newHubPool(t)
+		s := startHubSession(t, pool, "codex", hubSessionTiming{OneShotRead: time.Second, OneShotLifetime: 20 * time.Millisecond, Write: 10 * time.Millisecond}, nil, nil)
+		helloHub(t, s, "codex", 1)
+		select {
+		case <-s.done:
+		case <-time.After(time.Second):
+			t.Fatal("one-shot lifetime did not close")
+		}
+	})
+	t.Run("write", func(t *testing.T) {
+		pool, cfg := newHubPool(t)
+		enrollHubAgent(t, cfg, "codex")
+		s := startHubSession(t, pool, "codex", hubSessionTiming{Write: 20 * time.Millisecond}, nil, nil)
+		helloHub(t, s, "codex", 1)
+		if err := s.writer.Write(hubwire.Status{RequestBase: hubwire.RequestBase{T: "status", ID: 2}}, nil); err != nil {
+			t.Fatal(err)
+		}
+		// Do not read status-ok: net.Pipe makes the hub's response write block
+		// until the configured write deadline expires.
+		select {
+		case <-s.done:
+		case <-time.After(time.Second):
+			t.Fatal("write deadline did not close")
+		}
+	})
+}
+
+func TestHubSubcommandHiddenFromDispatcherHelp(t *testing.T) {
+	if commandHandlers["hub"] == nil {
+		t.Fatal("hub command is not dispatched")
+	}
+	if strings.Contains(dispatchHelpText(), "hub") {
+		t.Fatal("internal hub command leaked into ac help")
+	}
+}
+
+func TestValidateHubPoolDoesNotConsultDiscoveryEnvironment(t *testing.T) {
+	pool, _ := newHubPool(t)
+	t.Setenv("AGENTCHUTE_CONTROL_REPO", filepath.Join(t.TempDir(), "wrong"))
+	t.Setenv("AGENTCHUTE_LOOP_DIR", filepath.Join(t.TempDir(), "wrong-loop"))
+	got, cfg, id, err := validateHubPool(pool, fixturePoolID)
+	resolvedPool, resolveErr := filepath.EvalSymlinks(pool)
+	if resolveErr != nil {
+		t.Fatal(resolveErr)
+	}
+	if err != nil || got != resolvedPool || cfg.ControlRepo != resolvedPool || id != fixturePoolID {
+		t.Fatalf("got=%s cfg=%+v id=%s err=%v", got, cfg, id, err)
+	}
+}

--- a/internal/cli/hub_session_test.go
+++ b/internal/cli/hub_session_test.go
@@ -211,6 +211,38 @@ func TestHubSessionChannelHappyPathAndOrder(t *testing.T) {
 	}
 }
 
+func TestHubSessionRejectsUnencodableRegisterBeforeMutation(t *testing.T) {
+	pool, cfg := newHubPool(t)
+	s := startHubSession(t, pool, "codex", hubSessionTiming{}, nil, nil)
+	helloHub(t, s, "codex", 1)
+
+	vendor := "openai"
+	host := strings.Repeat("h", hubwire.MaxControlLine/2)
+	if err := s.writer.Write(hubwire.Register{RequestBase: hubwire.RequestBase{T: "register", ID: 2}, Vendor: &vendor, Host: host}, nil); err != nil {
+		t.Fatalf("the request itself must fit: %v", err)
+	}
+	raw, err := s.reader.Read()
+	if err != nil || raw.T != "error" {
+		t.Fatalf("register = %s, %v", raw.T, err)
+	}
+	var wireErr hubwire.Error
+	if err := raw.Decode(&wireErr); err != nil {
+		t.Fatal(err)
+	}
+	if wireErr.Code != hubwire.CodeTooLarge {
+		t.Fatalf("code = %s, want %s", wireErr.Code, hubwire.CodeTooLarge)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("codex")); !os.IsNotExist(err) {
+		t.Fatalf("oversize response committed a registration: %v", err)
+	}
+	if _, err := os.Stat(cfg.AgentInboxDir("codex")); !os.IsNotExist(err) {
+		t.Fatalf("oversize response created an inbox: %v", err)
+	}
+	if err := <-s.done; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestHubSessionEveryOneShotOp(t *testing.T) {
 	pool, cfg := newHubPool(t)
 	enrollHubAgent(t, cfg, "codex")

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -34,6 +34,12 @@ var sendStdin = os.Stdin
 //     asker-owned only.
 //   - --json:       structured output (filename, path).
 func cmdSend(args []string) error {
+	return cmdSendWithOp(args, op.Send)
+}
+
+type sendOperation func(*loop.Config, op.Context, op.SendReq) (op.SendResp, error)
+
+func cmdSendWithOp(args []string, send sendOperation) error {
 	fs := flag.NewFlagSet("send", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 
@@ -212,7 +218,7 @@ func cmdSend(args []string) error {
 	// so a write from a fenced (reclaimed) agent fails closed (MintSendStamp's
 	// VerifyFence -> ErrFenced). Empty env (no serve lease) => intentionally
 	// unfenced.
-	resp, sendErr := op.Send(cfg, actor, op.SendReq{
+	resp, sendErr := send(cfg, actor, op.SendReq{
 		To:         toID,
 		Content:    content,
 		Ask:        ask,

--- a/internal/cli/send_a5_test.go
+++ b/internal/cli/send_a5_test.go
@@ -227,26 +227,25 @@ func TestSendPartialSuccessOnOwedFailure(t *testing.T) {
 
 func TestSendPostLinkSyncFailureIsPartialSuccess(t *testing.T) {
 	root, cfg := setupSendFixture(t)
-	originalSend := op.SendTsMessageWithCommit
-	op.SendTsMessageWithCommit = func(cfg *loop.Config, from, to string, content []byte, serveToken string) (loop.TsID, bool, error) {
-		id, committed, err := originalSend(cfg, from, to, content, serveToken)
+	send := func(cfg *loop.Config, ctx op.Context, req op.SendReq) (op.SendResp, error) {
+		resp, err := op.Send(cfg, ctx, req)
 		if err != nil {
-			return id, committed, err
+			return resp, err
 		}
-		return id, true, errors.New("forced post-link sync failure")
+		resp.DurabilityNote = "forced post-link sync failure"
+		return resp, nil
 	}
-	defer func() { op.SendTsMessageWithCommit = originalSend }()
 
 	var stdout string
 	var sendErr error
 	stderr := captureStderr(t, func() {
 		withCwd(t, root, func() {
 			stdout, sendErr = captureStdout(t, func() error {
-				return cmdSend([]string{
+				return cmdSendWithOp([]string{
 					"--from", "claude-code", "--to", "codex",
 					"--ask", "--reply-by", "45m",
 					"--body", "linked before sync failed",
-				})
+				}, send)
 			})
 		})
 	})

--- a/internal/cli/send_b3_test.go
+++ b/internal/cli/send_b3_test.go
@@ -135,21 +135,19 @@ func TestSendRefusesMalformedRecipientAtPreflight(t *testing.T) {
 // itself catches the underlying race; this proves cmdSend renders it right).
 func TestSendFreshButRacingText(t *testing.T) {
 	root, cfg := setupSendFixture(t)
-	originalSend := op.SendTsMessageWithCommit
-	op.SendTsMessageWithCommit = func(cfg *loop.Config, from, to string, content []byte, serveToken string) (loop.TsID, bool, error) {
-		return loop.TsID{}, false, &loop.ErrRecipientStale{
-			To:        to,
+	send := func(_ *loop.Config, _ op.Context, req op.SendReq) (op.SendResp, error) {
+		return op.SendResp{}, &loop.ErrRecipientStale{
+			To:        req.To,
 			LastSeen:  time.Now().UTC().Add(-90 * time.Second),
 			Age:       90 * time.Second,
 			Threshold: time.Hour,
 		}
 	}
-	defer func() { op.SendTsMessageWithCommit = originalSend }()
 
 	var sendErr error
 	withCwd(t, root, func() {
 		sendErr = withSendStdin(t, "body", func() error {
-			return cmdSend([]string{"--from", "claude-code", "--to", "codex"})
+			return cmdSendWithOp([]string{"--from", "claude-code", "--to", "codex"}, send)
 		})
 	})
 	if sendErr == nil {

--- a/internal/hubwire/codec.go
+++ b/internal/hubwire/codec.go
@@ -1,0 +1,298 @@
+package hubwire
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"unicode/utf8"
+
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+// RawFrame is one decoded control object and its optional byte-exact trailer.
+type RawFrame struct {
+	Control []byte
+	Body    []byte
+	T       string
+	ID      int64
+	Re      int64
+	HasBody bool
+}
+
+type envelope struct {
+	T       string `json:"t"`
+	ID      int64  `json:"id"`
+	Re      int64  `json:"re"`
+	BodyLen *int64 `json:"body_len"`
+}
+
+type Reader struct{ r *bufio.Reader }
+
+func NewReader(r io.Reader) *Reader {
+	return &Reader{r: bufio.NewReaderSize(r, MaxControlLine+1)}
+}
+
+func (r *Reader) Read() (RawFrame, error) {
+	line, err := r.r.ReadSlice('\n')
+	if errors.Is(err, bufio.ErrBufferFull) {
+		return RawFrame{}, protocolError(CodeTooLarge, "control frame exceeds 64 KiB")
+	}
+	if err != nil {
+		if errors.Is(err, io.EOF) && len(line) == 0 {
+			return RawFrame{}, io.EOF
+		}
+		return RawFrame{}, protocolError(CodeMalformedFrame, "truncated control frame")
+	}
+	if len(line) > MaxControlLine {
+		return RawFrame{}, protocolError(CodeTooLarge, "control frame exceeds 64 KiB")
+	}
+	control := line[:len(line)-1]
+	if len(control) == 0 || !utf8.Valid(control) {
+		return RawFrame{}, protocolError(CodeMalformedFrame, "control frame is not a UTF-8 JSON object")
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(control, &object); err != nil || object == nil {
+		return RawFrame{}, protocolError(CodeMalformedFrame, "control frame is not a JSON object")
+	}
+	var env envelope
+	if err := json.Unmarshal(control, &env); err != nil || env.T == "" {
+		return RawFrame{}, protocolError(CodeMalformedFrame, "control frame has invalid envelope fields")
+	}
+	if err := validateMandatoryFields(env.T, control); err != nil {
+		return RawFrame{}, err
+	}
+	out := RawFrame{Control: append([]byte(nil), control...), T: env.T, ID: env.ID, Re: env.Re}
+	if env.BodyLen == nil {
+		return out, nil
+	}
+	out.HasBody = true
+	if *env.BodyLen < 0 {
+		return RawFrame{}, protocolError(CodeMalformedFrame, "body_len must be non-negative")
+	}
+	if *env.BodyLen > MaxBody {
+		return RawFrame{}, protocolError(CodeTooLarge, "body exceeds 4 MiB")
+	}
+	out.Body = make([]byte, int(*env.BodyLen))
+	if _, err := io.ReadFull(r.r, out.Body); err != nil {
+		return RawFrame{}, protocolError(CodeMalformedFrame, "truncated body trailer")
+	}
+	return out, nil
+}
+
+func validateMandatoryFields(frameType string, control []byte) error {
+	switch frameType {
+	case "send-ok":
+		var required struct {
+			Committed      *bool   `json:"committed"`
+			DurabilityNote *string `json:"durability_note"`
+			OwedNote       *string `json:"owed_note"`
+		}
+		if err := json.Unmarshal(control, &required); err != nil || required.Committed == nil || required.DurabilityNote == nil || required.OwedNote == nil {
+			return protocolError(CodeMalformedFrame, "send-ok requires committed, durability_note, and owed_note")
+		}
+	case "tick-ok":
+		var required struct {
+			Warnings *[]string `json:"warnings"`
+		}
+		if err := json.Unmarshal(control, &required); err != nil || required.Warnings == nil {
+			return protocolError(CodeMalformedFrame, "tick-ok requires warnings")
+		}
+	case "register-ok":
+		var required struct {
+			Warnings *[]string       `json:"warnings"`
+			Announce json.RawMessage `json:"announce"`
+		}
+		if err := json.Unmarshal(control, &required); err != nil || required.Warnings == nil || required.Announce == nil {
+			return protocolError(CodeMalformedFrame, "register-ok requires announce and warnings")
+		}
+		if !bytes.Equal(required.Announce, []byte("null")) {
+			var announce struct {
+				Warnings *[]string `json:"warnings"`
+			}
+			if err := json.Unmarshal(required.Announce, &announce); err != nil || announce.Warnings == nil {
+				return protocolError(CodeMalformedFrame, "register-ok announce requires warnings")
+			}
+		}
+	case "note":
+		var note Note
+		if err := json.Unmarshal(control, &note); err != nil {
+			return protocolError(CodeMalformedFrame, "invalid note frame")
+		}
+		return ValidateNoteLevel(note.Level)
+	}
+	return nil
+}
+
+func (f RawFrame) Decode(dst any) error {
+	if err := json.Unmarshal(f.Control, dst); err != nil {
+		return protocolError(CodeMalformedFrame, fmt.Sprintf("decode %s frame: %v", f.T, err))
+	}
+	return nil
+}
+
+type Writer struct{ w io.Writer }
+
+func NewWriter(w io.Writer) *Writer { return &Writer{w: w} }
+
+func (w *Writer) Write(frame any, body []byte) error {
+	line, err := encodeControl(frame, body)
+	if err != nil {
+		return err
+	}
+	if err := writeFull(w.w, line); err != nil {
+		return err
+	}
+	if body != nil {
+		return writeFull(w.w, body)
+	}
+	return nil
+}
+
+func Encode(frame any, body []byte) ([]byte, error) {
+	control, err := encodeControl(frame, body)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, 0, len(control)+len(body))
+	out = append(out, control...)
+	out = append(out, body...)
+	return out, nil
+}
+
+func encodeControl(frame any, body []byte) ([]byte, error) {
+	if err := validateOutboundFrame(frame); err != nil {
+		return nil, err
+	}
+	control, err := json.Marshal(frame)
+	if err != nil {
+		return nil, protocolError(CodeMalformedFrame, fmt.Sprintf("encode control frame: %v", err))
+	}
+	if body != nil {
+		if len(body) > MaxBody {
+			return nil, protocolError(CodeTooLarge, "body exceeds 4 MiB")
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(control, &fields); err != nil {
+			return nil, protocolError(CodeMalformedFrame, "encoded frame is not a JSON object")
+		}
+		length, _ := json.Marshal(len(body))
+		fields["body_len"] = length
+		control, err = json.Marshal(fields)
+		if err != nil {
+			return nil, protocolError(CodeMalformedFrame, fmt.Sprintf("encode body length: %v", err))
+		}
+	}
+	if len(control)+1 > MaxControlLine {
+		return nil, protocolError(CodeTooLarge, "control frame exceeds 64 KiB")
+	}
+	out := make([]byte, 0, len(control)+1)
+	out = append(out, control...)
+	out = append(out, '\n')
+	return out, nil
+}
+
+func validateOutboundFrame(frame any) error {
+	switch frame := frame.(type) {
+	case Note:
+		return ValidateNoteLevel(frame.Level)
+	case *Note:
+		return ValidateNoteLevel(frame.Level)
+	case TickOK:
+		if frame.Warnings == nil {
+			return protocolError(CodeMalformedFrame, "tick-ok requires warnings")
+		}
+	case *TickOK:
+		if frame.Warnings == nil {
+			return protocolError(CodeMalformedFrame, "tick-ok requires warnings")
+		}
+	case RegisterOK:
+		if frame.Warnings == nil || (frame.Announce != nil && frame.Announce.Warnings == nil) {
+			return protocolError(CodeMalformedFrame, "register-ok requires warnings")
+		}
+	case *RegisterOK:
+		if frame.Warnings == nil || (frame.Announce != nil && frame.Announce.Warnings == nil) {
+			return protocolError(CodeMalformedFrame, "register-ok requires warnings")
+		}
+	}
+	return nil
+}
+
+func writeFull(w io.Writer, p []byte) error {
+	for len(p) > 0 {
+		n, err := w.Write(p)
+		if err != nil {
+			return err
+		}
+		if n <= 0 {
+			return io.ErrShortWrite
+		}
+		p = p[n:]
+	}
+	return nil
+}
+
+// EncodeStatus applies the response-line and row budgets to the op's sorted
+// rows. The result always ends in LF and never exceeds MaxControlLine.
+func EncodeStatus(re int64, resp op.StatusResp) ([]byte, StatusOK, error) {
+	out := StatusOK{
+		ResponseBase: ResponseBase{T: "status-ok", Re: re},
+		Agents:       make([]op.StatusAgent, 0, min(len(resp.Agents), MaxStatusRows)),
+		Now:          resp.Now,
+	}
+	for i, row := range resp.Agents {
+		if i >= MaxStatusRows {
+			out.Truncated = true
+			break
+		}
+		candidate := out
+		candidate.Agents = append(append([]op.StatusAgent(nil), out.Agents...), row)
+		candidate.Truncated = false
+		line, err := Encode(candidate, nil)
+		if err != nil {
+			var pe *ProtocolError
+			if errors.As(err, &pe) && pe.Code == CodeTooLarge {
+				out.Truncated = true
+				break
+			}
+			return nil, StatusOK{}, err
+		}
+		if len(line) > MaxControlLine {
+			out.Truncated = true
+			break
+		}
+		out.Agents = append(out.Agents, row)
+	}
+	if len(out.Agents) < len(resp.Agents) {
+		out.Truncated = true
+	}
+	line, err := Encode(out, nil)
+	if err != nil {
+		return nil, StatusOK{}, err
+	}
+	return line, out, nil
+}
+
+func (w *Writer) WriteStatus(re int64, resp op.StatusResp) error {
+	line, _, err := EncodeStatus(re, resp)
+	if err != nil {
+		return err
+	}
+	return writeFull(w.w, line)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func controlLine(encoded []byte) []byte {
+	if i := bytes.IndexByte(encoded, '\n'); i >= 0 {
+		return encoded[:i+1]
+	}
+	return encoded
+}

--- a/internal/hubwire/codec_test.go
+++ b/internal/hubwire/codec_test.go
@@ -1,0 +1,312 @@
+package hubwire
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+func roundTrip(t *testing.T, frame any, body []byte) RawFrame {
+	t.Helper()
+	server, client := net.Pipe()
+	t.Cleanup(func() { _ = server.Close(); _ = client.Close() })
+	errCh := make(chan error, 1)
+	go func() { errCh <- NewWriter(client).Write(frame, body) }()
+	got, err := NewReader(server).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func TestRoundTripEveryFrameTypeOverNetPipe(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 123, time.UTC)
+	str := "openai"
+	bio := "bio"
+	frames := []struct {
+		name  string
+		frame any
+		body  []byte
+	}{
+		{"hello", Hello{RequestBase: RequestBase{T: "hello", ID: 1}, Proto: Protocol, V: 1, MinV: 1, Agent: "codex", Bin: "1.6.0"}, nil},
+		{"hello-ok", HelloOK{ResponseBase: ResponseBase{T: "hello-ok", Re: 1}, V: 1, Agent: "codex", Pool: "/pool", Pool12: "0123456789ab", Writable: true, HubBin: "1.6.0", HubTime: now}, nil},
+		{"send", Send{RequestBase: RequestBase{T: "send", ID: 2}, To: "grok", Ask: true, ReplyByS: 60, ServeToken: "token"}, []byte("body")},
+		{"send-ok", SendOK{ResponseBase: ResponseBase{T: "send-ok", Re: 2}, Filename: "m.md", Ref: "ref", Committed: true, DurabilityNote: "", OwedNote: ""}, nil},
+		{"msg", Message{ResponseBase: ResponseBase{T: "msg", Re: 3}, Filename: "m.md", Sender: "grok", Stamp: now.Format(time.RFC3339Nano), Redelivered: true, ReplyRequired: true, ReplyRef: "ref"}, []byte{}},
+		{"owed-item", OwedItem{ResponseBase: ResponseBase{T: "owed-item", Re: 3}, To: "grok", From: "codex", Stamp: "stamp", Suffix: "suffix", By: now, RecordedAt: now, Ref: "ref"}, nil},
+		{"check", Check{RequestBase: RequestBase{T: "check", ID: 3}, Limit: 2}, nil},
+		{"check-ok", CheckOK{ResponseBase: ResponseBase{T: "check-ok", Re: 3}, Claimed: 1, Redelivered: 1, Quarantined: 1, OwedExpired: 1}, nil},
+		{"ack", Ack{RequestBase: RequestBase{T: "ack", ID: 4}}, nil},
+		{"ack-item", AckItem{ResponseBase: ResponseBase{T: "ack-item", Re: 4}, Filename: "m.md", ArchivePath: "/archive/m.md"}, nil},
+		{"ack-ok", AckOK{ResponseBase: ResponseBase{T: "ack-ok", Re: 4}, Acked: 1, GateClear: true}, nil},
+		{"register", Register{RequestBase: RequestBase{T: "register", ID: 5}, Vendor: &str, Host: "tiny", Bio: &bio, WorkingRepos: []string{"/repo"}, Announce: true}, nil},
+		{"register-ok", RegisterOK{ResponseBase: ResponseBase{T: "register-ok", Re: 5}, Announce: &Announce{Warnings: []string{}}, Reg: Registration{AgentID: "codex", LastSeen: now}, Warnings: []string{}}, []byte("registration body")},
+		{"status", Status{RequestBase: RequestBase{T: "status", ID: 6}}, nil},
+		{"status-ok", StatusOK{ResponseBase: ResponseBase{T: "status-ok", Re: 6}, Agents: []op.StatusAgent{}, Now: now}, nil},
+		{"gate", Gate{RequestBase: RequestBase{T: "gate", ID: 7}, Phase: op.GatePhaseFinish}, nil},
+		{"gate-ok", GateOK{ResponseBase: ResponseBase{T: "gate-ok", Re: 7}, GateResp: op.GateResp{Agent: "codex", Phase: op.GatePhaseFinish}}, nil},
+		{"pending", Pending{RequestBase: RequestBase{T: "pending", ID: 8}, ShowBody: true}, nil},
+		{"pending-ok", PendingOK{ResponseBase: ResponseBase{T: "pending-ok", Re: 8}, Unread: 1}, nil},
+		{"clean-owed", CleanOwed{RequestBase: RequestBase{T: "clean-owed", ID: 9}, Apply: true}, nil},
+		{"clean-owed-ok", CleanOwedOK{ResponseBase: ResponseBase{T: "clean-owed-ok", Re: 9}, Agent: "codex", Pruned: []string{}}, nil},
+		{"lease-acquire", LeaseAcquire{RequestBase: RequestBase{T: "lease-acquire", ID: 10}}, nil},
+		{"lease-ok", LeaseOK{ResponseBase: ResponseBase{T: "lease-ok", Re: 10}, Token: "token"}, nil},
+		{"tick", Tick{RequestBase: RequestBase{T: "tick", ID: 11}}, nil},
+		{"tick-ok", TickOK{ResponseBase: ResponseBase{T: "tick-ok", Re: 11}, Warnings: []string{}}, nil},
+		{"lease-release", LeaseRelease{RequestBase: RequestBase{T: "lease-release", ID: 12}}, nil},
+		{"release-ok", ReleaseOK{ResponseBase: ResponseBase{T: "release-ok", Re: 12}}, nil},
+		{"note", Note{ResponseBase: ResponseBase{T: "note", Re: 3}, Level: op.NoteInfo, Msg: "note"}, nil},
+		{"error", Error{ResponseBase: ResponseBase{T: "error", Re: 3}, Code: "E_HUB_IO", Msg: "broken", Retriable: false, ClaimedHeld: true}, nil},
+	}
+	for _, tc := range frames {
+		t.Run(tc.name, func(t *testing.T) {
+			got := roundTrip(t, tc.frame, tc.body)
+			if got.T != tc.name {
+				t.Fatalf("t = %q", got.T)
+			}
+			if !bytes.Equal(got.Body, tc.body) || got.HasBody != (tc.body != nil) {
+				t.Fatalf("body = %q has=%v, want %q has=%v", got.Body, got.HasBody, tc.body, tc.body != nil)
+			}
+		})
+	}
+}
+
+func TestBodyTrailerBoundaries(t *testing.T) {
+	for _, size := range []int{0, 1, MaxBody} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			body := bytes.Repeat([]byte{'x'}, size)
+			got := roundTrip(t, Send{RequestBase: RequestBase{T: "send", ID: 1}, To: "codex"}, body)
+			if !bytes.Equal(got.Body, body) {
+				t.Fatalf("body bytes differ at %d", size)
+			}
+		})
+	}
+	_, err := Encode(Send{RequestBase: RequestBase{T: "send", ID: 1}}, make([]byte, MaxBody+1))
+	assertCode(t, err, CodeTooLarge)
+}
+
+func TestReaderRejectsTruncationAndOversize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []byte
+		code string
+	}{
+		{"empty truncated line", []byte("{"), CodeMalformedFrame},
+		{"valid json without LF", []byte(`{"t":"check","id":1}`), CodeMalformedFrame},
+		{"truncated trailer zero of one", []byte("{\"t\":\"send\",\"id\":1,\"body_len\":1}\n"), CodeMalformedFrame},
+		{"oversize declared trailer", []byte(fmt.Sprintf("{\"t\":\"send\",\"id\":1,\"body_len\":%d}\n", MaxBody+1)), CodeTooLarge},
+		{"oversize line", append(bytes.Repeat([]byte{' '}, MaxControlLine), '\n'), CodeTooLarge},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewReader(bytes.NewReader(tc.in)).Read()
+			assertCode(t, err, tc.code)
+		})
+	}
+}
+
+func TestControlAndTrailerExactBoundaries(t *testing.T) {
+	prefix := []byte(`{"t":"future","id":1,"pad":"`)
+	suffix := []byte(`"}` + "\n")
+	line := append(append(append([]byte(nil), prefix...), bytes.Repeat([]byte{'x'}, MaxControlLine-len(prefix)-len(suffix))...), suffix...)
+	if len(line) != MaxControlLine {
+		t.Fatalf("fixture line = %d", len(line))
+	}
+	if _, err := NewReader(bytes.NewReader(line)).Read(); err != nil {
+		t.Fatalf("exact control boundary: %v", err)
+	}
+	oneOver := append(append([]byte(nil), line[:len(line)-1]...), 'x', '\n')
+	if _, err := NewReader(bytes.NewReader(oneOver)).Read(); err == nil {
+		t.Fatal("one-byte-oversize control line accepted")
+	}
+	if _, err := NewReader(bytes.NewReader(line[:len(line)-1])).Read(); err == nil {
+		t.Fatal("exact-size control line without LF accepted")
+	}
+
+	header := []byte(fmt.Sprintf("{\"t\":\"send\",\"id\":1,\"body_len\":%d}\n", MaxBody))
+	truncated := append(header, bytes.Repeat([]byte{'b'}, MaxBody-1)...)
+	if _, err := NewReader(bytes.NewReader(truncated)).Read(); err == nil {
+		t.Fatal("max-size trailer truncated by one byte accepted")
+	}
+}
+
+func TestLargeRegistrationBodyUsesTrailer(t *testing.T) {
+	body := bytes.Repeat([]byte{'b'}, MaxControlLine+1)
+	frame := RegisterOK{ResponseBase: ResponseBase{T: "register-ok", Re: 2}, Announce: nil, Reg: Registration{AgentID: "codex"}, Warnings: []string{}}
+	got := roundTrip(t, frame, body)
+	if got.T != "register-ok" || len(got.Control)+1 > MaxControlLine || !bytes.Equal(got.Body, body) {
+		t.Fatalf("control=%d body=%d", len(got.Control)+1, len(got.Body))
+	}
+}
+
+func TestUnknownFieldsIgnoredAndMandatoryFieldsEnforced(t *testing.T) {
+	raw, err := NewReader(strings.NewReader("{\"t\":\"hello\",\"id\":1,\"proto\":\"agentchute-hub\",\"v\":1,\"min_v\":1,\"agent\":\"codex\",\"bin\":\"dev\",\"future\":true}\n")).Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hello Hello
+	if err := raw.Decode(&hello); err != nil || hello.Agent != "codex" {
+		t.Fatalf("decode = %+v, %v", hello, err)
+	}
+	for _, line := range []string{
+		`{"t":"send-ok","re":2,"durability_note":"","owed_note":""}` + "\n",
+		`{"t":"send-ok","re":2,"committed":true,"owed_note":""}` + "\n",
+		`{"t":"send-ok","re":2,"committed":true,"durability_note":""}` + "\n",
+		`{"t":"tick-ok","re":2}` + "\n",
+		`{"t":"register-ok","re":2,"announce":null}` + "\n",
+		`{"t":"note","re":2,"level":"debug","msg":"x"}` + "\n",
+	} {
+		_, err := NewReader(strings.NewReader(line)).Read()
+		assertCode(t, err, CodeMalformedFrame)
+	}
+}
+
+func TestStatusProducerBudgetsAndPrefix(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	row := func(id, host string) op.StatusAgent {
+		return op.StatusAgent{AgentID: id, LastSeen: now, Host: host, ProtocolVersion: 3, InboxDepth: 1, Status: "fresh"}
+	}
+	small := make([]op.StatusAgent, 65)
+	for i := range small {
+		small[i] = row(fmt.Sprintf("agent-%02d", i), "host")
+	}
+	line, out, err := EncodeStatus(1, op.StatusResp{Agents: small[:64], Now: now})
+	if err != nil || out.Truncated || len(out.Agents) != 64 || len(line) > MaxControlLine {
+		t.Fatalf("64 rows: len=%d out=%+v err=%v", len(line), out, err)
+	}
+	_, out, err = EncodeStatus(1, op.StatusResp{Agents: small, Now: now})
+	if err != nil || !out.Truncated || !reflect.DeepEqual(out.Agents, small[:64]) {
+		t.Fatalf("65 rows: kept=%d truncated=%v err=%v", len(out.Agents), out.Truncated, err)
+	}
+
+	huge := strings.Repeat("h", MaxControlLine)
+	_, out, err = EncodeStatus(1, op.StatusResp{Agents: []op.StatusAgent{row("a", huge), row("b", "ok"), row("c", "ok")}, Now: now})
+	if err != nil || !out.Truncated || len(out.Agents) != 0 {
+		t.Fatalf("oversize first: kept=%d truncated=%v err=%v", len(out.Agents), out.Truncated, err)
+	}
+	line, out, err = EncodeStatus(1, op.StatusResp{Agents: []op.StatusAgent{row("a", "ok"), row("b", "ok"), row("c", huge)}, Now: now})
+	if err != nil || !out.Truncated || len(out.Agents) != 2 || len(line) > MaxControlLine {
+		t.Fatalf("oversize last: line=%d kept=%d truncated=%v err=%v", len(line), len(out.Agents), out.Truncated, err)
+	}
+
+	base := row("boundary", "")
+	baseLine, _, err := EncodeStatus(9, op.StatusResp{Agents: []op.StatusAgent{base}, Now: now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base.Host = strings.Repeat("h", MaxControlLine-len(baseLine))
+	exact, exactOut, err := EncodeStatus(9, op.StatusResp{Agents: []op.StatusAgent{base}, Now: now})
+	if err != nil || len(exact) != MaxControlLine || exactOut.Truncated {
+		t.Fatalf("exact boundary: len=%d truncated=%v err=%v", len(exact), exactOut.Truncated, err)
+	}
+	base.Host += "h"
+	short, dropped, err := EncodeStatus(9, op.StatusResp{Agents: []op.StatusAgent{base}, Now: now})
+	if err != nil || !dropped.Truncated || len(dropped.Agents) != 0 || len(short) > MaxControlLine {
+		t.Fatalf("one over: len=%d kept=%d truncated=%v err=%v", len(short), len(dropped.Agents), dropped.Truncated, err)
+	}
+	base.Host = base.Host[:len(base.Host)-1]
+	flipped, flipOut, err := EncodeStatus(9, op.StatusResp{Agents: []op.StatusAgent{base, row("tail", "x")}, Now: now})
+	if err != nil || !flipOut.Truncated || len(flipOut.Agents) != 1 || len(flipped) != MaxControlLine-1 {
+		t.Fatalf("flag flip: len=%d kept=%d truncated=%v err=%v", len(flipped), len(flipOut.Agents), flipOut.Truncated, err)
+	}
+}
+
+func TestRegistryCompleteness(t *testing.T) {
+	opCodes := []string{"E_NOT_REGISTERED", "E_RECIPIENT_UNKNOWN", "E_RECIPIENT_UNREADABLE", "E_RECIPIENT_STALE", "E_RECIPIENT_RACING", "E_FENCED", "E_LEASE_HELD", "E_ORDER", "E_HUB_IO"}
+	codecCodes := []string{CodeVersion, CodeIdentity, CodePoolNotFound, CodePoolIDInvalid, CodePoolMismatch, CodeMalformedFrame, CodeTooLarge, CodeUnsupported}
+	clientOnly := []string{"E_CONNECT", "E_UNAUTHORIZED", "E_HOSTKEY_CHANGED", "E_CHANNEL_LOST", "E_SEND_UNKNOWN", "E_HELLO_TIMEOUT", "E_HUB_NO_BINARY", "E_NOT_JOINED", "E_NO_SSH"}
+	seen := map[string]bool{}
+	opErrors := []error{
+		op.ErrNotRegistered, op.ErrRecipientUnknown, op.ErrRecipientUnreadable,
+		op.ErrRecipientStale, op.ErrRecipientRacing, op.ErrFenced,
+		op.ErrLeaseHeld, op.ErrOrder, errors.New("default I/O"),
+	}
+	for i, err := range opErrors {
+		if got := op.CodeFor(err); got != opCodes[i] {
+			t.Fatalf("op.CodeFor(%v) = %s, want %s", err, got, opCodes[i])
+		}
+	}
+	for _, set := range [][]string{opCodes, codecCodes} {
+		for _, code := range set {
+			if seen[code] {
+				t.Fatalf("duplicate hub code %s", code)
+			}
+			seen[code] = true
+			if Emitters[code] != EmitterHub && !(code == CodePoolMismatch && Emitters[code] == EmitterBoth) {
+				t.Fatalf("hub code %s classified %q", code, Emitters[code])
+			}
+		}
+	}
+	if len(seen) != 17 {
+		t.Fatalf("hub union = %d, want 17", len(seen))
+	}
+	for _, code := range clientOnly {
+		if seen[code] || Emitters[code] != EmitterClient {
+			t.Fatalf("client-only code %s overlaps or misclassified", code)
+		}
+	}
+	if Emitters[CodePoolMismatch] != EmitterBoth {
+		t.Fatalf("pool mismatch emitter = %q", Emitters[CodePoolMismatch])
+	}
+	if len(Emitters) != 26 {
+		t.Fatalf("emitter registry = %d rows, want 26", len(Emitters))
+	}
+}
+
+func assertCode(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("nil error, want %s", want)
+	}
+	var pe *ProtocolError
+	if !errors.As(err, &pe) || pe.Code != want {
+		t.Fatalf("err = %v (%T), want %s", err, err, want)
+	}
+}
+
+func TestControlLineHelper(t *testing.T) {
+	encoded, err := Encode(Send{RequestBase: RequestBase{T: "send", ID: 1}}, []byte("body\nbytes"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := controlLine(encoded)
+	if len(line) == 0 || line[len(line)-1] != '\n' {
+		t.Fatal("control line missing LF")
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal(bytes.TrimSuffix(line, []byte{'\n'}), &envelope); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type shortWriter struct{ remaining int }
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if w.remaining == 0 {
+		return 0, io.ErrClosedPipe
+	}
+	if len(p) > w.remaining {
+		p = p[:w.remaining]
+	}
+	w.remaining -= len(p)
+	return len(p), nil
+}
+
+func TestWriterSurfacesMidFrameFailure(t *testing.T) {
+	err := NewWriter(&shortWriter{remaining: 5}).Write(Check{RequestBase: RequestBase{T: "check", ID: 1}}, nil)
+	if !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/internal/hubwire/codes.go
+++ b/internal/hubwire/codes.go
@@ -1,0 +1,82 @@
+package hubwire
+
+import (
+	"errors"
+
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+const (
+	CodeVersion        = "E_VERSION"
+	CodeIdentity       = "E_IDENTITY"
+	CodePoolNotFound   = "E_POOL_NOT_FOUND"
+	CodePoolIDInvalid  = "E_POOL_ID_INVALID"
+	CodePoolMismatch   = "E_POOL_MISMATCH"
+	CodeMalformedFrame = "E_MALFORMED_FRAME"
+	CodeTooLarge       = "E_TOO_LARGE"
+	CodeUnsupported    = "E_UNSUPPORTED"
+)
+
+const (
+	EmitterHub    = "hub"
+	EmitterClient = "client"
+	EmitterBoth   = "both"
+)
+
+// Emitters is the complete code-emitter classification. E_POOL_MISMATCH is
+// the only code emitted by both sides.
+var Emitters = map[string]string{
+	"E_NOT_REGISTERED":       EmitterHub,
+	"E_RECIPIENT_UNKNOWN":    EmitterHub,
+	"E_RECIPIENT_UNREADABLE": EmitterHub,
+	"E_RECIPIENT_STALE":      EmitterHub,
+	"E_RECIPIENT_RACING":     EmitterHub,
+	"E_FENCED":               EmitterHub,
+	"E_LEASE_HELD":           EmitterHub,
+	"E_ORDER":                EmitterHub,
+	"E_HUB_IO":               EmitterHub,
+	CodeVersion:              EmitterHub,
+	CodeIdentity:             EmitterHub,
+	CodePoolNotFound:         EmitterHub,
+	CodePoolIDInvalid:        EmitterHub,
+	CodePoolMismatch:         EmitterBoth,
+	CodeMalformedFrame:       EmitterHub,
+	CodeTooLarge:             EmitterHub,
+	CodeUnsupported:          EmitterHub,
+	"E_CONNECT":              EmitterClient,
+	"E_UNAUTHORIZED":         EmitterClient,
+	"E_HOSTKEY_CHANGED":      EmitterClient,
+	"E_CHANNEL_LOST":         EmitterClient,
+	"E_SEND_UNKNOWN":         EmitterClient,
+	"E_HELLO_TIMEOUT":        EmitterClient,
+	"E_HUB_NO_BINARY":        EmitterClient,
+	"E_NOT_JOINED":           EmitterClient,
+	"E_NO_SSH":               EmitterClient,
+}
+
+// ProtocolError is a named session/codec failure. Operation errors keep their
+// mapping in op.CodeFor; the codec contributes only the eight codes above.
+type ProtocolError struct {
+	Code        string
+	Msg         string
+	Retriable   bool
+	ClaimedHeld bool
+}
+
+func (e *ProtocolError) Error() string { return e.Msg }
+
+func protocolError(code, msg string) error {
+	return &ProtocolError{Code: code, Msg: msg}
+}
+
+// CodeFor is the complete hub-side error mapping.
+func CodeFor(err error) string {
+	if err == nil {
+		return ""
+	}
+	var pe *ProtocolError
+	if errors.As(err, &pe) {
+		return pe.Code
+	}
+	return op.CodeFor(err)
+}

--- a/internal/hubwire/frame.go
+++ b/internal/hubwire/frame.go
@@ -158,9 +158,12 @@ type Status struct{ RequestBase }
 
 type StatusOK struct {
 	ResponseBase
-	Agents    []op.StatusAgent `json:"agents"`
-	Truncated bool             `json:"truncated"`
-	Now       time.Time        `json:"now"`
+	Agents []op.StatusAgent `json:"agents"`
+	// Truncated must remain present when false: EncodeStatus measures candidates
+	// with false, whose encoding is one byte longer than true. Omitting false
+	// would make the wire budget optimistic at the 64 KiB boundary.
+	Truncated bool      `json:"truncated"`
+	Now       time.Time `json:"now"`
 }
 
 type Gate struct {

--- a/internal/hubwire/frame.go
+++ b/internal/hubwire/frame.go
@@ -1,0 +1,256 @@
+package hubwire
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+const (
+	Protocol       = "agentchute-hub"
+	Version        = 1
+	MinVersion     = 1
+	MaxControlLine = 64 << 10
+	MaxBody        = 4 << 20
+	MaxStatusRows  = 64
+)
+
+type RequestBase struct {
+	T  string `json:"t"`
+	ID int64  `json:"id"`
+}
+
+type ResponseBase struct {
+	T  string `json:"t"`
+	Re int64  `json:"re,omitempty"`
+}
+
+type Hello struct {
+	RequestBase
+	Proto string `json:"proto"`
+	V     int    `json:"v"`
+	MinV  int    `json:"min_v"`
+	Agent string `json:"agent"`
+	Bin   string `json:"bin"`
+}
+
+type HelloOK struct {
+	ResponseBase
+	V        int       `json:"v"`
+	Agent    string    `json:"agent"`
+	Pool     string    `json:"pool"`
+	Pool12   string    `json:"pool12"`
+	Writable bool      `json:"writable"`
+	HubBin   string    `json:"hub_bin"`
+	HubTime  time.Time `json:"hub_time"`
+}
+
+type Send struct {
+	RequestBase
+	To         string `json:"to"`
+	Ask        bool   `json:"ask,omitempty"`
+	ReplyByS   int64  `json:"reply_by_s,omitempty"`
+	ServeToken string `json:"serve_token,omitempty"`
+}
+
+type SendOK struct {
+	ResponseBase
+	Filename       string `json:"filename"`
+	Ref            string `json:"ref"`
+	Committed      bool   `json:"committed"`
+	DurabilityNote string `json:"durability_note"`
+	OwedNote       string `json:"owed_note"`
+}
+
+type Message struct {
+	ResponseBase
+	Filename      string `json:"filename"`
+	Sender        string `json:"sender"`
+	Stamp         string `json:"stamp"`
+	Redelivered   bool   `json:"redelivered,omitempty"`
+	ReplyRequired bool   `json:"reply_required,omitempty"`
+	ReplyRef      string `json:"reply_ref,omitempty"`
+}
+
+type OwedItem struct {
+	ResponseBase
+	To         string    `json:"to"`
+	From       string    `json:"from"`
+	Seq        uint64    `json:"seq,omitempty"`
+	Stamp      string    `json:"stamp,omitempty"`
+	Suffix     string    `json:"suffix,omitempty"`
+	By         time.Time `json:"by"`
+	RecordedAt time.Time `json:"recorded_at"`
+	Ref        string    `json:"ref"`
+}
+
+type Check struct {
+	RequestBase
+	Limit     int  `json:"limit,omitempty"`
+	NoArchive bool `json:"no_archive,omitempty"`
+}
+
+type CheckOK struct {
+	ResponseBase
+	Claimed     int `json:"claimed"`
+	Redelivered int `json:"redelivered"`
+	Quarantined int `json:"quarantined"`
+	OwedExpired int `json:"owed_expired"`
+}
+
+type Ack struct{ RequestBase }
+
+type AckItem struct {
+	ResponseBase
+	Filename    string `json:"filename"`
+	ArchivePath string `json:"archive_path"`
+}
+
+type AckOK struct {
+	ResponseBase
+	Acked        int      `json:"acked"`
+	GateClear    bool     `json:"gate_clear"`
+	BlockReasons []string `json:"block_reasons,omitempty"`
+}
+
+type Register struct {
+	RequestBase
+	Vendor       *string  `json:"vendor,omitempty"`
+	Host         string   `json:"host"`
+	Bio          *string  `json:"bio,omitempty"`
+	WorkingRepos []string `json:"working_repos,omitempty"`
+	Announce     bool     `json:"announce,omitempty"`
+	Sweep        bool     `json:"sweep,omitempty"`
+	ServeToken   string   `json:"serve_token,omitempty"`
+}
+
+type Registration struct {
+	AgentID         string    `json:"agent_id"`
+	ProtocolVersion int       `json:"v"`
+	Vendor          string    `json:"vendor"`
+	ControlRepo     string    `json:"control_repo"`
+	WorkingRepos    []string  `json:"working_repos,omitempty"`
+	Host            string    `json:"host"`
+	LastSeen        time.Time `json:"last_seen"`
+}
+
+type Announce struct {
+	Sent     int      `json:"sent"`
+	Total    int      `json:"total"`
+	Warnings []string `json:"warnings"`
+}
+
+type RegisterOK struct {
+	ResponseBase
+	Announce      *Announce    `json:"announce"`
+	Pending       int          `json:"pending"`
+	Reg           Registration `json:"reg"`
+	InboxDir      string       `json:"inbox_dir"`
+	Refreshed     bool         `json:"refreshed"`
+	ExistingFound bool         `json:"existing_found"`
+	ResolvedHost  string       `json:"resolved_host"`
+	Warnings      []string     `json:"warnings"`
+}
+
+type Status struct{ RequestBase }
+
+type StatusOK struct {
+	ResponseBase
+	Agents    []op.StatusAgent `json:"agents"`
+	Truncated bool             `json:"truncated"`
+	Now       time.Time        `json:"now"`
+}
+
+type Gate struct {
+	RequestBase
+	Phase          string `json:"phase"`
+	RequireConfirm bool   `json:"require_confirm,omitempty"`
+	AckStaleReg    bool   `json:"ack_stale_reg,omitempty"`
+}
+
+type GateOK struct {
+	ResponseBase
+	op.GateResp
+}
+
+type Pending struct {
+	RequestBase
+	ShowBody bool `json:"show_body,omitempty"`
+}
+
+type PendingOK struct {
+	ResponseBase
+	Unread    int  `json:"unread"`
+	Owed      int  `json:"owed"`
+	Malformed int  `json:"malformed"`
+	NeedsBoot bool `json:"needs_boot,omitempty"`
+}
+
+type CleanOwed struct {
+	RequestBase
+	Apply bool `json:"apply,omitempty"`
+}
+
+type CleanOwedOK struct {
+	ResponseBase
+	Agent   string   `json:"agent"`
+	Pruned  []string `json:"pruned"`
+	Applied bool     `json:"applied"`
+}
+
+type LeaseAcquire struct{ RequestBase }
+
+type LeaseOK struct {
+	ResponseBase
+	Token string `json:"token"`
+}
+
+type Tick struct{ RequestBase }
+
+type TickOK struct {
+	ResponseBase
+	Pending  int      `json:"pending"`
+	Skipped  int      `json:"skipped"`
+	Swept    []string `json:"swept,omitempty"`
+	Warnings []string `json:"warnings"`
+}
+
+type LeaseRelease struct{ RequestBase }
+type ReleaseOK struct{ ResponseBase }
+
+type Note struct {
+	ResponseBase
+	Level string `json:"level"`
+	Msg   string `json:"msg"`
+}
+
+type Error struct {
+	ResponseBase
+	Code        string `json:"code"`
+	Msg         string `json:"msg"`
+	Retriable   bool   `json:"retriable"`
+	ClaimedHeld bool   `json:"claimed_held,omitempty"`
+}
+
+func NewError(re int64, err error) Error {
+	f := Error{
+		ResponseBase: ResponseBase{T: "error", Re: re},
+		Code:         CodeFor(err),
+		Msg:          err.Error(),
+	}
+	var pe *ProtocolError
+	if errors.As(err, &pe) {
+		f.Retriable = pe.Retriable
+		f.ClaimedHeld = pe.ClaimedHeld
+	}
+	return f
+}
+
+func ValidateNoteLevel(level string) error {
+	if level != op.NoteWarn && level != op.NoteInfo {
+		return protocolError(CodeMalformedFrame, fmt.Sprintf("invalid note level %q", level))
+	}
+	return nil
+}

--- a/internal/hubwire/fuzz_test.go
+++ b/internal/hubwire/fuzz_test.go
@@ -1,0 +1,15 @@
+package hubwire
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzReader(f *testing.F) {
+	f.Add([]byte("{\"t\":\"check\",\"id\":1}\n"))
+	f.Add([]byte("{\"t\":\"send\",\"id\":2,\"body_len\":1}\nx"))
+	f.Fuzz(func(t *testing.T, data []byte) {
+		reader := NewReader(bytes.NewReader(data))
+		_, _ = reader.Read()
+	})
+}

--- a/internal/hubwire/handshake.go
+++ b/internal/hubwire/handshake.go
@@ -1,0 +1,69 @@
+package hubwire
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type HandshakeOptions struct {
+	PinnedAgent string
+	Pool        string
+	Pool12      string
+	HubBin      string
+	HubMin      int
+	HubMax      int
+	Now         func() time.Time
+}
+
+func NegotiateHello(req Hello, opts HandshakeOptions) (HelloOK, error) {
+	if req.T != "hello" || req.Proto != Protocol {
+		return HelloOK{}, protocolError(CodeVersion, fmt.Sprintf("hub speaks %s v1; client requested %q", Protocol, req.Proto))
+	}
+	hubMin, hubMax := opts.HubMin, opts.HubMax
+	if hubMin == 0 {
+		hubMin = MinVersion
+	}
+	if hubMax == 0 {
+		hubMax = Version
+	}
+	use := hubMax
+	if req.V < use {
+		use = req.V
+	}
+	if use < req.MinV || use < hubMin {
+		return HelloOK{}, protocolError(CodeVersion, fmt.Sprintf("hub speaks %s v%d; client requires >=%d; upgrade the hub first", Protocol, hubMax, req.MinV))
+	}
+	if req.Agent != opts.PinnedAgent {
+		return HelloOK{}, protocolError(CodeIdentity, fmt.Sprintf("key is authorized as %q; you are acting as %q", opts.PinnedAgent, req.Agent))
+	}
+	now := time.Now().UTC()
+	if opts.Now != nil {
+		now = opts.Now().UTC()
+	}
+	return HelloOK{
+		ResponseBase: ResponseBase{T: "hello-ok", Re: req.ID},
+		V:            use,
+		Agent:        opts.PinnedAgent,
+		Pool:         opts.Pool,
+		Pool12:       opts.Pool12,
+		Writable:     probeWritable(filepath.Join(opts.Pool, ".agentchute", "loop", "state")),
+		HubBin:       opts.HubBin,
+		HubTime:      now,
+	}, nil
+}
+
+func probeWritable(dir string) bool {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return false
+	}
+	f, err := os.CreateTemp(dir, ".hub-write-probe-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	closeErr := f.Close()
+	removeErr := os.Remove(name)
+	return closeErr == nil && removeErr == nil
+}

--- a/internal/hubwire/handshake_test.go
+++ b/internal/hubwire/handshake_test.go
@@ -1,0 +1,44 @@
+package hubwire
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestHandshakeMatrix(t *testing.T) {
+	now := time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		clientV   int
+		clientMin int
+		hubMax    int
+		wantV     int
+		wantCode  string
+	}{
+		{"v1-v1", 1, 1, 1, 1, ""},
+		{"v1 client v2 hub", 1, 1, 2, 1, ""},
+		{"v2 client v1 hub", 2, 1, 1, 1, ""},
+		{"client requires v2", 2, 2, 1, 0, CodeVersion},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := NegotiateHello(Hello{RequestBase: RequestBase{T: "hello", ID: 1}, Proto: Protocol, V: tc.clientV, MinV: tc.clientMin, Agent: "codex"}, HandshakeOptions{PinnedAgent: "codex", Pool: t.TempDir(), Pool12: "0123456789ab", HubMax: tc.hubMax, Now: func() time.Time { return now }})
+			if tc.wantCode != "" {
+				assertCode(t, err, tc.wantCode)
+				return
+			}
+			if err != nil || resp.V != tc.wantV || resp.Pool12 != "0123456789ab" || !resp.HubTime.Equal(now) {
+				t.Fatalf("resp=%+v err=%v", resp, err)
+			}
+		})
+	}
+}
+
+func TestHandshakeIdentityMismatch(t *testing.T) {
+	_, err := NegotiateHello(Hello{RequestBase: RequestBase{T: "hello", ID: 1}, Proto: Protocol, V: 1, MinV: 1, Agent: "grok"}, HandshakeOptions{PinnedAgent: "codex"})
+	var pe *ProtocolError
+	if !errors.As(err, &pe) || pe.Code != CodeIdentity {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/internal/hubwire/stream_test.go
+++ b/internal/hubwire/stream_test.go
@@ -1,0 +1,152 @@
+package hubwire
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+type measuringWriter struct {
+	writes   int
+	maxWrite int
+}
+
+func (w *measuringWriter) Write(p []byte) (int, error) {
+	w.writes++
+	if len(p) > w.maxWrite {
+		w.maxWrite = len(p)
+	}
+	return len(p), nil
+}
+
+func TestStreamThirtyTwoMaximumBodiesNeverCombinesBodies(t *testing.T) {
+	transport := &measuringWriter{}
+	w := NewWriter(transport)
+	body := bytes.Repeat([]byte{'x'}, MaxBody)
+	for i := 0; i < 32; i++ {
+		if err := w.Write(Message{ResponseBase: ResponseBase{T: "msg", Re: 2}, Filename: "m", Sender: "grok"}, body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// One small control write plus one body write per event. A codec that
+	// concatenates control+body, or buffers a second body, exceeds this bound.
+	if transport.writes != 64 || transport.maxWrite != MaxBody {
+		t.Fatalf("writes=%d max=%d, want 64 writes with max one body (%d)", transport.writes, transport.maxWrite, MaxBody)
+	}
+}
+
+type failCallWriter struct {
+	bytes.Buffer
+	calls  int
+	failAt int
+}
+
+func (w *failCallWriter) Write(p []byte) (int, error) {
+	w.calls++
+	if w.calls >= w.failAt {
+		return 0, io.ErrClosedPipe
+	}
+	return w.Buffer.Write(p)
+}
+
+func TestTypedEventStreamOrderAndFailureBoundaries(t *testing.T) {
+	first := Message{ResponseBase: ResponseBase{T: "msg", Re: 2}, Filename: "m", Sender: "grok"}
+	note := Note{ResponseBase: ResponseBase{T: "note", Re: 2}, Level: op.NoteInfo, Msg: "mid-stream"}
+	owed := OwedItem{ResponseBase: ResponseBase{T: "owed-item", Re: 2}, To: "grok", From: "codex", Ref: "r"}
+
+	// Failure after the first emitted item: its control+body are complete and
+	// the next frame contributes no partial bytes.
+	afterFirst := &failCallWriter{failAt: 3}
+	w := NewWriter(afterFirst)
+	if err := w.Write(first, []byte("body")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Write(note, nil); !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("failure = %v", err)
+	}
+	r := NewReader(bytes.NewReader(afterFirst.Bytes()))
+	raw, err := r.Read()
+	if err != nil || raw.T != "msg" || string(raw.Body) != "body" {
+		t.Fatalf("preserved first event = %s %q, %v", raw.T, raw.Body, err)
+	}
+	if _, err := r.Read(); !errors.Is(err, io.EOF) {
+		t.Fatalf("partial next frame survived: %v", err)
+	}
+
+	// Failure after a mid-stream note: msg then note remain in production
+	// order; the later owed item contributes no partial frame.
+	afterNote := &failCallWriter{failAt: 4}
+	w = NewWriter(afterNote)
+	if err := w.Write(first, []byte("body")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Write(note, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Write(owed, nil); !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("failure = %v", err)
+	}
+	r = NewReader(bytes.NewReader(afterNote.Bytes()))
+	var got []string
+	for {
+		raw, err := r.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, raw.T)
+	}
+	if len(got) != 2 || got[0] != "msg" || got[1] != "note" {
+		t.Fatalf("order = %v", got)
+	}
+}
+
+func TestInterleavedNoteLevelsPreserveFrameOrder(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf)
+	frames := []any{
+		Message{ResponseBase: ResponseBase{T: "msg", Re: 2}, Filename: "a", Sender: "grok"},
+		Note{ResponseBase: ResponseBase{T: "note", Re: 2}, Level: op.NoteWarn, Msg: "warn"},
+		OwedItem{ResponseBase: ResponseBase{T: "owed-item", Re: 2}, To: "grok", From: "codex", Ref: "r"},
+		Note{ResponseBase: ResponseBase{T: "note", Re: 2}, Level: op.NoteInfo, Msg: "info"},
+	}
+	for _, frame := range frames {
+		if err := w.Write(frame, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r := NewReader(&buf)
+	want := []string{"msg", "note", "owed-item", "note"}
+	for i, typ := range want {
+		raw, err := r.Read()
+		if err != nil || raw.T != typ {
+			t.Fatalf("frame %d = %s, %v", i, raw.T, err)
+		}
+		if raw.T == "note" {
+			var note Note
+			if err := raw.Decode(&note); err != nil {
+				t.Fatal(err)
+			}
+			wantLevel := op.NoteWarn
+			if i == 3 {
+				wantLevel = op.NoteInfo
+			}
+			if note.Level != wantLevel {
+				t.Fatalf("note %d level = %s", i, note.Level)
+			}
+		}
+	}
+}
+
+func TestPendingMaximumBodyUsesOrdinaryTrailer(t *testing.T) {
+	body := bytes.Repeat([]byte{'p'}, MaxBody)
+	got := roundTrip(t, Message{ResponseBase: ResponseBase{T: "msg", Re: 9}, Filename: "pending", Sender: "grok"}, body)
+	if got.T != "msg" || len(got.Body) != MaxBody {
+		t.Fatalf("pending msg = %s body=%d", got.T, len(got.Body))
+	}
+}

--- a/internal/hubwire/testdata/fuzz/FuzzReader/check
+++ b/internal/hubwire/testdata/fuzz/FuzzReader/check
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"t\":\"check\",\"id\":1}\n")

--- a/internal/hubwire/testdata/fuzz/FuzzReader/truncated
+++ b/internal/hubwire/testdata/fuzz/FuzzReader/truncated
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("{\"t\":\"send\",\"id\":2,\"body_len\":4}\nabc")

--- a/internal/loop/bootref_darwin.go
+++ b/internal/loop/bootref_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+package loop
+
+import (
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+func platformBootRef() string {
+	ref, err := unix.Sysctl("kern.bootsessionuuid")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(ref)
+}

--- a/internal/loop/bootref_linux.go
+++ b/internal/loop/bootref_linux.go
@@ -1,0 +1,13 @@
+//go:build linux
+
+package loop
+
+import "strings"
+
+func platformBootRef() string {
+	b, err := ReadFileLimit("/proc/sys/kernel/random/boot_id", 64)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}

--- a/internal/loop/bootref_other.go
+++ b/internal/loop/bootref_other.go
@@ -1,0 +1,5 @@
+//go:build !linux && !darwin
+
+package loop
+
+func platformBootRef() string { return "" }

--- a/internal/loop/lease.go
+++ b/internal/loop/lease.go
@@ -56,6 +56,7 @@ type ServeClaim struct {
 	ID         string    `json:"id"`
 	Host       string    `json:"host"`
 	PID        int       `json:"pid"`
+	BootRef    string    `json:"boot_ref,omitempty"`
 	ServeToken string    `json:"serve_token"` // the FENCE epoch (128-bit crypto/rand hex).
 	StartedAt  time.Time `json:"started_at"`
 	LastSeen   time.Time `json:"last_seen"`
@@ -86,6 +87,10 @@ var mintServeToken = func() (string, error) {
 	}
 	return hex.EncodeToString(b[:]), nil
 }
+
+// readBootRef is injectable so reclaim behavior is deterministic in tests.
+// Production implementations are platform-specific and return "" on failure.
+var readBootRef = platformBootRef
 
 // afterReclaimWriteHook, when non-nil, is invoked AFTER a stale-reclaim writes
 // its claim, still INSIDE withAgentLock. Test-only: lets a test observe the
@@ -156,40 +161,50 @@ func AcquireServeLease(cfg *Config, id string) (*ServeLease, error) {
 	if err != nil {
 		return nil, err
 	}
-	now := time.Now().UTC()
-	claim := &ServeClaim{
-		ID:         id,
-		Host:       host,
-		PID:        os.Getpid(),
-		ServeToken: token,
-		StartedAt:  now,
-		LastSeen:   now,
-	}
 
 	stateDir := cfg.AgentStateDir(id)
 	if err := ensurePrivateDir(stateDir); err != nil {
 		return nil, err
 	}
-	data, err := marshalClaim(claim)
-	if err != nil {
-		return nil, err
-	}
-
-	tempFile, err := os.CreateTemp(stateDir, tempFilePrefix+"*")
-	if err != nil {
-		return nil, err
-	}
-	tempPath := tempFile.Name()
-	defer func() { _ = os.Remove(tempPath) }()
-	if err := writeAndSyncOpenFile(tempFile, data); err != nil {
-		return nil, err
-	}
 	path := claimPath(cfg, id)
+	var tempPath string
+	defer func() {
+		if tempPath != "" {
+			_ = os.Remove(tempPath)
+		}
+	}()
 
 	// withAgentLock is NON-reentrant (filelock_unix.go): nothing in this closure
 	// may call a function that itself takes withAgentLock(cfg,id).
 	var lease *ServeLease
 	lockErr := withAgentLock(cfg, id, func() error {
+		// The boot reference is sampled inside the same critical section as the
+		// stale-claim decision. A reboot boundary can therefore never be observed
+		// on one side of the decision but recorded on the other.
+		bootRef := readBootRef()
+		now := time.Now().UTC()
+		claim := &ServeClaim{
+			ID:         id,
+			Host:       host,
+			PID:        os.Getpid(),
+			BootRef:    bootRef,
+			ServeToken: token,
+			StartedAt:  now,
+			LastSeen:   now,
+		}
+		data, err := marshalClaim(claim)
+		if err != nil {
+			return err
+		}
+		tempFile, err := os.CreateTemp(stateDir, tempFilePrefix+"*")
+		if err != nil {
+			return err
+		}
+		tempPath = tempFile.Name()
+		if err := writeAndSyncOpenFile(tempFile, data); err != nil {
+			return err
+		}
+
 		// Fresh-acquire attempt, now INSIDE the lock: link-no-clobber a unique
 		// temp inode into place. No claim exists yet in the common case, so
 		// this succeeds immediately.
@@ -233,13 +248,11 @@ func AcquireServeLease(cfg *Config, id string) (*ServeLease, error) {
 		// (d) Stale + same-host + pid alive: a frozen-but-alive process keeps its
 		// id (don't steal a live lane).
 		//
-		// LIMITATION (FIX 4 / §6b deferred to Gate 6): pidAlive is pid-ONLY
-		// liveness and is vulnerable to OS PID REUSE — a recycled pid number can
-		// read as "alive" and wrongly protect a dead lane (or, conversely, mask a
-		// distinct live process). §6b's full "pid/socket proof" — corroborate the
-		// pid with the process start-time or the runner socket — is deferred to
-		// Gate 6, when serve owns the socket. No behavior change here.
-		if existing.Host == host && pidAlive(existing.PID) {
+		// A differing, non-empty per-boot reference proves the recorded process
+		// belonged to a prior boot even when its pid has since been recycled. An
+		// absent or matching reference preserves the pid-only fail-closed rule.
+		if existing.Host == host && pidAlive(existing.PID) &&
+			(existing.BootRef == "" || bootRef == "" || existing.BootRef == bootRef) {
 			return ErrLeaseHeld
 		}
 		// (e) Stale + reclaimable: rename over the stale claim. Under the lock no

--- a/internal/loop/lease_test.go
+++ b/internal/loop/lease_test.go
@@ -1,6 +1,7 @@
 package loop
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,6 +58,178 @@ func withPidAlive(t *testing.T, fn func(int) bool) {
 	prev := pidAlive
 	pidAlive = fn
 	t.Cleanup(func() { pidAlive = prev })
+}
+
+func withBootRef(t *testing.T, ref string) {
+	t.Helper()
+	prev := readBootRef
+	readBootRef = func() string { return ref }
+	t.Cleanup(func() { readBootRef = prev })
+}
+
+func staleLiveClaim(t *testing.T, cfg *Config, bootRef string) {
+	t.Helper()
+	host, _ := os.Hostname()
+	writeClaim(t, cfg, &ServeClaim{
+		ID:         "alice",
+		Host:       host,
+		PID:        4242,
+		BootRef:    bootRef,
+		ServeToken: "old",
+		StartedAt:  time.Now().Add(-time.Hour).UTC(),
+		LastSeen:   time.Now().Add(-time.Hour).UTC(),
+	})
+	withPidAlive(t, func(int) bool { return true })
+}
+
+func TestAcquireServeLeaseBootReferenceRules(t *testing.T) {
+	tests := []struct {
+		name     string
+		stored   string
+		current  string
+		wantHeld bool
+	}{
+		{name: "different reclaims recycled pid", stored: "old-boot", current: "new-boot"},
+		{name: "matching refuses", stored: "same-boot", current: "same-boot", wantHeld: true},
+		{name: "pre-upgrade absent refuses", current: "new-boot", wantHeld: true},
+		{name: "current unreadable refuses", stored: "old-boot", wantHeld: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := newLeaseTestConfig(t)
+			staleLiveClaim(t, cfg, tc.stored)
+			withBootRef(t, tc.current)
+			lease, err := AcquireServeLease(cfg, "alice")
+			if tc.wantHeld {
+				if err != ErrLeaseHeld {
+					t.Fatalf("err = %v, want ErrLeaseHeld", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("reclaim: %v", err)
+			}
+			if lease.Token == "old" {
+				t.Fatal("reclaim kept the stale token")
+			}
+		})
+	}
+}
+
+func TestAcquireServeLeaseFreshnessPrecedesBootReference(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	host, _ := os.Hostname()
+	writeClaim(t, cfg, &ServeClaim{
+		ID: "alice", Host: host, PID: 4242, BootRef: "old-boot", ServeToken: "old",
+		StartedAt: time.Now().UTC(), LastSeen: time.Now().UTC(),
+	})
+	withPidAlive(t, func(int) bool { return true })
+	withBootRef(t, "new-boot")
+	if _, err := AcquireServeLease(cfg, "alice"); err != ErrLeaseHeld {
+		t.Fatalf("fresh differing-ref err = %v, want ErrLeaseHeld", err)
+	}
+}
+
+func TestClockStepsDoNotStealLiveLease(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	withBootRef(t, "same-boot")
+	lease, err := AcquireServeLease(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, _ := os.Hostname()
+	withPidAlive(t, func(int) bool { return true })
+	for _, lastSeen := range []time.Time{
+		time.Now().UTC().Add(-24 * time.Hour),
+		time.Now().UTC().Add(24 * time.Hour),
+	} {
+		claim, err := readClaim(claimPath(cfg, "alice"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		claim.Host = host
+		claim.PID = 4242
+		claim.LastSeen = lastSeen
+		writeClaim(t, cfg, claim)
+		before, err := os.ReadFile(claimPath(cfg, "alice"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := AcquireServeLease(cfg, "alice"); err != ErrLeaseHeld {
+			t.Fatalf("last_seen %s: err = %v, want ErrLeaseHeld", lastSeen, err)
+		}
+		afterBytes, err := os.ReadFile(claimPath(cfg, "alice"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(afterBytes) != string(before) {
+			t.Fatal("failed clock-step acquire changed the claim bytes")
+		}
+		after, err := readClaim(claimPath(cfg, "alice"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if after.ServeToken != lease.Token {
+			t.Fatalf("clock step changed token %q to %q", lease.Token, after.ServeToken)
+		}
+	}
+}
+
+func TestRenewLeaseDropsUnknownClaimKey(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	withBootRef(t, "this-boot")
+	lease, err := AcquireServeLease(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := claimPath(cfg, "alice")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(b, &fields); err != nil {
+		t.Fatal(err)
+	}
+	fields["future_key"] = "accepted-on-read"
+	b, _ = json.MarshalIndent(fields, "", "  ")
+	if err := os.WriteFile(path, append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readClaim(path); err != nil {
+		t.Fatalf("unknown claim key did not parse: %v", err)
+	}
+	if err := RenewLease(lease); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(after), "future_key") {
+		t.Fatal("unknown claim key survived the typed renew rewrite")
+	}
+}
+
+func TestRenewLeasePreservesBootReference(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	withBootRef(t, "this-boot")
+	lease, err := AcquireServeLease(cfg, "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := RenewLease(lease); err != nil {
+			t.Fatal(err)
+		}
+		claim, err := readClaim(claimPath(cfg, "alice"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if claim.BootRef != "this-boot" {
+			t.Fatalf("renew %d boot_ref = %q", i, claim.BootRef)
+		}
+	}
 }
 
 func TestAcquireServeLeaseFreshClaimFailsClosed(t *testing.T) {

--- a/internal/op/channel.go
+++ b/internal/op/channel.go
@@ -110,9 +110,19 @@ func (c *Channel) Token() string {
 // also where the template comes from — the tick needs one, and a validating
 // template is exactly this request's payload.
 func (c *Channel) Register(req RegisterReq) (RegisterResp, error) {
+	return c.register(req, nil)
+}
+
+// RegisterWithPrecommitValidation is Register with a transport-owned response
+// validator that runs before the registration write.
+func (c *Channel) RegisterWithPrecommitValidation(req RegisterReq, validate func(RegisterResp) error) (RegisterResp, error) {
+	return c.register(req, validate)
+}
+
+func (c *Channel) register(req RegisterReq, validate func(RegisterResp) error) (RegisterResp, error) {
 	req.ServeToken = c.Token()
 	now := time.Now().UTC()
-	resp, err := Register(c.cfg, c.ctx, req, now)
+	resp, err := register(c.cfg, c.ctx, req, now, validate)
 	if err != nil {
 		return resp, err
 	}

--- a/internal/op/register.go
+++ b/internal/op/register.go
@@ -105,6 +105,17 @@ type RegisterResp struct {
 // A fresh serve lease owned by another process refuses the registration
 // regardless of row age; stale same-id state is merged as crash recovery.
 func Register(cfg *loop.Config, ctx Context, req RegisterReq, now time.Time) (RegisterResp, error) {
+	return register(cfg, ctx, req, now, nil)
+}
+
+// RegisterWithPrecommitValidation lets a transport reject a response shape
+// before the corresponding registration becomes visible. The validator runs
+// under the agent lock after the final merge but before any filesystem write.
+func RegisterWithPrecommitValidation(cfg *loop.Config, ctx Context, req RegisterReq, now time.Time, validate func(RegisterResp) error) (RegisterResp, error) {
+	return register(cfg, ctx, req, now, validate)
+}
+
+func register(cfg *loop.Config, ctx Context, req RegisterReq, now time.Time, validate func(RegisterResp) error) (RegisterResp, error) {
 	if err := loop.ValidateAgentID(ctx.ActorID); err != nil {
 		return RegisterResp{}, err
 	}
@@ -129,13 +140,13 @@ func Register(cfg *loop.Config, ctx Context, req RegisterReq, now time.Time) (Re
 		return RegisterResp{}, fmt.Errorf("missing --vendor (recommended values: anthropic, openai, local, human)")
 	}
 
-	resp, err := publishRegistrationOnce(cfg, ctx.ActorID, vendor, req, now)
+	resp, err := publishRegistrationOnce(cfg, ctx.ActorID, vendor, req, now, validate)
 	if os.IsExist(err) {
 		// WriteRegistrationExclusive closed a creation race with a writer that
 		// did not take our agent lock. Re-read once through the normal merge
 		// path; its live-owner check decides whether this caller may adopt the
 		// now-existing row.
-		resp, err = publishRegistrationOnce(cfg, ctx.ActorID, vendor, req, now)
+		resp, err = publishRegistrationOnce(cfg, ctx.ActorID, vendor, req, now, validate)
 	}
 	if err != nil {
 		return RegisterResp{}, err
@@ -172,7 +183,7 @@ func Register(cfg *loop.Config, ctx Context, req RegisterReq, now time.Time) (Re
 // no-wake record, ensure the inbox dir, then write — exclusively
 // (create-if-not-exists) on a fresh row, so a concurrent same-id create is
 // re-read before this process may merge it.
-func publishRegistrationOnce(cfg *loop.Config, agentID, vendor string, req RegisterReq, now time.Time) (RegisterResp, error) {
+func publishRegistrationOnce(cfg *loop.Config, agentID, vendor string, req RegisterReq, now time.Time, validate func(RegisterResp) error) (RegisterResp, error) {
 	regPath := cfg.AgentRegistrationPath(agentID)
 	inboxDir := cfg.AgentInboxDir(agentID)
 
@@ -216,6 +227,13 @@ func publishRegistrationOnce(cfg *loop.Config, agentID, vendor string, req Regis
 			reg.Body = *req.Bio
 		}
 
+		resp := registerWriteResponse(reg, inboxDir, existingFound, req.Host)
+		if validate != nil {
+			if verr := validate(resp); verr != nil {
+				return verr
+			}
+		}
+
 		// Fix A2: create the inbox (and the agent-state dir) BEFORE publishing
 		// the registration so a peer can never observe a live registration with
 		// no inbox. A leftover empty inbox dir for an id whose exclusive create
@@ -245,13 +263,17 @@ func publishRegistrationOnce(cfg *loop.Config, agentID, vendor string, req Regis
 		return RegisterResp{}, err
 	}
 
+	return registerWriteResponse(reg, inboxDir, existingFound, req.Host), nil
+}
+
+func registerWriteResponse(reg *loop.Registration, inboxDir string, existingFound bool, resolvedHost string) RegisterResp {
 	return RegisterResp{
 		Reg:           RegistrationViewOf(reg),
 		InboxDir:      inboxDir,
 		Refreshed:     true, // §5: any successful boot/register write reports refreshed
 		ExistingFound: existingFound,
-		ResolvedHost:  req.Host,
-	}, nil
+		ResolvedHost:  resolvedHost,
+	}
 }
 
 // registrationLiveElsewhere reports whether a FRESH serve claim owns this id and

--- a/internal/op/send.go
+++ b/internal/op/send.go
@@ -7,13 +7,7 @@ import (
 	"github.com/agentchute/agentchute/internal/loop"
 )
 
-// SendTsMessageWithCommit is the delivery seam (F1): mint the send stamp under
-// the write-ahead floor, then link into the recipient's inbox under their lock
-// (fresh-suffix EEXIST retry included). EXPORTED deliberately — two existing
-// package-`cli` tests reassign it to force a post-link sync failure and a
-// fresh-but-racing recipient, and an unexported var here would leave them
-// nothing to patch. One production call site: Send, below.
-var SendTsMessageWithCommit = loop.SendTsMessageWithCommit
+type sendDelivery func(*loop.Config, string, string, []byte, string) (loop.TsID, bool, error)
 
 // SendReq is a fully composed message plus its delivery options.
 //
@@ -113,6 +107,13 @@ func SendPreflight(cfg *loop.Config, ctx Context, to string) error {
 // expressible on the wire at all. A seam whose local behavior cannot survive
 // its own transport is a seam defect, so the fact moved onto the response.
 func Send(cfg *loop.Config, ctx Context, req SendReq) (SendResp, error) {
+	return sendWithDelivery(cfg, ctx, req, loop.SendTsMessageWithCommit)
+}
+
+// sendWithDelivery keeps the delivery dependency invocation-scoped. A hub
+// process may serve many sessions, so a mutable package seam would let one
+// session or test change every other session's send path.
+func sendWithDelivery(cfg *loop.Config, ctx Context, req SendReq, deliver sendDelivery) (SendResp, error) {
 	now := time.Now().UTC()
 
 	if err := SendPreflight(cfg, ctx, req.To); err != nil {
@@ -123,7 +124,7 @@ func Send(cfg *loop.Config, ctx Context, req SendReq) (SendResp, error) {
 	// `agentchute serve` carries the runner's active serve-lease epoch, so a
 	// write from a fenced (reclaimed) agent fails closed. Empty token (no
 	// serve lease) => intentionally unfenced.
-	id, committed, sendErr := SendTsMessageWithCommit(cfg, ctx.ActorID, req.To, req.Content, req.ServeToken)
+	id, committed, sendErr := deliver(cfg, ctx.ActorID, req.To, req.Content, req.ServeToken)
 	if sendErr != nil && !committed {
 		return SendResp{}, classifyDeliveryFailure(sendErr)
 	}

--- a/internal/op/send_globals_test.go
+++ b/internal/op/send_globals_test.go
@@ -1,0 +1,85 @@
+package op
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestSendHubPathHasNoMutablePackageState is the WI-3.6 check. It follows the
+// local function call graph from Send and permits only the package's fixed
+// error sentinels. Any new package variable reachable from the production send
+// path fails, regardless of whether its name is exported.
+func TestSendHubPathHasNoMutablePackageState(t *testing.T) {
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate test source")
+	}
+	dir := filepath.Dir(self)
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(info os.FileInfo) bool {
+		return filepath.Ext(info.Name()) == ".go" && !strings.HasSuffix(info.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkg := pkgs["op"]
+	funcs := map[string]*ast.FuncDecl{}
+	vars := map[string]bool{}
+	for _, file := range pkg.Files {
+		for _, decl := range file.Decls {
+			switch decl := decl.(type) {
+			case *ast.FuncDecl:
+				if decl.Recv == nil {
+					funcs[decl.Name.Name] = decl
+				}
+			case *ast.GenDecl:
+				if decl.Tok != token.VAR {
+					continue
+				}
+				for _, spec := range decl.Specs {
+					for _, name := range spec.(*ast.ValueSpec).Names {
+						vars[name.Name] = true
+					}
+				}
+			}
+		}
+	}
+	allowed := map[string]bool{
+		"ErrNotRegistered": true, "ErrRecipientUnknown": true,
+		"ErrRecipientUnreadable": true, "ErrFenced": true,
+		"ErrLeaseHeld": true, "ErrRecipientStale": true,
+		"ErrRecipientRacing": true, "ErrOrder": true,
+	}
+	visited := map[string]bool{}
+	var walk func(string)
+	walk = func(name string) {
+		if visited[name] {
+			return
+		}
+		visited[name] = true
+		fn := funcs[name]
+		if fn == nil || fn.Body == nil {
+			return
+		}
+		ast.Inspect(fn.Body, func(node ast.Node) bool {
+			switch node := node.(type) {
+			case *ast.Ident:
+				if vars[node.Name] && !allowed[node.Name] {
+					t.Errorf("op.Send reaches mutable package state %q", node.Name)
+				}
+			case *ast.CallExpr:
+				if id, ok := node.Fun.(*ast.Ident); ok && funcs[id.Name] != nil {
+					walk(id.Name)
+				}
+			}
+			return true
+		})
+	}
+	walk("Send")
+}

--- a/internal/op/send_test.go
+++ b/internal/op/send_test.go
@@ -86,13 +86,11 @@ func TestSendClassifiesUnderLockStaleAsRacing(t *testing.T) {
 	enroll(t, cfg, "claude-code")
 	enroll(t, cfg, "codex")
 
-	original := SendTsMessageWithCommit
-	SendTsMessageWithCommit = func(*loop.Config, string, string, []byte, string) (loop.TsID, bool, error) {
+	deliver := func(*loop.Config, string, string, []byte, string) (loop.TsID, bool, error) {
 		return loop.TsID{}, false, &loop.ErrRecipientStale{To: "codex", Age: 90 * time.Second, Threshold: time.Hour}
 	}
-	defer func() { SendTsMessageWithCommit = original }()
 
-	resp, err := Send(cfg, Context{ActorID: "claude-code"}, SendReq{To: "codex", Content: []byte("body")})
+	resp, err := sendWithDelivery(cfg, Context{ActorID: "claude-code"}, SendReq{To: "codex", Content: []byte("body")}, deliver)
 	if !errors.Is(err, ErrRecipientRacing) {
 		t.Fatalf("err = %v, want ErrRecipientRacing", err)
 	}
@@ -189,17 +187,15 @@ func TestSendPartialSuccessReportsDurabilityNote(t *testing.T) {
 	enroll(t, cfg, "claude-code")
 	enroll(t, cfg, "codex")
 
-	original := SendTsMessageWithCommit
-	SendTsMessageWithCommit = func(cfg *loop.Config, from, to string, content []byte, token string) (loop.TsID, bool, error) {
-		id, committed, err := original(cfg, from, to, content, token)
+	deliver := func(cfg *loop.Config, from, to string, content []byte, token string) (loop.TsID, bool, error) {
+		id, committed, err := loop.SendTsMessageWithCommit(cfg, from, to, content, token)
 		if err != nil {
 			return id, committed, err
 		}
 		return id, true, errors.New("forced post-link sync failure")
 	}
-	defer func() { SendTsMessageWithCommit = original }()
 
-	resp, err := Send(cfg, Context{ActorID: "claude-code"}, SendReq{To: "codex", Content: []byte("body")})
+	resp, err := sendWithDelivery(cfg, Context{ActorID: "claude-code"}, SendReq{To: "codex", Content: []byte("body")}, deliver)
 	if err != nil {
 		t.Fatalf("partial success returned an error: %v", err)
 	}
@@ -269,15 +265,13 @@ func TestSendReportsDurabilityAndOwedFailuresIndependently(t *testing.T) {
 	enroll(t, cfg, "claude-code")
 	enroll(t, cfg, "codex")
 
-	original := SendTsMessageWithCommit
-	SendTsMessageWithCommit = func(cfg *loop.Config, from, to string, content []byte, token string) (loop.TsID, bool, error) {
-		id, committed, err := original(cfg, from, to, content, token)
+	deliver := func(cfg *loop.Config, from, to string, content []byte, token string) (loop.TsID, bool, error) {
+		id, committed, err := loop.SendTsMessageWithCommit(cfg, from, to, content, token)
 		if err != nil {
 			return id, committed, err
 		}
 		return id, true, errors.New("forced post-link sync failure")
 	}
-	defer func() { SendTsMessageWithCommit = original }()
 
 	if err := os.MkdirAll(cfg.AgentStateDir("claude-code"), 0o700); err != nil {
 		t.Fatal(err)
@@ -286,11 +280,11 @@ func TestSendReportsDurabilityAndOwedFailuresIndependently(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resp, err := Send(cfg, Context{ActorID: "claude-code"}, SendReq{
+	resp, err := sendWithDelivery(cfg, Context{ActorID: "claude-code"}, SendReq{
 		To:      "codex",
 		Content: loop.ComposeMessage("claude-code", "", "hi"),
 		Ask:     true,
-	})
+	}, deliver)
 	if err != nil {
 		t.Fatalf("a committed delivery must not return an error: %v", err)
 	}

--- a/internal/spectest/lease.go
+++ b/internal/spectest/lease.go
@@ -1,0 +1,140 @@
+package spectest
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+func AssertLeaseVectors(t *testing.T, vectors []Vector) {
+	t.Helper()
+	for _, vector := range vectors {
+		vector := vector
+		t.Run(vector.ID+"/"+vector.Kind, func(t *testing.T) {
+			cfg := newLeasePool(t)
+			switch vector.ID {
+			case "L1":
+				assertL1(t, cfg)
+			case "L2":
+				assertL2(t, cfg)
+			case "L3":
+				assertL3(t, cfg)
+			case "L4":
+				assertL4(t, cfg)
+			default:
+				t.Fatalf("unknown lease vector %s", vector.ID)
+			}
+		})
+	}
+}
+
+func newLeasePool(t *testing.T) *loop.Config {
+	t.Helper()
+	root := t.TempDir()
+	return &loop.Config{ControlRepo: root, LoopDir: filepath.Join(root, ".agentchute", "loop"), Vendor: "agentchute"}
+}
+
+func assertL1(t *testing.T, cfg *loop.Config) {
+	if _, err := loop.AcquireServeLease(cfg, "codex"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loop.AcquireServeLease(cfg, "codex"); !errors.Is(err, loop.ErrLeaseHeld) {
+		t.Fatalf("second acquire = %v", err)
+	}
+}
+
+func assertL2(t *testing.T, cfg *loop.Config) {
+	lease, err := loop.AcquireServeLease(cfg, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimPath := filepath.Join(cfg.AgentStateDir("codex"), "serve.claim")
+	rewriteClaimToken(t, claimPath, "successor")
+	before, err := os.ReadFile(claimPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := loop.RenewLease(lease); !errors.Is(err, loop.ErrFenced) {
+		t.Fatalf("renew = %v", err)
+	}
+	if _, err := loop.MintSendStamp(cfg, "codex", time.Now().UTC(), lease.Token); !errors.Is(err, loop.ErrFenced) {
+		t.Fatalf("mint = %v", err)
+	}
+	after, err := os.ReadFile(claimPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("fenced heartbeat or mint changed the successor claim")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.AgentStateDir("codex"), "send.floor")); !os.IsNotExist(err) {
+		t.Fatalf("fenced mint wrote send.floor: %v", err)
+	}
+}
+
+func assertL3(t *testing.T, cfg *loop.Config) {
+	lease, err := loop.AcquireServeLease(cfg, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimPath := filepath.Join(cfg.AgentStateDir("codex"), "serve.claim")
+	rewriteClaimToken(t, claimPath, "successor")
+	if err := loop.ReleaseLease(lease); !errors.Is(err, loop.ErrFenced) {
+		t.Fatalf("release = %v", err)
+	}
+	claim, err := loop.ReadServeClaim(cfg, "codex")
+	if err != nil || claim.ServeToken != "successor" {
+		t.Fatalf("successor claim = %+v, %v", claim, err)
+	}
+}
+
+func assertL4(t *testing.T, cfg *loop.Config) {
+	host, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := loop.ServeClaim{
+		ID: "codex", Host: host, PID: 1 << 30, ServeToken: "old",
+		StartedAt: time.Now().Add(-time.Hour).UTC(), LastSeen: time.Now().Add(-time.Hour).UTC(),
+	}
+	claimPath := filepath.Join(cfg.AgentStateDir("codex"), "serve.claim")
+	if err := loop.EnsurePrivateDir(filepath.Dir(claimPath)); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := json.MarshalIndent(claim, "", "  ")
+	if err := os.WriteFile(claimPath, append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := loop.AcquireServeLease(cfg, "codex")
+	if err != nil {
+		t.Fatalf("reclaim = %v", err)
+	}
+	if lease.Token == "old" {
+		t.Fatal("reclaim kept old token")
+	}
+	if err := loop.VerifyFence(cfg, "codex", "old"); !errors.Is(err, loop.ErrFenced) {
+		t.Fatalf("old token = %v", err)
+	}
+}
+
+func rewriteClaimToken(t *testing.T, path, token string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var claim loop.ServeClaim
+	if err := json.Unmarshal(b, &claim); err != nil {
+		t.Fatal(err)
+	}
+	claim.ServeToken = token
+	b, _ = json.MarshalIndent(claim, "", "  ")
+	if err := os.WriteFile(path, append(b, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/spectest/lease_test.go
+++ b/internal/spectest/lease_test.go
@@ -1,0 +1,11 @@
+package spectest
+
+import "testing"
+
+func TestLeaseVectors(t *testing.T) {
+	vectors, err := LoadVectors("lease.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	AssertLeaseVectors(t, vectors)
+}

--- a/internal/spectest/vectors.go
+++ b/internal/spectest/vectors.go
@@ -1,0 +1,40 @@
+package spectest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+type Vector struct {
+	ID   string `json:"id"`
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}
+
+type vectorFile struct {
+	Schema  string   `json:"schema"`
+	Vectors []Vector `json:"vectors"`
+}
+
+func LoadVectors(name string) ([]Vector, error) {
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		return nil, fmt.Errorf("locate spectest vectors.go")
+	}
+	path := filepath.Join(filepath.Dir(self), "..", "..", "conformance", "vectors", name)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var file vectorFile
+	if err := json.Unmarshal(b, &file); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if file.Schema == "" || len(file.Vectors) == 0 {
+		return nil, fmt.Errorf("%s: empty schema or vector set", path)
+	}
+	return file.Vectors, nil
+}

--- a/internal/spectest/wire.go
+++ b/internal/spectest/wire.go
@@ -1,0 +1,268 @@
+package spectest
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/hubwire"
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// SessionFactory is the transport-neutral W harness contract. M3 supplies a
+// net.Pipe factory; M6 supplies an SSH factory. The same assertions use only
+// open/forced-disconnect/close and the pool-state probe below.
+type SessionFactory interface {
+	Open(context.Context, string) (Session, error)
+	State() StateProbe
+}
+
+type Session interface {
+	io.ReadWriteCloser
+	ForceDisconnect() error
+	Wait(context.Context) error
+}
+
+type StateProbe interface {
+	Deliver(from, to, body string) error
+	InboxCount(agent string) (int, error)
+	ClaimedCount(agent string) (int, error)
+	ReplaceLeaseToken(agent, token string) error
+	StageUnreadableClaim(agent string) (restore func() error, err error)
+}
+
+type FactoryBuilder func(*testing.T) SessionFactory
+
+func AssertWireVectors(t *testing.T, vectors []Vector, build FactoryBuilder) {
+	t.Helper()
+	for _, vector := range vectors {
+		vector := vector
+		t.Run(vector.ID+"/"+vector.Kind, func(t *testing.T) {
+			factory := build(t)
+			switch vector.ID {
+			case "W1":
+				assertW1(t, factory)
+			case "W2":
+				assertW2(t, factory)
+			case "W3":
+				assertW3(t, factory)
+			case "W4":
+				assertHandshakeError(t, factory, "grok", 1, hubwire.CodeIdentity)
+			case "W5":
+				assertHandshakeError(t, factory, "codex", 2, hubwire.CodeVersion)
+			case "W6":
+				assertW6(t, factory)
+			default:
+				t.Fatalf("unknown wire vector %s", vector.ID)
+			}
+		})
+	}
+}
+
+func openHello(t *testing.T, factory SessionFactory, pinned, acting string, minV int) (Session, *hubwire.Reader, *hubwire.Writer) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	session, err := factory.Open(ctx, pinned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = session.Close() })
+	r := hubwire.NewReader(session)
+	w := hubwire.NewWriter(session)
+	if err := w.Write(hubwire.Hello{RequestBase: hubwire.RequestBase{T: "hello", ID: 1}, Proto: hubwire.Protocol, V: max(1, minV), MinV: minV, Agent: acting, Bin: "spectest"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	return session, r, w
+}
+
+func requireHelloOK(t *testing.T, r *hubwire.Reader) {
+	t.Helper()
+	raw, err := r.Read()
+	if err != nil || raw.T != "hello-ok" {
+		t.Fatalf("hello = %s, %v", raw.T, err)
+	}
+}
+
+func assertW1(t *testing.T, f SessionFactory) {
+	if err := f.State().Deliver("grok", "codex", "claimed"); err != nil {
+		t.Fatal(err)
+	}
+	s, r, w := openHello(t, f, "codex", "codex", 1)
+	requireHelloOK(t, r)
+	if err := w.Write(hubwire.Check{RequestBase: hubwire.RequestBase{T: "check", ID: 2}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := r.Read()
+	if err != nil || raw.T != "msg" {
+		t.Fatalf("first check frame = %s, %v", raw.T, err)
+	}
+	if err := s.ForceDisconnect(); err != nil {
+		t.Fatal(err)
+	}
+	waitSession(t, s)
+	if n, err := f.State().ClaimedCount("codex"); err != nil || n != 1 {
+		t.Fatalf("claimed residue = %d, %v", n, err)
+	}
+
+	_, r2, w2 := openHello(t, f, "codex", "codex", 1)
+	requireHelloOK(t, r2)
+	if err := w2.Write(hubwire.Check{RequestBase: hubwire.RequestBase{T: "check", ID: 2}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := r2.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded hubwire.Message
+	if err := msg.Decode(&decoded); err != nil || !decoded.Redelivered {
+		t.Fatalf("redelivery = %+v, %v", decoded, err)
+	}
+	for {
+		raw, err := r2.Read()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if raw.T != "check-ok" {
+			continue
+		}
+		var summary hubwire.CheckOK
+		if err := raw.Decode(&summary); err != nil || summary.Redelivered != 1 {
+			t.Fatalf("redelivery summary = %+v, %v", summary, err)
+		}
+		break
+	}
+}
+
+func assertW2(t *testing.T, f SessionFactory) {
+	s, r, w := openHello(t, f, "codex", "codex", 1)
+	requireHelloOK(t, r)
+	if err := w.Write(hubwire.Send{RequestBase: hubwire.RequestBase{T: "send", ID: 2}, To: "grok"}, loop.ComposeMessage("codex", "", "once")); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		n, err := f.State().InboxCount("grok")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("send never committed")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err := s.ForceDisconnect(); err != nil {
+		t.Fatal(err)
+	}
+	waitSession(t, s)
+	if n, err := f.State().InboxCount("grok"); err != nil || n != 1 {
+		t.Fatalf("delivery count = %d, %v", n, err)
+	}
+}
+
+func assertW3(t *testing.T, f SessionFactory) {
+	channel, cr, cw := openHello(t, f, "codex", "codex", 1)
+	requireHelloOK(t, cr)
+	if err := cw.Write(hubwire.LeaseAcquire{RequestBase: hubwire.RequestBase{T: "lease-acquire", ID: 2}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := cr.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lease hubwire.LeaseOK
+	if err := raw.Decode(&lease); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.State().ReplaceLeaseToken("codex", "successor"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, r, w := openHello(t, f, "codex", "codex", 1)
+	requireHelloOK(t, r)
+	if err := w.Write(hubwire.Send{RequestBase: hubwire.RequestBase{T: "send", ID: 2}, To: "grok", ServeToken: lease.Token}, loop.ComposeMessage("codex", "", "fenced")); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var frame hubwire.Error
+	if err := raw.Decode(&frame); err != nil || frame.Code != "E_FENCED" {
+		t.Fatalf("send error = %+v, %v", frame, err)
+	}
+	if n, err := f.State().InboxCount("grok"); err != nil || n != 0 {
+		t.Fatalf("delivery count = %d, %v", n, err)
+	}
+	_ = channel.ForceDisconnect()
+}
+
+func assertHandshakeError(t *testing.T, f SessionFactory, acting string, minV int, want string) {
+	s, r, _ := openHello(t, f, "codex", acting, minV)
+	raw, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var frame hubwire.Error
+	if err := raw.Decode(&frame); err != nil || frame.Code != want {
+		t.Fatalf("handshake error = %+v, %v", frame, err)
+	}
+	waitSession(t, s)
+}
+
+func assertW6(t *testing.T, f SessionFactory) {
+	if err := f.State().Deliver("grok", "codex", "held"); err != nil {
+		t.Fatal(err)
+	}
+	restore, err := f.State().StageUnreadableClaim("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = restore() })
+	_, r, w := openHello(t, f, "codex", "codex", 1)
+	requireHelloOK(t, r)
+	if err := w.Write(hubwire.Check{RequestBase: hubwire.RequestBase{T: "check", ID: 2}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := r.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var frame hubwire.Error
+	if err := raw.Decode(&frame); err != nil || raw.T != "error" || frame.Code != "E_HUB_IO" || !frame.ClaimedHeld {
+		t.Fatalf("error = %+v, %v", frame, err)
+	}
+}
+
+func waitSession(t *testing.T, s Session) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := s.Wait(ctx); err != nil && err != io.EOF && !isClosed(err) {
+		t.Fatalf("wait session: %v", err)
+	}
+}
+
+func isClosed(err error) bool {
+	return err != nil && (err == io.ErrClosedPipe || contains(err.Error(), "closed"))
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/spectest/wire_test.go
+++ b/internal/spectest/wire_test.go
@@ -1,0 +1,136 @@
+package spectest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/cli"
+	"github.com/agentchute/agentchute/internal/loop"
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+const testPoolID = "0123456789ab"
+
+type pipeFactory struct {
+	pool string
+	cfg  *loop.Config
+}
+
+type pipeSession struct {
+	conn net.Conn
+	done <-chan error
+}
+
+func (s *pipeSession) Read(p []byte) (int, error)  { return s.conn.Read(p) }
+func (s *pipeSession) Write(p []byte) (int, error) { return s.conn.Write(p) }
+func (s *pipeSession) Close() error                { return s.conn.Close() }
+func (s *pipeSession) ForceDisconnect() error      { return s.conn.Close() }
+func (s *pipeSession) Wait(ctx context.Context) error {
+	select {
+	case err := <-s.done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (f *pipeFactory) Open(ctx context.Context, pinned string) (Session, error) {
+	server, client := net.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		done <- cli.ServeHubSession(ctx, server, cli.HubSessionConfig{Agent: pinned, Pool: f.pool, PoolID: testPoolID, HubBin: "spectest"})
+	}()
+	return &pipeSession{conn: client, done: done}, nil
+}
+
+func (f *pipeFactory) State() StateProbe { return (*pipeState)(f) }
+
+type pipeState pipeFactory
+
+func (s *pipeState) Deliver(from, to, body string) error {
+	_, _, err := loop.SendTsMessageWithCommit(s.cfg, from, to, loop.ComposeMessage(from, "", body), "")
+	return err
+}
+
+func (s *pipeState) InboxCount(agent string) (int, error) {
+	msgs, _, err := loop.ListInboxMessagesWithSkipped(s.cfg.AgentInboxDir(agent))
+	if errors.Is(err, loop.ErrInboxMissing) {
+		return 0, nil
+	}
+	return len(msgs), err
+}
+
+func (s *pipeState) ClaimedCount(agent string) (int, error) {
+	msgs, err := loop.ListClaimedMessages(s.cfg.AgentClaimedDir(agent))
+	return len(msgs), err
+}
+
+func (s *pipeState) ReplaceLeaseToken(agent, token string) error {
+	path := filepath.Join(s.cfg.AgentStateDir(agent), "serve.claim")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	var claim loop.ServeClaim
+	if err := json.Unmarshal(b, &claim); err != nil {
+		return err
+	}
+	claim.ServeToken = token
+	b, err = json.MarshalIndent(claim, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(b, '\n'), 0o600)
+}
+
+func (s *pipeState) StageUnreadableClaim(agent string) (func() error, error) {
+	msgs, _, err := loop.ListInboxMessagesWithSkipped(s.cfg.AgentInboxDir(agent))
+	if err != nil {
+		return nil, err
+	}
+	if len(msgs) != 1 {
+		return nil, errors.New("expected one inbox message")
+	}
+	path, err := loop.ClaimMessage(msgs[0], s.cfg.AgentClaimedDir(agent))
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, 0); err != nil {
+		return nil, err
+	}
+	return func() error { return os.Chmod(path, 0o600) }, nil
+}
+
+func TestWireVectors(t *testing.T) {
+	vectors, err := LoadVectors("wire.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	AssertWireVectors(t, vectors, func(t *testing.T) SessionFactory {
+		pool := t.TempDir()
+		if err := os.WriteFile(filepath.Join(pool, "AGENTCHUTE.md"), []byte("# spec\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		loopDir := filepath.Join(pool, ".agentchute", "loop")
+		if err := os.MkdirAll(filepath.Join(loopDir, "state"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(loopDir, "state", "pool.id"), []byte(testPoolID+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cfg := &loop.Config{ControlRepo: pool, LoopDir: loopDir, Vendor: "agentchute"}
+		vendor := "test"
+		for _, id := range []string{"codex", "grok"} {
+			if _, err := op.Register(cfg, op.Context{ActorID: id}, op.RegisterReq{Vendor: &vendor, Host: "test"}, time.Now().UTC()); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return &pipeFactory{pool: pool, cfg: cfg}
+	})
+}

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -19,6 +19,10 @@ say "go test ./..."
 # shellcheck disable=SC2086
 env $strip_env go test ./... || { say "FAIL: go test"; exit 1; }
 
+say "cd conformance && go test ./..."
+# shellcheck disable=SC2086
+(cd conformance && env $strip_env go test ./...) || { say "FAIL: conformance go test"; exit 1; }
+
 say "go build ./..."
 # shellcheck disable=SC2086
 env $strip_env go build ./... || { say "FAIL: go build"; exit 1; }


### PR DESCRIPTION
## Summary

- add the v1 NDJSON + raw-trailer hub codec, full frame/code vocabulary, handshake, status two-budget encoder, fuzz corpus, and streaming boundary tests
- add `agentchute hub session` with direct pinned-pool config, J1 pool identity validation, every-op dispatch, channel ordering, deadlines, and lease release on every exit
- add boot-reference lease proof on Linux/Darwin, invocation-scoped send delivery injection, and executable L1-L4/W1-W6 conformance vectors

## Review-owned proposals

### Shared W session factory

`internal/spectest/wire.go` defines the M3/M6 transport boundary:

```go
type SessionFactory interface {
    Open(context.Context, string) (Session, error)
    State() StateProbe
}

type Session interface {
    io.ReadWriteCloser
    ForceDisconnect() error
    Wait(context.Context) error
}
```

`StateProbe` exposes only the fixture/state operations the six shared W assertions require. M3 drives it with `net.Pipe`; M6 can supply the SSH transport without duplicating assertions.

### No-mutable-send-state check

`TestSendHubPathHasNoMutablePackageState` parses the root-module `internal/op` call graph starting at `Send`. It permits only the fixed error sentinels and fails if any other package variable—exported or unexported—becomes reachable. Production `Send` passes `loop.SendTsMessageWithCommit` into the invocation-scoped `sendWithDelivery` helper; CLI-only tests inject through `cmdSendWithOp`.

## Scope proof

- base: `7c8c4451f555cf24d384d3363528368e8eb824af`
- head: `e509239`
- no changes to `AGENTCHUTE.md`, PLAN, DESIGN, either `go.mod`, or either `go.sum`
- `internal/loop` production delta is exactly `lease.go` plus `bootref_{linux,darwin,other}.go`; `lease_test.go` contains the seven deterministic WI-3.4 rows and mixed-version-key assertion
- `tools/test.sh` has exactly the planned env-stripped conformance block

## Verification

- `sh tools/test.sh`
- env-stripped `go test -race ./... -count=1 -timeout=300s`
- Linux amd64 compile: `internal/loop`, `internal/cli`
- Windows amd64 compile: `internal/loop` (verifies the third boot-ref build-tag arm)
- Darwin tests executed locally
