### PR TITLE
feat: add SSH hub client transport

### DIFF
--- a/internal/cli/ack.go
+++ b/internal/cli/ack.go
@@ -88,7 +88,7 @@ func cmdAck(args []string) error {
 		return err
 	}
 
-	agentID, err = resolveAgentID(agentID)
+	agentID, err = resolveAgentID(agentID, cfg)
 	if err != nil {
 		return err
 	}
@@ -155,12 +155,23 @@ func cmdAck(args []string) error {
 // empty, non-nil slice).
 func ackClaimed(cfg *loop.Config, agentID string) ([]ackItem, op.AckSummary, error) {
 	acked := make([]ackItem, 0)
-	sum, err := op.Ack(cfg, op.Context{ActorID: agentID}, op.AckReq{}, func(ev op.Event) error {
+	emit := func(ev op.Event) error {
 		if ev.Ack != nil {
 			acked = append(acked, ackItem{Filename: ev.Ack.Filename, ArchivePath: ev.Ack.ArchivePath})
 		}
 		return nil
-	})
+	}
+	var sum op.AckSummary
+	var err error
+	if cfg.Remote != nil {
+		session, openErr := openRemoteOneShot(cfg, agentID)
+		if openErr != nil {
+			return nil, sum, openErr
+		}
+		sum, err = session.Ack(emit)
+	} else {
+		sum, err = op.Ack(cfg, op.Context{ActorID: agentID}, op.AckReq{}, emit)
+	}
 	if err != nil {
 		return nil, sum, err
 	}

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/agentchute/agentchute/internal/loop"
+	"github.com/agentchute/agentchute/internal/op"
 )
 
 // cmdBoot is the session-start ritual: one command replacing register +
@@ -57,6 +58,8 @@ func cmdBoot(args []string) error {
 			opts.HostProvided = true
 		case "bio":
 			opts.BioProvided = true
+		case "vendor":
+			opts.VendorProvided = true
 		}
 	})
 
@@ -75,7 +78,7 @@ func cmdBoot(args []string) error {
 		return err
 	}
 
-	agentID, err = resolveAgentID(agentID)
+	agentID, err = resolveAgentID(agentID, cfg)
 	if err != nil {
 		return err
 	}
@@ -83,11 +86,24 @@ func cmdBoot(args []string) error {
 		return err
 	}
 	opts.AgentID = agentID
-	opts.Vendor = resolveAgentVendor(vendor, agentID, cfg)
+	if cfg.Remote != nil {
+		opts.Vendor = strings.TrimSpace(vendor)
+		opts.Sweep = true
+	} else {
+		opts.Vendor = resolveAgentVendor(vendor, agentID, cfg)
+	}
 
 	now := time.Now().UTC()
+	hookMode := contextOnly || codexHook == "SessionStart"
+	if cfg.Remote != nil && hookMode && remoteHookCached(cfg) {
+		fmt.Fprintln(os.Stderr, "hub unreachable; skipping (will retry next event)")
+		return nil
+	}
 	result, err := performRegister(cfg, opts, now)
 	if err != nil {
+		if cfg.Remote != nil && hookMode && degradeRemoteHook(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -96,32 +112,57 @@ func cmdBoot(args []string) error {
 	// runner is offline still gets bounded hygiene from whoever boots into it.
 	// A sweep failure is a warning, never a boot failure: hygiene is best-effort
 	// and must not block session start.
-	if _, serr := loop.SweepStaleRegistrations(cfg, agentID, now); serr != nil {
-		result.Warnings = append(result.Warnings, fmt.Sprintf("sweep stale registrations: %v", serr))
+	if cfg.Remote == nil {
+		if _, serr := loop.SweepStaleRegistrations(cfg, agentID, now); serr != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("sweep stale registrations: %v", serr))
+		}
 	}
 
 	// Inbox peek — strictly side-effect free, same path `pending` uses.
-	msgs, skipped, err := loop.ListInboxMessagesWithSkipped(result.InboxDir)
-	if err != nil {
-		return fmt.Errorf("list inbox: %w", err)
-	}
-	unread := make([]pendingEntry, 0, len(msgs))
+	unread := make([]pendingEntry, 0)
+	malformedCount := 0
 	inheritedMail := false
-	for _, msg := range msgs {
-		if msg.Timestamp.Before(result.Reg.LastSeen) {
-			inheritedMail = true
-		}
-		entry := pendingEntry{
-			From:      msg.Sender,
-			Filename:  msg.Filename,
-			Timestamp: msg.Timestamp.UTC().Format(time.RFC3339Nano),
-		}
-		if fm, _, ferr := readFrontmatter(msg.Path); ferr == nil {
-			if v := strings.ToLower(strings.TrimSpace(fm["reply_required"])); v == "true" {
-				entry.ReplyRequired = true
+	if cfg.Remote != nil {
+		session, openErr := openRemoteOneShot(cfg, agentID)
+		if openErr != nil {
+			if hookMode && degradeRemoteHook(openErr) {
+				return nil
 			}
+			return openErr
 		}
-		unread = append(unread, entry)
+		sum, pendingErr := session.Pending(op.PendingReq{}, func(ev op.Event) error {
+			if ev.Message != nil {
+				stamp, _ := time.Parse(time.RFC3339Nano, ev.Message.Stamp)
+				if stamp.Before(result.Reg.LastSeen) {
+					inheritedMail = true
+				}
+				unread = append(unread, pendingEntry{From: ev.Message.Sender, Filename: ev.Message.Filename, Timestamp: ev.Message.Stamp, ReplyRequired: ev.Message.ReplyRequired})
+			}
+			return nil
+		})
+		if pendingErr != nil {
+			if hookMode && degradeRemoteHook(pendingErr) {
+				return nil
+			}
+			return pendingErr
+		}
+		malformedCount = sum.Malformed
+	} else {
+		msgs, skipped, listErr := loop.ListInboxMessagesWithSkipped(result.InboxDir)
+		if listErr != nil {
+			return fmt.Errorf("list inbox: %w", listErr)
+		}
+		malformedCount = len(skipped)
+		for _, msg := range msgs {
+			if msg.Timestamp.Before(result.Reg.LastSeen) {
+				inheritedMail = true
+			}
+			entry := pendingEntry{From: msg.Sender, Filename: msg.Filename, Timestamp: msg.Timestamp.UTC().Format(time.RFC3339Nano)}
+			if fm, _, ferr := readFrontmatter(msg.Path); ferr == nil {
+				entry.ReplyRequired = strings.EqualFold(strings.TrimSpace(fm["reply_required"]), "true")
+			}
+			unread = append(unread, entry)
+		}
 	}
 	var notes []string
 	if inheritedMail {
@@ -133,12 +174,12 @@ func cmdBoot(args []string) error {
 	// recipient-side pending-reply ledger. Blocking is purely on unread mail.
 	status := bootStatus{
 		Agent:          agentID,
-		Vendor:         opts.Vendor,
+		Vendor:         result.Reg.Vendor,
 		Refreshed:      result.Refreshed,
 		ExistingFound:  result.ExistingFound,
 		UnreadCount:    len(unread),
 		Unread:         unread,
-		MalformedCount: len(skipped),
+		MalformedCount: malformedCount,
 		Host:           result.ResolvedHost,
 		Warnings:       result.Warnings,
 		Notes:          notes,

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentchute/agentchute/internal/hubclient"
 	"github.com/agentchute/agentchute/internal/loop"
 	"github.com/agentchute/agentchute/internal/op"
 )
@@ -85,7 +86,7 @@ func cmdCheck(args []string) error {
 		return err
 	}
 
-	agentID, err = resolveAgentID(agentID)
+	agentID, err = resolveAgentID(agentID, cfg)
 	if err != nil {
 		return err
 	}
@@ -130,13 +131,7 @@ func cmdCheck(args []string) error {
 			setLatch()
 			renderClaimedMessage(agentID, *ev.Message, now)
 		case ev.Note != nil:
-			// The level IS the stream, and the renderer — never the op —
-			// supplies the `warning: ` prefix.
-			if ev.Note.Level == op.NoteWarn {
-				fmt.Fprintf(os.Stderr, "warning: %s\n", ev.Note.Msg)
-			} else {
-				fmt.Println(ev.Note.Msg)
-			}
+			renderOpNote(*ev.Note)
 		case ev.Owed != nil:
 			// C19: print-only. The explicit, human-triggered prune command is
 			// what actually removes an obligation.
@@ -153,7 +148,17 @@ func cmdCheck(args []string) error {
 	// archiving DURING check (the old behavior) is at-most-once for the WORK. A
 	// crash between claim and ack now RE-DELIVERS (at-least-once); handlers must
 	// be idempotent.
-	sum, err := op.Claim(cfg, op.Context{ActorID: agentID}, op.ClaimReq{Limit: limit, NoArchive: noArchive}, emit)
+	claimReq := op.ClaimReq{Limit: limit, NoArchive: noArchive}
+	var sum op.ClaimSummary
+	if cfg.Remote != nil {
+		session, openErr := openRemoteOneShot(cfg, agentID)
+		if openErr != nil {
+			return openErr
+		}
+		sum, err = session.Check(claimReq, emit)
+	} else {
+		sum, err = op.Claim(cfg, op.Context{ActorID: agentID}, claimReq, emit)
+	}
 	// Arm on residue EXISTENCE, not only on a rendered message, and do it
 	// before returning any error: claimed-but-unacked mail whose body cannot be
 	// read (a permissions change, or residue past MaxInboxMessageBytes — the
@@ -161,7 +166,7 @@ func cmdCheck(args []string) error {
 	// holding it, which is exactly the state the latch covers. Emitting arms
 	// earlier and per-message, so this is a no-op on every path that displayed
 	// anything.
-	if sum.Redelivered > 0 {
+	if sum.Redelivered > 0 || hubclient.ClaimedHeld(err) {
 		setLatch()
 	}
 	if err != nil {
@@ -171,6 +176,14 @@ func cmdCheck(args []string) error {
 		return err
 	}
 	return nil
+}
+
+func renderOpNote(note op.NoteEvent) {
+	if note.Level == op.NoteWarn {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", note.Msg)
+		return
+	}
+	fmt.Println(note.Msg)
 }
 
 // renderClaimedMessage prints one consumed message: the C18 age banner when it

--- a/internal/cli/clean.go
+++ b/internal/cli/clean.go
@@ -78,7 +78,7 @@ func cmdClean(args []string) error {
 		if strings.TrimSpace(agentID) == "" && strings.TrimSpace(os.Getenv("AGENTCHUTE_AGENT_ID")) == "" {
 			return cleanUsage(fmt.Errorf("--owed requires an explicit identity: pass --as <id> or set AGENTCHUTE_AGENT_ID"))
 		}
-		agentID, err = resolveAgentID(agentID)
+		agentID, err = resolveAgentID(agentID, cfg)
 		if err != nil {
 			return err
 		}
@@ -86,6 +86,9 @@ func cmdClean(args []string) error {
 			return err
 		}
 		return cmdCleanOwed(cfg, agentID, apply, jsonOut, now)
+	}
+	if cfg.Remote != nil {
+		return fmt.Errorf("clean --mailbox is hub-local; run it on the hub")
 	}
 
 	if err := loop.ValidateAgentID(mailboxTarget); err != nil {
@@ -119,7 +122,18 @@ type cleanOwedResult struct {
 // RecordOwed/ClearOwed (from the agent's own `check`/`send`) cannot race the
 // read-modify-write.
 func cmdCleanOwed(cfg *loop.Config, agentID string, apply, jsonOut bool, now time.Time) error {
-	resp, err := op.CleanOwed(cfg, op.Context{ActorID: agentID}, op.CleanOwedReq{Apply: apply})
+	req := op.CleanOwedReq{Apply: apply}
+	var resp op.CleanOwedResp
+	var err error
+	if cfg.Remote != nil {
+		session, openErr := openRemoteOneShot(cfg, agentID)
+		if openErr != nil {
+			return openErr
+		}
+		resp, err = session.CleanOwed(req)
+	} else {
+		resp, err = op.CleanOwed(cfg, op.Context{ActorID: agentID}, req)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -239,23 +239,26 @@ func dispatchExecRun(plan dispatchPlan, shimDir string) error {
 	if err != nil {
 		return err
 	}
-	runArgs := buildDispatchRunArgs(agentchuteBin, plan.Wrapper.Vendor, forwardGlobal, cfg.ControlRepo, cfg.LoopDir, wrapperArgs)
+	runArgs := buildDispatchRunArgs(agentchuteBin, plan.Wrapper.Vendor, forwardGlobal, cfg, wrapperArgs)
 	return execReplace(agentchuteBin, runArgs, os.Environ())
 }
 
 // buildDispatchRunArgs assembles the `agentchute serve` argv for a dispatcher
 // launch, emitting exactly one authoritative --vendor/--control-repo/--loop-dir.
-func buildDispatchRunArgs(agentchuteBin, vendor string, forwardGlobal []string, controlRepo, loopDir string, wrapperArgs []string) []string {
+func buildDispatchRunArgs(agentchuteBin, vendor string, forwardGlobal []string, cfg *loop.Config, wrapperArgs []string) []string {
 	runArgs := []string{agentchuteBin, "serve", "--vendor", vendor}
 	runArgs = append(runArgs, forwardGlobal...)
-	runArgs = append(runArgs,
-		"--control-repo", controlRepo,
-		"--loop-dir", loopDir,
-		"--shim-name", "ac",
-		"--",
-	)
+	runArgs = append(runArgs, launcherControlArgs(cfg)...)
+	runArgs = append(runArgs, "--shim-name", "ac", "--")
 	runArgs = append(runArgs, wrapperArgs...)
 	return runArgs
+}
+
+func launcherControlArgs(cfg *loop.Config) []string {
+	if cfg.Remote != nil {
+		return []string{"--control-repo", cfg.Remote.URL}
+	}
+	return []string{"--control-repo", cfg.ControlRepo, "--loop-dir", cfg.LoopDir}
 }
 
 func dispatchHasFlag(args []string, name string) bool {

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/agentchute/agentchute/internal/loop"
 )
 
 func TestParseDispatch_Commands(t *testing.T) {
@@ -220,7 +224,7 @@ func TestSplitDispatchContext_ThenParseRoundTrip(t *testing.T) {
 
 func TestBuildDispatchRunArgs_SingleAuthoritativePair(t *testing.T) {
 	got := buildDispatchRunArgs("/bin/agentchute", "openai", []string{"--as", "reviewer"},
-		"/repo", "/repo/.agentchute/loop", []string{"/usr/bin/codex", "resume"})
+		&loop.Config{ControlRepo: "/repo", LoopDir: "/repo/.agentchute/loop"}, []string{"/usr/bin/codex", "resume"})
 	want := []string{
 		"/bin/agentchute", "serve", "--vendor", "openai", "--as", "reviewer",
 		"--control-repo", "/repo", "--loop-dir", "/repo/.agentchute/loop", "--shim-name", "ac", "--",
@@ -240,6 +244,64 @@ func TestBuildDispatchRunArgs_SingleAuthoritativePair(t *testing.T) {
 		if n != 1 {
 			t.Errorf("%s appears %d times, want 1", f, n)
 		}
+	}
+}
+
+func TestBuildDispatchRunArgs_RemoteForwardsLocatorWithoutLoopDir(t *testing.T) {
+	cfg := &loop.Config{
+		ControlRepo: "/local/repo",
+		LoopDir:     "/home/me/.agentchute/hub/abc/.agentchute/loop",
+		Remote:      &loop.RemoteConfig{URL: "ssh://user@hub.example/remote/pool"},
+	}
+	got := buildDispatchRunArgs("/bin/agentchute", "openai", nil, cfg, []string{"/usr/bin/codex"})
+	want := []string{
+		"/bin/agentchute", "serve", "--vendor", "openai",
+		"--control-repo", cfg.Remote.URL, "--shim-name", "ac", "--", "/usr/bin/codex",
+	}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("runArgs =\n  %v\nwant\n  %v", got, want)
+	}
+	if stringSliceContains(got, "--loop-dir") {
+		t.Fatalf("remote runArgs contains --loop-dir: %v", got)
+	}
+}
+
+func TestBuildDispatchRunArgs_RemoteDiscoveryRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	remote, err := loop.ParseRemoteURL("ssh://User@HUB.Example:22/remote/pool/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(remote.ConfigPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(remote.ConfigPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	argv := buildDispatchRunArgs("/bin/agentchute", "openai", nil, &loop.Config{
+		ControlRepo: t.TempDir(),
+		LoopDir:     remote.ShadowLoopDir,
+		Remote:      remote,
+	}, []string{"/usr/bin/codex"})
+	locator, rest, found := extractGlobalFlag(argv[2:], "--control-repo")
+	if !found {
+		t.Fatalf("emitted argv has no --control-repo: %v", argv)
+	}
+	if _, _, found := extractGlobalFlag(rest, "--loop-dir"); found {
+		t.Fatalf("emitted remote argv has --loop-dir: %v", argv)
+	}
+	cwd := t.TempDir()
+	cfg, err := loop.Discover(loop.DiscoverOpts{ControlRepoFlag: locator, Cwd: cwd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Remote == nil {
+		t.Fatalf("round-trip discovery de-remoted argv: %#v", cfg)
+	}
+	if cfg.Remote.URL != "ssh://User@hub.example/remote/pool" || cfg.LoopDir != remote.ShadowLoopDir {
+		t.Fatalf("round-trip remote/shadow = %q/%q", cfg.Remote.URL, cfg.LoopDir)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentchute/agentchute/internal/hubclient"
+	"github.com/agentchute/agentchute/internal/hubwire"
 	"github.com/agentchute/agentchute/internal/loop"
 )
 
@@ -147,7 +149,19 @@ func cmdDoctor(args []string) error {
 		opts.PoolState = &ps
 	}
 
-	report := runDoctorChecks(cfg, agentID, opts)
+	if agentID != "" {
+		agentID, err = resolveAgentID(agentID, cfg)
+		if err != nil {
+			return err
+		}
+	}
+
+	var report doctorReport
+	if cfg.Remote != nil {
+		report = runRemoteDoctorChecks(cfg, agentID, opts.Now)
+	} else {
+		report = runDoctorChecks(cfg, agentID, opts)
+	}
 
 	if jsonOut {
 		if err := emitDoctorJSON(report); err != nil {
@@ -160,6 +174,82 @@ func cmdDoctor(args []string) error {
 		return errBlocked
 	}
 	return nil
+}
+
+func runRemoteDoctorChecks(cfg *loop.Config, agentID string, now time.Time) doctorReport {
+	report := doctorReport{Agent: agentID}
+	add := func(check doctorCheck) {
+		report.Checks = append(report.Checks, check)
+		switch check.Severity {
+		case severityBlocker:
+			report.Blockers++
+		case severityWarn:
+			report.Warnings++
+		}
+	}
+	hubCfg, err := hubclient.ReadHubConfig(cfg.Remote.HubID)
+	if err != nil {
+		add(doctorCheck{Name: "hub_config", Severity: severityBlocker, Message: err.Error()})
+		return report
+	}
+	joined := strings.Join(hubCfg.JoinedAs, ", ")
+	add(doctorCheck{Name: "hub_config", Severity: severityOK, Message: fmt.Sprintf("%s, joined as %s", hubCfg.URL, joined)})
+	if agentID == "" && len(hubCfg.JoinedAs) > 0 {
+		agentID = hubCfg.JoinedAs[0]
+		report.Agent = agentID
+	}
+	key := filepath.Join(cfg.Remote.HubDir, "keys", agentID+"_ed25519")
+	keyInfo, keyErr := os.Lstat(key)
+	if keyErr != nil {
+		add(doctorCheck{Name: "hub_key", Severity: severityBlocker, Message: fmt.Sprintf("key unavailable at %s: %v", key, keyErr)})
+	} else if keyInfo.Mode()&os.ModeSymlink == 0 {
+		add(doctorCheck{Name: "hub_key", Severity: severityBlocker, Message: fmt.Sprintf("%s is not the active-key symlink", key)})
+	} else if target, err := filepath.EvalSymlinks(key); err != nil {
+		add(doctorCheck{Name: "hub_key", Severity: severityBlocker, Message: fmt.Sprintf("active key target invalid: %v", err)})
+	} else if info, err := os.Stat(target); err != nil || info.Mode().Perm() != 0o600 {
+		add(doctorCheck{Name: "hub_key", Severity: severityBlocker, Message: fmt.Sprintf("active key target must be a 0600 file: %s", target)})
+	} else {
+		add(doctorCheck{Name: "hub_key", Severity: severityOK, Message: fmt.Sprintf("%s -> %s, 0600", key, filepath.Base(target))})
+	}
+	if cached, age, err := hubclient.ConnectFailureCached(cfg.Remote, now); err == nil && cached {
+		add(doctorCheck{Name: "hub_negative_cache", Severity: severityWarn, Message: fmt.Sprintf("hooks are suppressing repeat connects after E_CONNECT %s ago", age.Round(time.Second))})
+	}
+	if agentID == "" {
+		add(doctorCheck{Name: "hub_connect", Severity: severityBlocker, Message: "no joined identity available for the hub probe"})
+		return report
+	}
+	started := time.Now()
+	session, err := openRemoteOneShot(cfg, agentID)
+	if err != nil {
+		code := hubclient.ErrorCode(err)
+		if code == "" {
+			code = "E_CONNECT"
+		}
+		add(doctorCheck{Name: "hub_connect", Severity: severityBlocker, Message: fmt.Sprintf("%s: %v", code, err)})
+		return report
+	}
+	hello := session.Hello()
+	_ = session.Close()
+	add(doctorCheck{Name: "hub_connect", Severity: severityOK, Message: fmt.Sprintf("rtt %s", time.Since(started).Round(time.Millisecond))})
+	if hello.Agent != agentID {
+		add(doctorCheck{Name: "hub_identity", Severity: severityBlocker, Message: fmt.Sprintf("key pinned to %s, acting as %s", hello.Agent, agentID)})
+	} else {
+		add(doctorCheck{Name: "hub_identity", Severity: severityOK, Message: fmt.Sprintf("key pinned to %s; protocol %s v%d; hub binary %s", hello.Agent, hubwire.Protocol, hello.V, hello.HubBin)})
+	}
+	if hello.Pool != hubCfg.Pool || hello.Pool12 != hubCfg.Pool12 {
+		add(doctorCheck{Name: "hub_pool", Severity: severityBlocker, Message: fmt.Sprintf("E_POOL_MISMATCH: joined %s/%s, hub reports %s/%s", hubCfg.Pool, hubCfg.Pool12, hello.Pool, hello.Pool12)})
+	} else if !hello.Writable {
+		add(doctorCheck{Name: "hub_pool", Severity: severityBlocker, Message: "hub pool is not writable"})
+	} else {
+		offset := hello.HubTime.Sub(time.Now().UTC()).Round(100 * time.Millisecond)
+		add(doctorCheck{Name: "hub_pool", Severity: severityOK, Message: fmt.Sprintf("writable; hub time offset %s", offset)})
+	}
+	if envID := strings.TrimSpace(os.Getenv("AGENTCHUTE_AGENT_ID")); envID != "" {
+		if mapped, ok := hubCfg.Names[envID]; ok && mapped != envID {
+			add(doctorCheck{Name: "hub_identity_env", Severity: severityWarn, Message: fmt.Sprintf("AGENTCHUTE_AGENT_ID=%s is a local name on this machine; every command resolves it to %q (this hub's names map). Unset it, or export the full id, if that is not what you want.", envID, mapped)})
+		}
+	}
+	return report
 }
 
 const (

--- a/internal/cli/gate.go
+++ b/internal/cli/gate.go
@@ -70,7 +70,7 @@ func cmdGate(args []string) error {
 		return err
 	}
 
-	agentID, err = resolveAgentID(agentID)
+	agentID, err = resolveAgentID(agentID, cfg)
 	if err != nil {
 		return err
 	}
@@ -86,11 +86,21 @@ func cmdGate(args []string) error {
 		return gateUsage(fmt.Errorf("unknown phase %q (valid: consensus|commit|release|finish|continue)", phase))
 	}
 
-	status, err := op.Gate(cfg, op.Context{ActorID: agentID}, op.GateReq{
+	req := op.GateReq{
 		Phase:          phase,
 		RequireConfirm: requireConfirm,
 		AckStaleReg:    ackStaleReg,
-	})
+	}
+	var status op.GateResp
+	if cfg.Remote != nil {
+		session, openErr := openRemoteOneShot(cfg, agentID)
+		if openErr != nil {
+			return openErr
+		}
+		status, err = session.Gate(req)
+	} else {
+		status, err = op.Gate(cfg, op.Context{ActorID: agentID}, req)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/cli/guard.go
+++ b/internal/cli/guard.go
@@ -172,22 +172,6 @@ func evaluateGuardInvocation(agentIDFlag, controlRepo, loopDir, toolCmd string) 
 		return guardDecision{Allowed: true}
 	}
 
-	id := strings.TrimSpace(agentIDFlag)
-	if id == "" {
-		id = strings.TrimSpace(os.Getenv("AGENTCHUTE_AGENT_ID"))
-	}
-	if id == "" {
-		// Cannot resolve whose latch to check. Guard is armed (a serve session
-		// is active) but the id this process would need is missing — a
-		// misconfiguration, not a signal to block. Fail open (hint only, no
-		// stdout noise that would corrupt hook JSON parsing).
-		fmt.Fprintln(os.Stderr, "agentchute guard: AGENTCHUTE_AGENT_ID not set; cannot resolve guard latch, allowing (hint: guard only applies inside an `ac serve` session)")
-		return guardDecision{Allowed: true}
-	}
-	if err := loop.ValidateAgentID(id); err != nil {
-		return guardDecision{Allowed: true}
-	}
-
 	cwd, err := os.Getwd()
 	if err != nil {
 		return guardDecision{Allowed: true}
@@ -200,6 +184,16 @@ func evaluateGuardInvocation(agentIDFlag, controlRepo, loopDir, toolCmd string) 
 		EnvLoopDir:      os.Getenv("AGENTCHUTE_LOOP_DIR"),
 	})
 	if err != nil {
+		return guardDecision{Allowed: true}
+	}
+	id, err := resolveAgentID(agentIDFlag, cfg)
+	if err != nil {
+		if strings.TrimSpace(agentIDFlag) == "" && strings.TrimSpace(os.Getenv("AGENTCHUTE_AGENT_ID")) == "" {
+			// Cannot resolve whose latch to check. Guard is armed (a serve
+			// session is active) but identity is missing. Fail open (hint only,
+			// no stdout noise that would corrupt hook JSON parsing).
+			fmt.Fprintln(os.Stderr, "agentchute guard: AGENTCHUTE_AGENT_ID not set; cannot resolve guard latch, allowing (hint: guard only applies inside an `ac serve` session)")
+		}
 		return guardDecision{Allowed: true}
 	}
 

--- a/internal/cli/identity.go
+++ b/internal/cli/identity.go
@@ -5,16 +5,35 @@ import (
 	"os"
 	"strings"
 
+	"github.com/agentchute/agentchute/internal/hubclient"
 	"github.com/agentchute/agentchute/internal/loop"
 	"github.com/agentchute/agentchute/internal/op"
 )
 
 const missingAgentIdentityHint = "missing agent identity: pass --as/--from or set AGENTCHUTE_AGENT_ID (e.g. export AGENTCHUTE_AGENT_ID=claude-code). See AGENTS.md enrollment."
 
-func resolveAgentID(flagID string) (string, error) {
-	id, err := resolveAgentIDRaw(flagID)
+func resolveAgentID(flagID string, cfg *loop.Config, fallbackID ...string) (string, error) {
+	id, err := resolveAgentIDRaw(flagID, fallbackID...)
 	if err != nil {
 		return "", err
+	}
+	if cfg != nil && cfg.Remote != nil {
+		hubCfg, err := hubclient.ReadHubConfig(cfg.Remote.HubID)
+		if err != nil {
+			return "", err
+		}
+		joinedID := false
+		for _, candidate := range hubCfg.JoinedAs {
+			if id == candidate {
+				joinedID = true
+				break
+			}
+		}
+		if !joinedID {
+			if mapped, ok := hubCfg.Names[id]; ok {
+				id = mapped
+			}
+		}
 	}
 	// Structural traversal-safety: every path that produces an agent id flows
 	// through this single validation, so a hostile --as / AGENTCHUTE_AGENT_ID
@@ -25,7 +44,7 @@ func resolveAgentID(flagID string) (string, error) {
 	return id, nil
 }
 
-func resolveAgentIDRaw(flagID string) (string, error) {
+func resolveAgentIDRaw(flagID string, fallbackID ...string) (string, error) {
 	// 1. Explicit --as flag wins.
 	if strings.TrimSpace(flagID) != "" {
 		return strings.TrimSpace(flagID), nil
@@ -34,6 +53,11 @@ func resolveAgentIDRaw(flagID string) (string, error) {
 	// 2. AGENTCHUTE_AGENT_ID env var.
 	if envID := strings.TrimSpace(os.Getenv("AGENTCHUTE_AGENT_ID")); envID != "" {
 		return envID, nil
+	}
+
+	// 3. A direct serve launch may supply its wrapper's canonical id.
+	if len(fallbackID) > 0 && strings.TrimSpace(fallbackID[0]) != "" {
+		return strings.TrimSpace(fallbackID[0]), nil
 	}
 
 	return "", fmt.Errorf("%s", missingAgentIdentityHint)

--- a/internal/cli/identity_cmd.go
+++ b/internal/cli/identity_cmd.go
@@ -4,6 +4,11 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"sort"
+
+	"github.com/agentchute/agentchute/internal/hubclient"
+	"github.com/agentchute/agentchute/internal/loop"
 )
 
 func cmdIdentity(args []string) error {
@@ -21,11 +26,37 @@ func cmdIdentity(args []string) error {
 		return identityUsage(err)
 	}
 
-	id, err := resolveAgentID(agentID)
+	var cfg *loop.Config
+	if cwd, err := os.Getwd(); err == nil {
+		cfg, _ = loop.Discover(loop.DiscoverOpts{
+			ControlRepoFlag: controlRepo,
+			LoopDirFlag:     loopDir,
+			Cwd:             cwd,
+			EnvControlRepo:  os.Getenv("AGENTCHUTE_CONTROL_REPO"),
+			EnvLoopDir:      os.Getenv("AGENTCHUTE_LOOP_DIR"),
+		})
+	}
+	id, err := resolveAgentID(agentID, cfg)
 	if err != nil {
 		return err
 	}
-	fmt.Println(id)
+	if cfg == nil || cfg.Remote == nil {
+		fmt.Println(id)
+		return nil
+	}
+	hubCfg, err := hubclient.ReadHubConfig(cfg.Remote.HubID)
+	if err != nil {
+		return err
+	}
+	names := make([]string, 0, len(hubCfg.Names))
+	for name := range hubCfg.Names {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		fmt.Printf("%s -> %s\n", name, hubCfg.Names[name])
+	}
+	fmt.Printf("resolved: %s\n", id)
 	return nil
 }
 

--- a/internal/cli/identity_test.go
+++ b/internal/cli/identity_test.go
@@ -16,13 +16,13 @@ func TestResolveAgentIDRejectsTraversal(t *testing.T) {
 		".hidden",
 		"-leading-dash",
 	} {
-		if got, err := resolveAgentID(bad); err == nil {
+		if got, err := resolveAgentID(bad, nil); err == nil {
 			t.Errorf("resolveAgentID(--as=%q) = %q, want error", bad, got)
 		}
 	}
 
 	t.Setenv("AGENTCHUTE_AGENT_ID", "../../etc/passwd")
-	if got, err := resolveAgentID(""); err == nil {
+	if got, err := resolveAgentID("", nil); err == nil {
 		t.Errorf("resolveAgentID(env=../../etc/passwd) = %q, want error", got)
 	}
 }
@@ -30,7 +30,7 @@ func TestResolveAgentIDRejectsTraversal(t *testing.T) {
 func TestResolveAgentIDExplicitOnly(t *testing.T) {
 	t.Run("flag wins", func(t *testing.T) {
 		t.Setenv("AGENTCHUTE_AGENT_ID", "env-id")
-		got, err := resolveAgentID("explicit-id")
+		got, err := resolveAgentID("explicit-id", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -41,7 +41,7 @@ func TestResolveAgentIDExplicitOnly(t *testing.T) {
 
 	t.Run("env fallback", func(t *testing.T) {
 		t.Setenv("AGENTCHUTE_AGENT_ID", "env-id")
-		got, err := resolveAgentID("")
+		got, err := resolveAgentID("", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -52,7 +52,7 @@ func TestResolveAgentIDExplicitOnly(t *testing.T) {
 
 	t.Run("missing has exact fix hint", func(t *testing.T) {
 		t.Setenv("AGENTCHUTE_AGENT_ID", "")
-		_, err := resolveAgentID("")
+		_, err := resolveAgentID("", nil)
 		if err == nil {
 			t.Fatal("missing identity returned nil error")
 		}

--- a/internal/cli/pending.go
+++ b/internal/cli/pending.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/agentchute/agentchute/internal/loop"
+	"github.com/agentchute/agentchute/internal/op"
 )
 
 // cmdPending lists unread inbox messages without archiving, quarantining,
@@ -60,51 +61,12 @@ func cmdPending(args []string) error {
 		return err
 	}
 
-	agentID, err = resolveAgentID(agentID)
+	agentID, err = resolveAgentID(agentID, cfg)
 	if err != nil {
 		return err
 	}
 	if err := loop.ValidateAgentID(agentID); err != nil {
 		return err
-	}
-
-	// v0.2.1 "Enforced Enrollment" (AGENTCHUTE.md §5.3): pending stays
-	// read-only, so it does NOT hard-refuse on missing registration like
-	// the active commands. Instead it surfaces a `needs_boot` reason in
-	// every output mode (text, --json, --claude-hook, --codex-hook). The
-	// only exit-2 path is --fail-if-any (codex review: needs_boot IS
-	// actionable work).
-	needsBoot := false
-	if _, err := os.Stat(cfg.AgentRegistrationPath(agentID)); err != nil {
-		if os.IsNotExist(err) {
-			needsBoot = true
-		} else {
-			return fmt.Errorf("stat own registration: %w", err)
-		}
-	}
-
-	// Strictly read-only: we do NOT update last_seen here. Pending is the
-	// hook-safe peek; `boot` is the lifecycle event that ticks last_seen.
-	inboxDir := cfg.AgentInboxDir(agentID)
-	msgs, skipped, err := loop.ListInboxMessagesWithSkipped(inboxDir)
-	if err != nil {
-		if errors.Is(err, loop.ErrInboxMissing) {
-			needsBoot = true
-			msgs, skipped = nil, nil
-		} else {
-			return fmt.Errorf("list inbox: %w", err)
-		}
-	}
-
-	// Asker-owned `.owed` obligations — replies WE are owed by peers (v0.9.0:
-	// the sole reply-obligation surface). Surfaced alongside the inbox count so
-	// per-turn hook context shows the full picture. NON-BLOCKING (asker-owned,
-	// dead-recipient signal); LoadOwedLedger is strictly read-only. A corrupt
-	// `.owed` is not fatal here — gate/boot own blocking, so pending stays a
-	// best-effort peek and reports zero owed rather than crashing.
-	var owedEntries []loop.OwedEntry
-	if owed, oerr := loop.LoadOwedLedger(cfg, agentID); oerr == nil {
-		owedEntries = owed.OutstandingOwed()
 	}
 
 	// Staleness annotation is ON BY DEFAULT at the same threshold `check`
@@ -124,29 +86,85 @@ func cmdPending(args []string) error {
 	}
 
 	now := time.Now().UTC()
-	entries := make([]pendingEntry, 0, len(msgs))
-	for _, msg := range msgs {
-		entry := pendingEntry{
-			From:      msg.Sender,
-			Filename:  msg.Filename,
-			Timestamp: msg.Timestamp.UTC().Format(time.RFC3339Nano),
-			Age:       humanAge(now.Sub(msg.Timestamp.UTC())),
+	needsBoot := false
+	malformed := 0
+	entries := make([]pendingEntry, 0)
+	var owedEntries []loop.OwedEntry
+	if cfg.Remote != nil {
+		if remoteHookCached(cfg) {
+			fmt.Fprintln(os.Stderr, "hub unreachable; skipping (will retry next event)")
+			return nil
 		}
-		// Parse frontmatter for reply_required.
-		// Body intentionally not read unless --show-body.
-		fm, body, ferr := readFrontmatter(msg.Path)
-		if ferr == nil {
-			if v := strings.ToLower(strings.TrimSpace(fm["reply_required"])); v == "true" {
-				entry.ReplyRequired = true
+		session, openErr := openRemoteOneShot(cfg, agentID)
+		if openErr != nil {
+			if degradeRemoteHook(openErr) {
+				return nil
 			}
-			if showBody {
-				entry.Body = body
+			return openErr
+		}
+		emit := func(ev op.Event) error {
+			switch {
+			case ev.Message != nil:
+				stamp, _ := time.Parse(time.RFC3339Nano, ev.Message.Stamp)
+				entry := pendingEntry{From: ev.Message.Sender, Filename: ev.Message.Filename, Timestamp: ev.Message.Stamp, Age: humanAge(now.Sub(stamp)), ReplyRequired: ev.Message.ReplyRequired}
+				if showBody && ev.Message.Body != nil {
+					entry.Body = loop.ExtractMessageBody(ev.Message.Body)
+				}
+				if staleThreshold > 0 && now.Sub(stamp) > staleThreshold {
+					entry.Stale = true
+				}
+				entries = append(entries, entry)
+			case ev.Owed != nil:
+				owedEntries = append(owedEntries, loop.OwedEntry{To: ev.Owed.To, From: ev.Owed.From, Seq: ev.Owed.Seq, Stamp: ev.Owed.Stamp, Suffix: ev.Owed.Suffix, By: ev.Owed.By, RecordedAt: ev.Owed.RecordedAt})
+			}
+			return nil
+		}
+		sum, pendingErr := session.Pending(op.PendingReq{ShowBody: showBody}, emit)
+		if pendingErr != nil {
+			if degradeRemoteHook(pendingErr) {
+				return nil
+			}
+			return pendingErr
+		}
+		needsBoot = sum.NeedsBoot
+		malformed = sum.Malformed
+	} else {
+		// v0.2.1 enforced enrollment: pending remains a read-only report.
+		if _, err := os.Stat(cfg.AgentRegistrationPath(agentID)); err != nil {
+			if os.IsNotExist(err) {
+				needsBoot = true
+			} else {
+				return fmt.Errorf("stat own registration: %w", err)
 			}
 		}
-		if staleThreshold > 0 && now.Sub(msg.Timestamp.UTC()) > staleThreshold {
-			entry.Stale = true
+		msgs, skipped, listErr := loop.ListInboxMessagesWithSkipped(cfg.AgentInboxDir(agentID))
+		if listErr != nil {
+			if errors.Is(listErr, loop.ErrInboxMissing) {
+				needsBoot = true
+				msgs, skipped = nil, nil
+			} else {
+				return fmt.Errorf("list inbox: %w", listErr)
+			}
 		}
-		entries = append(entries, entry)
+		malformed = len(skipped)
+		if owed, oerr := loop.LoadOwedLedger(cfg, agentID); oerr == nil {
+			owedEntries = owed.OutstandingOwed()
+		}
+		entries = make([]pendingEntry, 0, len(msgs))
+		for _, msg := range msgs {
+			entry := pendingEntry{From: msg.Sender, Filename: msg.Filename, Timestamp: msg.Timestamp.UTC().Format(time.RFC3339Nano), Age: humanAge(now.Sub(msg.Timestamp.UTC()))}
+			fm, body, ferr := readFrontmatter(msg.Path)
+			if ferr == nil {
+				entry.ReplyRequired = strings.EqualFold(strings.TrimSpace(fm["reply_required"]), "true")
+				if showBody {
+					entry.Body = body
+				}
+			}
+			if staleThreshold > 0 && now.Sub(msg.Timestamp.UTC()) > staleThreshold {
+				entry.Stale = true
+			}
+			entries = append(entries, entry)
+		}
 	}
 
 	// Emit output. The two --*-hook modes emit wrapper-specific JSON shapes
@@ -154,15 +172,15 @@ func cmdPending(args []string) error {
 	// context for that hook event. They never exit nonzero — the hook is
 	// for information, not lifecycle gating.
 	if claudeHook == "UserPromptSubmit" {
-		return emitClaudeUserPromptSubmit(entries, owedEntries, len(skipped), needsBoot, agentID)
+		return emitClaudeUserPromptSubmit(entries, owedEntries, malformed, needsBoot, agentID)
 	}
 	if codexHook == "UserPromptSubmit" {
-		return emitCodexUserPromptSubmit(entries, owedEntries, len(skipped), needsBoot, agentID)
+		return emitCodexUserPromptSubmit(entries, owedEntries, malformed, needsBoot, agentID)
 	}
 	if jsonOut {
-		return emitPendingJSON(entries, owedEntries, len(skipped), needsBoot, agentID)
+		return emitPendingJSON(entries, owedEntries, malformed, needsBoot, agentID)
 	}
-	emitPendingText(entries, owedEntries, len(skipped), needsBoot, agentID)
+	emitPendingText(entries, owedEntries, malformed, needsBoot, agentID)
 
 	// Exit code: 0 by default. With --fail-if-any, exit 2 if the inbox has
 	// unread mail OR the agent needs boot — the reasons a scheduler should wake

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentchute/agentchute/internal/hubclient"
 	"github.com/agentchute/agentchute/internal/loop"
 	"github.com/agentchute/agentchute/internal/op"
 )
@@ -39,9 +41,12 @@ type registerOpts struct {
 	Bio             string
 	WorkingRepos    []string
 	ServeToken      string
+	Announce        bool
+	Sweep           bool
 
-	HostProvided bool
-	BioProvided  bool
+	HostProvided   bool
+	BioProvided    bool
+	VendorProvided bool
 }
 
 // registerResult is performRegister's outcome.
@@ -59,6 +64,8 @@ type registerResult struct {
 	ExistingFound bool   // true if a prior registration file existed before this call.
 	ResolvedHost  string // post-merge host actually written
 	Warnings      []string
+	Announce      *op.AnnounceView
+	Pending       int
 }
 
 // performRegister writes / refreshes a registration through the seam.
@@ -84,22 +91,34 @@ func performRegister(cfg *loop.Config, opts registerOpts, now time.Time) (*regis
 	}
 
 	vendor := opts.Vendor
+	var vendorPtr *string
+	if cfg.Remote == nil || opts.VendorProvided {
+		vendorPtr = &vendor
+	}
 	req := op.RegisterReq{
-		Vendor:       &vendor,
+		Vendor:       vendorPtr,
 		Host:         host,
 		WorkingRepos: opts.WorkingRepos,
 		ServeToken:   opts.ServeToken,
-		// Announce and Sweep stay false on every local path: cmdRegister keeps
-		// its own AnnounceEnrollment call and cmdBoot its own sweep, so nothing
-		// local changes. Both fields exist for the wire, where a remote lane's
-		// fan-out and hygiene must run against the HUB's pool.
+		Announce:     opts.Announce,
+		Sweep:        opts.Sweep,
 	}
 	if opts.BioProvided {
 		bio := opts.Bio
 		req.Bio = &bio
 	}
 
-	resp, err := op.Register(cfg, op.Context{ActorID: opts.AgentID}, req, now)
+	var resp op.RegisterResp
+	var err error
+	if cfg.Remote != nil {
+		session, openErr := openRemoteOneShot(cfg, opts.AgentID)
+		if openErr != nil {
+			return nil, openErr
+		}
+		resp, err = session.Register(req)
+	} else {
+		resp, err = op.Register(cfg, op.Context{ActorID: opts.AgentID}, req, now)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +129,40 @@ func performRegister(cfg *loop.Config, opts registerOpts, now time.Time) (*regis
 		ExistingFound: resp.ExistingFound,
 		ResolvedHost:  resp.ResolvedHost,
 		Warnings:      resp.Warnings,
+		Announce:      resp.Announce,
+		Pending:       resp.Pending,
 	}, nil
+}
+
+func openRemoteOneShot(cfg *loop.Config, agentID string) (*hubclient.OneShot, error) {
+	session, err := hubclient.OpenOneShot(context.Background(), cfg.Remote, agentID, version)
+	if err != nil {
+		if hubclient.ErrorCode(err) == "E_CONNECT" {
+			_ = hubclient.RecordConnectFailure(cfg.Remote, time.Now().UTC())
+		}
+		return nil, err
+	}
+	_ = hubclient.ClearConnectFailure(cfg.Remote)
+	for _, warning := range session.Warnings() {
+		fmt.Fprintf(os.Stderr, "warning: %s\n", warning)
+	}
+	return session, nil
+}
+
+func remoteHookCached(cfg *loop.Config) bool {
+	if cfg == nil || cfg.Remote == nil {
+		return false
+	}
+	cached, _, err := hubclient.ConnectFailureCached(cfg.Remote, time.Now().UTC())
+	return err == nil && cached
+}
+
+func degradeRemoteHook(err error) bool {
+	if hubclient.ErrorCode(err) != "E_CONNECT" {
+		return false
+	}
+	fmt.Fprintln(os.Stderr, "hub unreachable; skipping (will retry next event)")
+	return true
 }
 
 func cmdRegister(args []string) error {
@@ -148,6 +200,8 @@ func cmdRegister(args []string) error {
 			opts.HostProvided = true
 		case "bio":
 			opts.BioProvided = true
+		case "vendor":
+			opts.VendorProvided = true
 		}
 	})
 
@@ -170,22 +224,25 @@ func cmdRegister(args []string) error {
 		return err
 	}
 
-	agentID, err = resolveAgentID(agentID)
+	agentID, err = resolveAgentID(agentID, cfg)
 	if err != nil {
 		return err
 	}
 	opts.AgentID = agentID
-	opts.Vendor = resolveAgentVendor(vendor, agentID, cfg)
+	if cfg.Remote != nil {
+		opts.Vendor = strings.TrimSpace(vendor)
+		opts.Announce = announce
+	} else {
+		opts.Vendor = resolveAgentVendor(vendor, agentID, cfg)
+	}
 
 	now := time.Now().UTC()
 	result, err := performRegister(cfg, opts, now)
 	if err != nil {
 		return err
 	}
-	reg := result.Reg
-
 	fmt.Printf("Registered %s\n", agentID)
-	fmt.Printf("  vendor:        %s\n", opts.Vendor)
+	fmt.Printf("  vendor:        %s\n", result.Reg.Vendor)
 	fmt.Printf("  host:          %s\n", result.ResolvedHost)
 	fmt.Printf("  control_repo:  %s%s\n", cfg.ControlRepo, formatOriginSuffix(cfg.ControlRepoOrigin))
 	fmt.Printf("  loop_dir:      %s%s\n", cfg.LoopDir, formatOriginSuffix(cfg.LoopDirOrigin))
@@ -197,8 +254,18 @@ func cmdRegister(args []string) error {
 	}
 
 	if announce {
-		ar, err := loop.AnnounceEnrollment(cfg, reg)
-		if err != nil {
+		if cfg.Remote != nil {
+			if result.Announce != nil {
+				for _, w := range result.Announce.Warnings {
+					fmt.Fprintf(os.Stderr, "warning: %s\n", w)
+				}
+				if result.Announce.Total == 0 {
+					fmt.Println("  announce:      no peers to announce to")
+				} else {
+					fmt.Printf("  announce:      sent to %d of %d peer(s)\n", result.Announce.Sent, result.Announce.Total)
+				}
+			}
+		} else if ar, err := loop.AnnounceEnrollment(cfg, result.Reg); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: announce failed: %v\n", err)
 		} else {
 			for _, w := range ar.Warnings {

--- a/internal/cli/remote_identity_test.go
+++ b/internal/cli/remote_identity_test.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/agentchute/agentchute/internal/hubclient"
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+func TestResolveAgentIDRemoteNamesMap(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AGENTCHUTE_AGENT_ID", "")
+	remote, err := loop.ParseRemoteURL("ssh://hub.example/remote/pool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := hubclient.WriteHubConfig(remote.HubID, &hubclient.HubConfig{
+		URL:      remote.URL,
+		JoinedAs: []string{"codex-tiny"},
+		Names:    map[string]string{"codex": "codex-tiny"},
+		Pool:     "/remote/pool",
+		Pool12:   "0123456789ab",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &loop.Config{Remote: remote, LoopDir: remote.ShadowLoopDir}
+
+	for _, tt := range []struct {
+		name       string
+		flagID     string
+		fallbackID []string
+		want       string
+	}{
+		{name: "local name", flagID: "codex", want: "codex-tiny"},
+		{name: "joined id", flagID: "codex-tiny", want: "codex-tiny"},
+		{name: "unmapped passthrough", flagID: "reviewer", want: "reviewer"},
+		{name: "direct launch fallback", fallbackID: []string{"codex"}, want: "codex-tiny"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveAgentID(tt.flagID, cfg, tt.fallbackID...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolved id = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveAgentIDRemoteEnvName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AGENTCHUTE_AGENT_ID", "codex")
+	remote, err := loop.ParseRemoteURL("ssh://hub.example/remote/pool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := hubclient.WriteHubConfig(remote.HubID, &hubclient.HubConfig{
+		URL:      remote.URL,
+		JoinedAs: []string{"codex-tiny"},
+		Names:    map[string]string{"codex": "codex-tiny"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveAgentID("", &loop.Config{Remote: remote})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "codex-tiny" {
+		t.Fatalf("resolved env id = %q, want codex-tiny", got)
+	}
+}

--- a/internal/cli/remote_render_test.go
+++ b/internal/cli/remote_render_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/hubclient"
+	"github.com/agentchute/agentchute/internal/loop"
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+func TestRemoteNoteProductionRendererGolden(t *testing.T) {
+	stdout, stderr, err := captureStdoutStderr(t, func() error {
+		renderOpNote(op.NoteEvent{Level: op.NoteWarn, Msg: "first warning"})
+		renderOpNote(op.NoteEvent{Level: op.NoteInfo, Msg: "then info"})
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdout != "then info\n" || stderr != "warning: first warning\n" {
+		t.Fatalf("stdout/stderr = %q/%q", stdout, stderr)
+	}
+}
+
+func TestPrintRemoteStatusUsesHubRowsAndPinnedNotices(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	cfg := &loop.Config{
+		ControlRepo: "/local/repo", ControlRepoOrigin: "env",
+		LoopDir: "/local/shadow/.agentchute/loop", LoopDirOrigin: "remote", Vendor: "agentchute",
+		Remote: &loop.RemoteConfig{URL: "ssh://hub.example/remote/pool"},
+	}
+	resp := op.StatusResp{Now: now, Truncated: true, Agents: []op.StatusAgent{{
+		AgentID: "codex-tiny", LastSeen: now.Add(-2 * time.Second), Host: "tiny", ProtocolVersion: loop.CurrentProtocolVersion, InboxDepth: 7, Status: "lease-held",
+	}}}
+	var out bytes.Buffer
+	printRemoteStatus(&out, cfg, resp)
+	text := out.String()
+	for _, want := range []string{
+		"control_repo: ssh://hub.example/remote/pool   (via env)",
+		"loop_dir:     /local/shadow/.agentchute/loop   (via remote)",
+		"  (local shadow: this process's own loop dir, not the hub's)",
+		"codex-tiny  lease-held  7",
+		"note: listing truncated by the hub at the first row that would exceed 64 rows or a 64 KiB response; later agent ids are missing.\n",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("remote status missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRemoteSendUnknownSpoolsOutsideShadowWithBodyFileRetry(t *testing.T) {
+	hubDir := t.TempDir()
+	cfg := &loop.Config{
+		LoopDir: filepath.Join(hubDir, ".agentchute", "loop"),
+		Remote:  &loop.RemoteConfig{HubDir: hubDir},
+	}
+	err := preserveRemoteSendBody(cfg, "codex-tiny", "claude-code", "body", time.Now().UTC(), sendRetryOptions{}, &hubclient.Error{Code: "E_SEND_UNKNOWN", Msg: "unknown"})
+	if err == nil {
+		t.Fatal("expected E_SEND_UNKNOWN")
+	}
+	if !strings.Contains(err.Error(), "DELIVERY UNKNOWN") || !strings.Contains(err.Error(), "--body-file") {
+		t.Fatalf("error = %v", err)
+	}
+	entries, readErr := os.ReadDir(filepath.Join(hubDir, "spool"))
+	if readErr != nil || len(entries) != 1 {
+		t.Fatalf("spool entries = %v, err=%v", entries, readErr)
+	}
+	spool := filepath.Join(hubDir, "spool", entries[0].Name())
+	if strings.HasPrefix(spool, cfg.LoopDir+string(filepath.Separator)) {
+		t.Fatalf("spool %s is inside shadow %s", spool, cfg.LoopDir)
+	}
+	data, readErr := os.ReadFile(spool)
+	if readErr != nil || string(data) != "body" {
+		t.Fatalf("spool body = %q, err=%v", data, readErr)
+	}
+	retryBody, retryErr := readSendBodyFile(cfg, spool)
+	if retryErr != nil || retryBody != "body" {
+		t.Fatalf("printed --body-file retry was not accepted: body=%q err=%v", retryBody, retryErr)
+	}
+}
+
+func TestClaimedHeldErrorArmsLocalLatch(t *testing.T) {
+	cfg := &loop.Config{LoopDir: filepath.Join(t.TempDir(), ".agentchute", "loop")}
+	t.Setenv("AGENTCHUTE_GUARD", "1")
+	t.Setenv("AGENTCHUTE_SERVE_TOKEN", "session-token")
+	err := &hubclient.Error{Code: "E_HUB_IO", Msg: "read failed", ClaimedHeld: true}
+	if !hubclient.ClaimedHeld(err) {
+		t.Fatal("claimed_held was lost")
+	}
+	maybeSetGuardLatch(cfg, "codex")
+	latch, readErr := loop.ReadGuardLatch(cfg, "codex")
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if latch.Session != "session-token" {
+		t.Fatalf("latch session = %q", latch.Session)
+	}
+}
+
+func TestRecipientReachabilityFromWireError(t *testing.T) {
+	rr, ok := recipientReachabilityFromWireError(`op: stale: recipient "grok" registration is stale (last_seen=2026-08-17T11:59:00Z age=1m0s > stale_after=30s)`)
+	if !ok || rr.Age != time.Minute || rr.Threshold != 30*time.Second {
+		t.Fatalf("reachability = %#v, ok=%v", rr, ok)
+	}
+	if _, ok := recipientReachabilityFromWireError(errors.New("bad").Error()); ok {
+		t.Fatal("malformed error parsed")
+	}
+}

--- a/internal/cli/remote_render_test.go
+++ b/internal/cli/remote_render_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/agentchute/agentchute/internal/hubclient"
+	"github.com/agentchute/agentchute/internal/hubwire"
 	"github.com/agentchute/agentchute/internal/loop"
 	"github.com/agentchute/agentchute/internal/op"
 )
@@ -85,15 +87,38 @@ func TestRemoteSendUnknownSpoolsOutsideShadowWithBodyFileRetry(t *testing.T) {
 	}
 }
 
-func TestClaimedHeldErrorArmsLocalLatch(t *testing.T) {
-	cfg := &loop.Config{LoopDir: filepath.Join(t.TempDir(), ".agentchute", "loop")}
+func TestW6ClientRemoteCheckClaimedHeldArmsLocalLatch(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGENTCHUTE_CONTROL_REPO", "")
+	t.Setenv("AGENTCHUTE_LOOP_DIR", "")
 	t.Setenv("AGENTCHUTE_GUARD", "1")
 	t.Setenv("AGENTCHUTE_SERVE_TOKEN", "session-token")
-	err := &hubclient.Error{Code: "E_HUB_IO", Msg: "read failed", ClaimedHeld: true}
-	if !hubclient.ClaimedHeld(err) {
-		t.Fatal("claimed_held was lost")
+	t.Setenv("AGENTCHUTE_W6_TEST_BINARY", os.Args[0])
+	t.Setenv("AGENTCHUTE_W6_TEST_HELPER", "1")
+
+	remote, err := loop.ParseRemoteURL("ssh://hub.example/remote/pool")
+	if err != nil {
+		t.Fatal(err)
 	}
-	maybeSetGuardLatch(cfg, "codex")
+	if err := hubclient.WriteHubConfig(remote.HubID, &hubclient.HubConfig{
+		URL: remote.URL, JoinedAs: []string{"codex"}, Pool: "/remote/pool", Pool12: "0123456789ab",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	ssh := filepath.Join(binDir, "ssh")
+	script := "#!/bin/sh\nexec \"$AGENTCHUTE_W6_TEST_BINARY\" -test.run '^TestW6ClientRemoteCheckClaimedHeldSSHHelper$'\n"
+	if err := os.WriteFile(ssh, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	err = cmdCheck([]string{"--as", "codex", "--control-repo", remote.URL})
+	if hubclient.ErrorCode(err) != "E_HUB_IO" || !hubclient.ClaimedHeld(err) {
+		t.Fatalf("check error = %v code=%s claimed_held=%v", err, hubclient.ErrorCode(err), hubclient.ClaimedHeld(err))
+	}
+	cfg := &loop.Config{LoopDir: remote.ShadowLoopDir}
 	latch, readErr := loop.ReadGuardLatch(cfg, "codex")
 	if readErr != nil {
 		t.Fatal(readErr)
@@ -101,6 +126,44 @@ func TestClaimedHeldErrorArmsLocalLatch(t *testing.T) {
 	if latch.Session != "session-token" {
 		t.Fatalf("latch session = %q", latch.Session)
 	}
+}
+
+func TestW6ClientRemoteCheckClaimedHeldSSHHelper(t *testing.T) {
+	if os.Getenv("AGENTCHUTE_W6_TEST_HELPER") != "1" {
+		return
+	}
+	fail := func(err error) {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	r := hubwire.NewReader(os.Stdin)
+	w := hubwire.NewWriter(os.Stdout)
+	raw, err := r.Read()
+	if err != nil || raw.T != "hello" {
+		fail(fmt.Errorf("read hello: type=%q err=%v", raw.T, err))
+	}
+	var hello hubwire.Hello
+	if err := raw.Decode(&hello); err != nil {
+		fail(err)
+	}
+	if err := w.Write(hubwire.HelloOK{
+		ResponseBase: hubwire.ResponseBase{T: "hello-ok", Re: raw.ID},
+		V:            hubwire.Version, Agent: hello.Agent, Pool: "/remote/pool", Pool12: "0123456789ab",
+		Writable: true, HubBin: "test", HubTime: time.Now().UTC(),
+	}, nil); err != nil {
+		fail(err)
+	}
+	raw, err = r.Read()
+	if err != nil || raw.T != "check" {
+		fail(fmt.Errorf("read check: type=%q err=%v", raw.T, err))
+	}
+	if err := w.Write(hubwire.Error{
+		ResponseBase: hubwire.ResponseBase{T: "error", Re: raw.ID},
+		Code:         "E_HUB_IO", Msg: "fixture unreadable claim", ClaimedHeld: true,
+	}, nil); err != nil {
+		fail(err)
+	}
+	os.Exit(0)
 }
 
 func TestRecipientReachabilityFromWireError(t *testing.T) {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -303,6 +303,29 @@ func TestRunnerChildEnvCarriesServeToken(t *testing.T) {
 	}
 }
 
+func TestRunnerChildEnvRemotePreservesLocatorAndOmitsLoopDir(t *testing.T) {
+	t.Setenv("AGENTCHUTE_CONTROL_REPO", "/inherited/local/repo")
+	t.Setenv("AGENTCHUTE_LOOP_DIR", "/inherited/local/loop")
+	cfg := &loop.Config{
+		ControlRepo: "/current/local/repo",
+		LoopDir:     "/local/shadow/.agentchute/loop",
+		Remote:      &loop.RemoteConfig{URL: "ssh://user@hub.example/remote/pool"},
+	}
+	env := runnerChildEnv(cfg, runnerOptions{AgentID: "codex-tiny", Vendor: "openai"}, "tok-remote")
+	controlRepos := make([]string, 0, 1)
+	for _, kv := range env {
+		switch {
+		case strings.HasPrefix(kv, "AGENTCHUTE_CONTROL_REPO="):
+			controlRepos = append(controlRepos, strings.TrimPrefix(kv, "AGENTCHUTE_CONTROL_REPO="))
+		case strings.HasPrefix(kv, "AGENTCHUTE_LOOP_DIR="):
+			t.Fatalf("remote child carries a loop-dir override: %q", kv)
+		}
+	}
+	if len(controlRepos) != 1 || controlRepos[0] != cfg.Remote.URL {
+		t.Fatalf("remote child control repo = %v, want only %q", controlRepos, cfg.Remote.URL)
+	}
+}
+
 // TestRunnerChildEnvStripsInheritedGuardBit is the v2.5 A7/C22 guard-enablement
 // contract (codex review, PR #89 finding #2): an unguarded wrapper (Guarded:
 // false, e.g. grok) must never appear armed just because the PROCESS running

--- a/internal/cli/self_check.go
+++ b/internal/cli/self_check.go
@@ -49,6 +49,8 @@ func cmdSelfCheck(args []string) error {
 			opts.HostProvided = true
 		case "bio":
 			opts.BioProvided = true
+		case "vendor":
+			opts.VendorProvided = true
 		}
 	})
 
@@ -68,14 +70,21 @@ func cmdSelfCheck(args []string) error {
 	}
 
 	now := time.Now().UTC()
+	if cfg.Remote != nil && remoteHookCached(cfg) {
+		fmt.Fprintln(os.Stderr, "hub unreachable; skipping (will retry next event)")
+		return nil
+	}
 	agentID, result, err := selfRepairRegistration(cfg, &opts, agentID, vendor, now)
 	if err != nil {
+		if cfg.Remote != nil && degradeRemoteHook(err) {
+			return nil
+		}
 		return err
 	}
 
 	status := selfCheckStatus{
 		Agent:    agentID,
-		Vendor:   opts.Vendor,
+		Vendor:   result.Reg.Vendor,
 		Host:     result.ResolvedHost,
 		LastSeen: result.Reg.LastSeen.UTC().Format(time.RFC3339),
 		Warnings: result.Warnings,
@@ -115,7 +124,7 @@ func cmdSelfCheck(args []string) error {
 // determined at all) returns "" — that is the one case nothing downstream can
 // proceed on.
 func selfRepairRegistration(cfg *loop.Config, opts *registerOpts, agentIDFlag, vendorFlag string, now time.Time) (string, *registerResult, error) {
-	agentID, err := resolveAgentID(agentIDFlag)
+	agentID, err := resolveAgentID(agentIDFlag, cfg)
 	if err != nil {
 		return "", nil, err
 	}
@@ -123,7 +132,11 @@ func selfRepairRegistration(cfg *loop.Config, opts *registerOpts, agentIDFlag, v
 		return "", nil, err
 	}
 	opts.AgentID = agentID
-	opts.Vendor = resolveAgentVendor(vendorFlag, agentID, cfg)
+	if cfg.Remote != nil {
+		opts.Vendor = strings.TrimSpace(vendorFlag)
+	} else {
+		opts.Vendor = resolveAgentVendor(vendorFlag, agentID, cfg)
+	}
 
 	result, err := performRegister(cfg, *opts, now)
 	if err != nil {

--- a/internal/cli/send.go
+++ b/internal/cli/send.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentchute/agentchute/internal/hubclient"
 	"github.com/agentchute/agentchute/internal/loop"
 	"github.com/agentchute/agentchute/internal/op"
 )
@@ -129,7 +130,7 @@ func cmdSendWithOp(args []string, send sendOperation) error {
 		}
 	}
 
-	fromID, err = resolveAgentID(fromID)
+	fromID, err = resolveAgentID(fromID, cfg)
 	if err != nil {
 		return err
 	}
@@ -146,8 +147,10 @@ func cmdSendWithOp(args []string, send sendOperation) error {
 	actor := op.Context{ActorID: fromID}
 	inboxDir := cfg.AgentInboxDir(toID)
 	now := time.Now().UTC()
-	if err := op.SendPreflight(cfg, actor, toID); err != nil {
-		return renderSendPreflightError(fromID, toID, err)
+	if cfg.Remote == nil {
+		if err := op.SendPreflight(cfg, actor, toID); err != nil {
+			return renderSendPreflightError(fromID, toID, err)
+		}
 	}
 
 	// `--body-file` is an explicit body source even when the file is empty: an
@@ -218,13 +221,25 @@ func cmdSendWithOp(args []string, send sendOperation) error {
 	// so a write from a fenced (reclaimed) agent fails closed (MintSendStamp's
 	// VerifyFence -> ErrFenced). Empty env (no serve lease) => intentionally
 	// unfenced.
-	resp, sendErr := send(cfg, actor, op.SendReq{
+	sendReq := op.SendReq{
 		To:         toID,
 		Content:    content,
 		Ask:        ask,
 		ReplyBy:    replyBy,
 		ServeToken: os.Getenv("AGENTCHUTE_SERVE_TOKEN"),
-	})
+	}
+	var resp op.SendResp
+	var sendErr error
+	if cfg.Remote != nil {
+		session, openErr := openRemoteOneShot(cfg, fromID)
+		if openErr != nil {
+			sendErr = openErr
+		} else {
+			resp, sendErr = session.Send(sendReq)
+		}
+	} else {
+		resp, sendErr = send(cfg, actor, sendReq)
+	}
 	retry := sendRetryOptions{
 		Ask:        ask,
 		ReplyBy:    replyBy.String(),
@@ -240,12 +255,22 @@ func cmdSendWithOp(args []string, send sendOperation) error {
 	// can ride a commit arrive as fields on the response, not as errors —
 	// DurabilityNote and OwedNote, both handled below.
 	if !resp.Committed {
+		if cfg.Remote != nil {
+			return preserveRemoteSendBody(cfg, fromID, toID, rawBody, now, retry, sendErr)
+		}
 		return preserveSendBody(cfg, fromID, toID, rawBody, now, retry, sendErr)
 	}
 	// The on-wire identity is (to,from,timestamp,suffix) (v2.5 plan B7): `to`
 	// is the inbox directory, from/stamp/suffix the filename. The committed
 	// suffix may differ from what was first proposed if a link collision forced
 	// a fresh-suffix retry (C4). No sender-asserted message_id is emitted.
+	if cfg.Remote != nil {
+		pool := cfg.Remote.PoolPath
+		if hubCfg, cfgErr := hubclient.ReadHubConfig(cfg.Remote.HubID); cfgErr == nil && hubCfg.Pool != "" {
+			pool = hubCfg.Pool
+		}
+		inboxDir = filepath.Join(pool, ".agentchute", "loop", "inbox", toID)
+	}
 	msg := loop.Message{Filename: resp.Filename, Path: filepath.Join(inboxDir, resp.Filename)}
 	result := sendResult{
 		Filename: msg.Filename,
@@ -297,6 +322,14 @@ func cmdSendWithOp(args []string, send sendOperation) error {
 // texts. One sentinel, one text each; the sender-path "sender %q" wording is
 // this call site's own and differs from check/status's "agent %q" by design.
 func renderSendPreflightError(from, to string, err error) error {
+	switch hubclient.ErrorCode(err) {
+	case "E_RECIPIENT_RACING":
+		return racingRecipientError(to)
+	case "E_RECIPIENT_STALE":
+		if rr, ok := recipientReachabilityFromWireError(err.Error()); ok {
+			return staleRecipientError(to, rr)
+		}
+	}
 	switch {
 	case errors.Is(err, op.ErrNotRegistered):
 		return fmt.Errorf("sender %q is not registered. Run `agentchute boot --as %s --vendor <vendor>` first (AGENTCHUTE.md §5.3)", from, from)
@@ -317,6 +350,30 @@ func renderSendPreflightError(from, to string, err error) error {
 	default:
 		return err
 	}
+}
+
+func recipientReachabilityFromWireError(message string) (loop.RecipientReachability, bool) {
+	var out loop.RecipientReachability
+	lastSeenAt := strings.Index(message, "last_seen=")
+	ageAt := strings.Index(message, " age=")
+	thresholdAt := strings.Index(message, " > stale_after=")
+	if lastSeenAt < 0 || ageAt < 0 || thresholdAt < 0 || lastSeenAt >= ageAt || ageAt >= thresholdAt {
+		return out, false
+	}
+	lastSeen := message[lastSeenAt+len("last_seen=") : ageAt]
+	ageText := message[ageAt+len(" age=") : thresholdAt]
+	thresholdText := strings.TrimSuffix(message[thresholdAt+len(" > stale_after="):], ")")
+	var err error
+	out.LastSeen, err = time.Parse(time.RFC3339, lastSeen)
+	if err != nil {
+		return loop.RecipientReachability{}, false
+	}
+	out.Age, err = time.ParseDuration(ageText)
+	if err != nil {
+		return loop.RecipientReachability{}, false
+	}
+	out.Threshold, err = time.ParseDuration(thresholdText)
+	return out, err == nil
 }
 
 // sendResult is the structured shape of `send`'s output (the same fields
@@ -441,8 +498,23 @@ func preserveSendBody(cfg *loop.Config, from, to, body string, now time.Time, re
 	return fmt.Errorf("%w\nbody preserved at %s; retry with: %s", baseErr, spoolPath, sendRetryCommand(from, to, spoolPath, retry))
 }
 
+func preserveRemoteSendBody(cfg *loop.Config, from, to, body string, now time.Time, retry sendRetryOptions, cause error) error {
+	spoolPath, spoolErr := writeSendSpool(cfg, from, to, body, now)
+	if spoolErr != nil {
+		return fmt.Errorf("%w; body preservation failed: %v", cause, spoolErr)
+	}
+	retryCommand := sendRetryCommandBodyFile(from, to, spoolPath, retry)
+	if hubclient.ErrorCode(cause) == "E_SEND_UNKNOWN" {
+		return fmt.Errorf("hub: connection lost after the send was transmitted — DELIVERY UNKNOWN. Do NOT resend blindly: a copy may already be in %s's inbox (check `agentchute status`, or ask them). Body preserved at %s; if you confirm it did not arrive, retry with: %s", to, spoolPath, retryCommand)
+	}
+	return fmt.Errorf("%w\nbody preserved at %s; retry with: %s", renderSendPreflightError(from, to, cause), spoolPath, retryCommand)
+}
+
 func writeSendSpool(cfg *loop.Config, from, to, body string, now time.Time) (string, error) {
 	spoolDir := filepath.Join(cfg.AgentStateDir(from), "spool")
+	if cfg.Remote != nil {
+		spoolDir = filepath.Join(cfg.Remote.HubDir, "spool")
+	}
 	if err := os.MkdirAll(spoolDir, 0o700); err != nil {
 		return "", err
 	}
@@ -491,6 +563,20 @@ func sendRetryCommand(from, to, spoolPath string, opts sendRetryOptions) string 
 		parts = append(parts, "--reply-to", shellQuote(opts.ReplyTo))
 	}
 	return strings.Join(parts, " ") + " < " + shellQuote(spoolPath)
+}
+
+func sendRetryCommandBodyFile(from, to, spoolPath string, opts sendRetryOptions) string {
+	parts := []string{"agentchute", "send", "--to", to, "--from", from}
+	if opts.Ask {
+		parts = append(parts, "--ask")
+	}
+	if opts.ReplyBySet {
+		parts = append(parts, "--reply-by", shellQuote(opts.ReplyBy))
+	}
+	if opts.ReplyToSet {
+		parts = append(parts, "--reply-to", shellQuote(opts.ReplyTo))
+	}
+	return strings.Join(parts, " ") + " --body-file " + shellQuote(spoolPath)
 }
 
 // applyAskHeading prepends a `## ASK` heading if the body doesn't already

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -72,6 +72,7 @@ type runnerOptions struct {
 	WrapperArgs     []string
 	ShimName        string // ac-* launcher shim that started this lane (provenance).
 	Guarded         bool   // wrapper's hooks can clear the guard latch (v2.5 A7/C22); serve exports AGENTCHUTE_GUARD=1 only when true.
+	VendorProvided  bool
 }
 
 func cmdServe(args []string) error {
@@ -93,6 +94,11 @@ func cmdServe(args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return runUsage(err)
 	}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "vendor" {
+			opts.VendorProvided = true
+		}
+	})
 
 	if opts.IntervalSeconds < minServeIntervalSeconds {
 		return fmt.Errorf("--interval must be >= %d seconds", minServeIntervalSeconds)
@@ -143,19 +149,29 @@ func cmdServe(args []string) error {
 	if err != nil {
 		return err
 	}
-	opts.AgentID, err = resolveAgentID(opts.AgentID)
+	fallbackID := ""
+	if launchedWrapper != "" {
+		if _, lookupErr := exec.LookPath(opts.WrapperArgs[0]); lookupErr == nil {
+			fallbackID = launchedWrapper
+		}
+	}
+	opts.AgentID, err = resolveAgentID(opts.AgentID, cfg, fallbackID)
 	if err != nil {
 		return err
 	}
 	if err := loop.ValidateAgentID(opts.AgentID); err != nil {
 		return err
 	}
-	opts.Vendor = resolveAgentVendor(opts.Vendor, opts.AgentID, cfg)
-	if opts.Vendor == "" {
+	if cfg.Remote == nil {
+		opts.Vendor = resolveAgentVendor(opts.Vendor, opts.AgentID, cfg)
+	}
+	if cfg.Remote == nil && opts.Vendor == "" {
 		return fmt.Errorf("missing --vendor (recommended values: anthropic, openai, google)")
 	}
-	if err := loop.ValidateAgentID(opts.Vendor); err != nil {
-		return fmt.Errorf("--vendor: %w", err)
+	if opts.Vendor != "" {
+		if err := loop.ValidateAgentID(opts.Vendor); err != nil {
+			return fmt.Errorf("--vendor: %w", err)
+		}
 	}
 	if err := refreshWrapperHook(cfg.ControlRepo, launchedWrapper); err != nil {
 		return fmt.Errorf("serve: refresh %s hook: %w", launchedWrapper, err)
@@ -552,12 +568,13 @@ func registerRunner(cfg *loop.Config, opts runnerOptions, serveToken string, now
 	// path via the PTY supervisor, not a registration field. The registration is
 	// a plain no-wake record.
 	_, err := performRegister(cfg, registerOpts{
-		AgentID:      opts.AgentID,
-		Vendor:       opts.Vendor,
-		WorkingRepos: []string{cfg.ControlRepo},
-		Host:         localHostname(),
-		HostProvided: true,
-		ServeToken:   serveToken,
+		AgentID:        opts.AgentID,
+		Vendor:         opts.Vendor,
+		WorkingRepos:   []string{cfg.ControlRepo},
+		Host:           localHostname(),
+		HostProvided:   true,
+		ServeToken:     serveToken,
+		VendorProvided: opts.VendorProvided,
 	}, now)
 	return err
 }

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -534,18 +534,13 @@ func withoutEnv(env []string, keys ...string) []string {
 }
 
 func runnerChildEnv(cfg *loop.Config, opts runnerOptions, serveToken string) []string {
-	// Strip any inherited AGENTCHUTE_GUARD before conditionally re-adding it
-	// below: os.Environ() carries THIS process's own env, which is nonempty
-	// whenever a guarded session itself launches `ac serve <other-wrapper>`
-	// (e.g. `ac serve grok` run from inside a guarded claude-code session).
-	// Without stripping, an unguarded wrapper's child would inherit the bit
-	// from its guarded parent and appear armed with no hook able to ever
-	// clear the latch (codex review, PR #89 finding #2).
-	env := withoutEnv(os.Environ(), "AGENTCHUTE_GUARD")
+	// Strip inherited authoritative values before conditionally re-adding them:
+	// os.Environ() carries THIS process's discovery and guard context whenever a
+	// served child launches another lane. A remote child must inherit the hub URL
+	// and no loop-dir override; an unguarded child must not inherit the guard bit.
+	env := withoutEnv(os.Environ(), "AGENTCHUTE_GUARD", "AGENTCHUTE_CONTROL_REPO", "AGENTCHUTE_LOOP_DIR")
 	env = append(env,
 		"AGENTCHUTE_AGENT_ID="+opts.AgentID,
-		"AGENTCHUTE_CONTROL_REPO="+cfg.ControlRepo,
-		"AGENTCHUTE_LOOP_DIR="+cfg.LoopDir,
 		"AGENTCHUTE_RUNNER=1",
 		"AGENTCHUTE_RUNNER_PID="+strconv.Itoa(os.Getpid()),
 		// Fence the child's sends: send.go passes this serve_token to
@@ -553,6 +548,14 @@ func runnerChildEnv(cfg *loop.Config, opts runnerOptions, serveToken string) []s
 		// (protocol-v2 §6b). Empty when launched without a lease => unfenced.
 		"AGENTCHUTE_SERVE_TOKEN="+serveToken,
 	)
+	if cfg.Remote != nil {
+		env = append(env, "AGENTCHUTE_CONTROL_REPO="+cfg.Remote.URL)
+	} else {
+		env = append(env,
+			"AGENTCHUTE_CONTROL_REPO="+cfg.ControlRepo,
+			"AGENTCHUTE_LOOP_DIR="+cfg.LoopDir,
+		)
+	}
 	if opts.Guarded {
 		// v2.5 A7/C22: only a wrapper whose installed hooks can clear the
 		// guard latch (via turn-end) may have it armed. Unguarded wrappers

--- a/internal/cli/shims.go
+++ b/internal/cli/shims.go
@@ -297,18 +297,18 @@ func cmdShimsExec(args []string) error {
 	if err != nil {
 		return err
 	}
-	runArgs := []string{
-		agentchuteBin,
-		"serve",
-		"--vendor", spec.Vendor,
-		"--control-repo", cfg.ControlRepo,
-		"--loop-dir", cfg.LoopDir,
-		"--shim-name", spec.Name,
-	}
-	runArgs = append(runArgs, ensureDispatchIdentity(nil, spec.AgentID, os.Getenv("AGENTCHUTE_AGENT_ID"))...)
+	runArgs := buildShimRunArgs(agentchuteBin, spec, cfg, os.Getenv("AGENTCHUTE_AGENT_ID"), wrapperArgs)
+	return execReplace(agentchuteBin, runArgs, os.Environ())
+}
+
+func buildShimRunArgs(agentchuteBin string, spec wrapperSpec, cfg *loop.Config, envID string, wrapperArgs []string) []string {
+	runArgs := []string{agentchuteBin, "serve", "--vendor", spec.Vendor}
+	runArgs = append(runArgs, launcherControlArgs(cfg)...)
+	runArgs = append(runArgs, "--shim-name", spec.Name)
+	runArgs = append(runArgs, ensureDispatchIdentity(nil, spec.AgentID, envID)...)
 	runArgs = append(runArgs, "--")
 	runArgs = append(runArgs, wrapperArgs...)
-	return execReplace(agentchuteBin, runArgs, os.Environ())
+	return runArgs
 }
 
 func wrapperSpecForName(name string) (wrapperSpec, bool) {

--- a/internal/cli/shims_test.go
+++ b/internal/cli/shims_test.go
@@ -6,7 +6,45 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/agentchute/agentchute/internal/loop"
 )
+
+func TestBuildShimRunArgsLocalAndRemote(t *testing.T) {
+	spec, ok := wrapperSpecForName("ac-codex")
+	if !ok {
+		t.Fatal("missing codex wrapper spec")
+	}
+	wrapperArgs := []string{"/usr/bin/codex", "resume"}
+	local := &loop.Config{ControlRepo: "/repo", LoopDir: "/repo/.agentchute/loop"}
+	got := buildShimRunArgs("/bin/agentchute", spec, local, "reviewer", wrapperArgs)
+	want := []string{
+		"/bin/agentchute", "serve", "--vendor", "openai",
+		"--control-repo", "/repo", "--loop-dir", "/repo/.agentchute/loop",
+		"--shim-name", spec.Name, "--", "/usr/bin/codex", "resume",
+	}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("local runArgs =\n  %v\nwant\n  %v", got, want)
+	}
+
+	remote := &loop.Config{
+		ControlRepo: "/local/repo",
+		LoopDir:     "/home/me/.agentchute/hub/abc/.agentchute/loop",
+		Remote:      &loop.RemoteConfig{URL: "ssh://user@hub.example/remote/pool"},
+	}
+	got = buildShimRunArgs("/bin/agentchute", spec, remote, "reviewer", wrapperArgs)
+	want = []string{
+		"/bin/agentchute", "serve", "--vendor", "openai",
+		"--control-repo", remote.Remote.URL,
+		"--shim-name", spec.Name, "--", "/usr/bin/codex", "resume",
+	}
+	if strings.Join(got, " ") != strings.Join(want, " ") {
+		t.Fatalf("remote runArgs =\n  %v\nwant\n  %v", got, want)
+	}
+	if stringSliceContains(got, "--loop-dir") {
+		t.Fatalf("remote runArgs contains --loop-dir: %v", got)
+	}
+}
 
 // legacyShimScript renders a pre-dispatcher per-wrapper `ac-*`/same-name shim
 // (the format the removed production renderShimScript emitted). Kept as a

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -32,12 +32,6 @@ func cmdStatus(args []string) error {
 		return statusUsage(fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " ")))
 	}
 
-	var err error
-	agentID, err = resolveAgentID(agentID)
-	if err != nil {
-		return err
-	}
-
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -52,16 +46,30 @@ func cmdStatus(args []string) error {
 	if err != nil {
 		return err
 	}
+	agentID, err = resolveAgentID(agentID, cfg)
+	if err != nil {
+		return err
+	}
 
 	now := time.Now().UTC()
 	// Read errors arrive as warn notes DURING the read, so they land on stderr
 	// before the table exactly as they always have — position included.
-	resp, err := op.Status(cfg, op.Context{ActorID: agentID}, op.StatusReq{}, func(ev op.Event) error {
+	emit := func(ev op.Event) error {
 		if ev.Note != nil && ev.Note.Level == op.NoteWarn {
 			fmt.Fprintf(os.Stderr, "warning: %s\n", ev.Note.Msg)
 		}
 		return nil
-	})
+	}
+	var resp op.StatusResp
+	if cfg.Remote != nil {
+		session, openErr := openRemoteOneShot(cfg, agentID)
+		if openErr != nil {
+			return openErr
+		}
+		resp, err = session.Status(emit)
+	} else {
+		resp, err = op.Status(cfg, op.Context{ActorID: agentID}, op.StatusReq{}, emit)
+	}
 	if err != nil {
 		if errors.Is(err, op.ErrNotRegistered) {
 			return fmt.Errorf("agent %q is not registered. Run `agentchute boot --as %s --vendor <vendor>` first (AGENTCHUTE.md §5.3)", agentID, agentID)
@@ -69,7 +77,11 @@ func cmdStatus(args []string) error {
 		return err
 	}
 
-	printStatus(os.Stdout, cfg, registrationsOf(resp.Agents), now)
+	if cfg.Remote != nil {
+		printRemoteStatus(os.Stdout, cfg, resp)
+	} else {
+		printStatus(os.Stdout, cfg, registrationsOf(resp.Agents), now)
+	}
 	return nil
 }
 
@@ -98,13 +110,7 @@ func statusUsage(err error) error {
 }
 
 func printStatus(w io.Writer, cfg *loop.Config, regs map[string]*loop.Registration, now time.Time) {
-	fmt.Fprintf(w, "control_repo: %s%s\n", cfg.ControlRepo, formatOriginSuffix(cfg.ControlRepoOrigin))
-	fmt.Fprintf(w, "loop_dir:     %s%s\n", cfg.LoopDir, formatOriginSuffix(cfg.LoopDirOrigin))
-	fmt.Fprintf(w, "vendor:       %s\n", cfg.Vendor)
-	for _, shadowed := range cfg.ShadowedPointers {
-		fmt.Fprintf(w, "  (shadowed pointer: %s)\n", shadowed)
-	}
-	fmt.Fprintln(w)
+	printStatusHeader(w, cfg)
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	// Pull-only (Gate 6c): registrations carry no wake state. There is no
@@ -126,6 +132,48 @@ func printStatus(w io.Writer, cfg *loop.Config, regs map[string]*loop.Registrati
 	}
 	_ = tw.Flush()
 
+	printProtocolWarnings(w, regs)
+}
+
+func printStatusHeader(w io.Writer, cfg *loop.Config) {
+	controlRepo := cfg.ControlRepo
+	if cfg.Remote != nil {
+		controlRepo = cfg.Remote.URL
+	}
+	fmt.Fprintf(w, "control_repo: %s%s\n", controlRepo, formatOriginSuffix(cfg.ControlRepoOrigin))
+	fmt.Fprintf(w, "loop_dir:     %s%s\n", cfg.LoopDir, formatOriginSuffix(cfg.LoopDirOrigin))
+	if cfg.Remote != nil {
+		fmt.Fprintln(w, "  (local shadow: this process's own loop dir, not the hub's)")
+	}
+	fmt.Fprintf(w, "vendor:       %s\n", cfg.Vendor)
+	for _, shadowed := range cfg.ShadowedPointers {
+		fmt.Fprintf(w, "  (shadowed pointer: %s)\n", shadowed)
+	}
+	fmt.Fprintln(w)
+}
+
+func printRemoteStatus(w io.Writer, cfg *loop.Config, resp op.StatusResp) {
+	printStatusHeader(w, cfg)
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "AGENT\tSTATUS\tINBOX\tLAST_SEEN\tAGE\tHOST\tPROTO")
+	regs := make(map[string]*loop.Registration, len(resp.Agents))
+	for _, agent := range resp.Agents {
+		regs[agent.AgentID] = &loop.Registration{AgentID: agent.AgentID, LastSeen: agent.LastSeen, Host: agent.Host, ProtocolVersion: agent.ProtocolVersion}
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\t%s\t%s\n",
+			agent.AgentID, agent.Status, agent.InboxDepth,
+			formatMaybeTime(agent.LastSeen), formatAge(resp.Now, agent.LastSeen),
+			formatDash(agent.Host), formatProtocolVersion(agent.ProtocolVersion),
+		)
+	}
+	_ = tw.Flush()
+	printProtocolWarnings(w, regs)
+	if resp.Truncated {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "note: listing truncated by the hub at the first row that would exceed 64 rows or a 64 KiB response; later agent ids are missing.")
+	}
+}
+
+func printProtocolWarnings(w io.Writer, regs map[string]*loop.Registration) {
 	var warnings []string
 	for _, id := range loop.RegistrationsByAgentID(regs) {
 		if warning := protocolVersionWarning(regs[id]); warning != "" {

--- a/internal/cli/turn_end.go
+++ b/internal/cli/turn_end.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentchute/agentchute/internal/hubclient"
 	"github.com/agentchute/agentchute/internal/loop"
 	"github.com/agentchute/agentchute/internal/op"
 )
@@ -88,6 +89,8 @@ func cmdTurnEnd(args []string) error {
 			opts.HostProvided = true
 		case "bio":
 			opts.BioProvided = true
+		case "vendor":
+			opts.VendorProvided = true
 		}
 	})
 
@@ -154,6 +157,9 @@ func cmdTurnEnd(args []string) error {
 	if archive {
 		acked, _, err = ackClaimed(cfg, agentID)
 		if err != nil {
+			if cfg.Remote != nil && hubclient.ErrorCode(err) == "E_CONNECT" {
+				return fmt.Errorf("turn-end: could not reach the hub to commit claimed mail (connect failed after 5s). Nothing is lost: the claim is held on the hub and the guard latch stays armed; turn-end retries at the next turn boundary. If this persists, check the network and run agentchute doctor")
+			}
 			return err
 		}
 	}
@@ -167,7 +173,17 @@ func cmdTurnEnd(args []string) error {
 	}
 
 	// STEP 3.
-	status, err := op.Gate(cfg, op.Context{ActorID: agentID}, op.GateReq{Phase: gatePhaseFinish})
+	gateReq := op.GateReq{Phase: gatePhaseFinish}
+	var status op.GateResp
+	if cfg.Remote != nil {
+		gateSession, openErr := openRemoteOneShot(cfg, agentID)
+		if openErr != nil {
+			return openErr
+		}
+		status, err = gateSession.Gate(gateReq)
+	} else {
+		status, err = op.Gate(cfg, op.Context{ActorID: agentID}, gateReq)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/hubclient/cache.go
+++ b/internal/hubclient/cache.go
@@ -1,0 +1,93 @@
+package hubclient
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+const hubDownTTL = 30 * time.Second
+
+type hubDownState struct {
+	LastEConnect time.Time `json:"last_econnect"`
+}
+
+func HubDownPath(remote *loop.RemoteConfig) string {
+	return filepath.Join(remote.HubDir, "hub-down.json")
+}
+
+func RecordConnectFailure(remote *loop.RemoteConfig, now time.Time) error {
+	if remote == nil {
+		return nil
+	}
+	if err := loop.EnsurePrivateDir(remote.HubDir); err != nil {
+		return err
+	}
+	data, err := json.Marshal(hubDownState{LastEConnect: now.UTC()})
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	path := HubDownPath(remote)
+	tmp, err := os.CreateTemp(remote.HubDir, ".hub-down.json.tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func ClearConnectFailure(remote *loop.RemoteConfig) error {
+	if remote == nil {
+		return nil
+	}
+	err := os.Remove(HubDownPath(remote))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func ConnectFailureCached(remote *loop.RemoteConfig, now time.Time) (bool, time.Duration, error) {
+	if remote == nil {
+		return false, 0, nil
+	}
+	path := HubDownPath(remote)
+	data, err := loop.ReadFileLimit(path, 64<<10)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, 0, nil
+	}
+	if err != nil {
+		return false, 0, err
+	}
+	var state hubDownState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return false, 0, fmt.Errorf("parse %s: %w", path, err)
+	}
+	age := now.Sub(state.LastEConnect)
+	if age < 0 {
+		age = 0
+	}
+	return age < hubDownTTL, age, nil
+}

--- a/internal/hubclient/cache_test.go
+++ b/internal/hubclient/cache_test.go
@@ -1,0 +1,35 @@
+package hubclient
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+func TestConnectFailureCacheWindowAndClear(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	remote, err := loop.ParseRemoteURL("ssh://hub.example/pool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	if err := RecordConnectFailure(remote, now); err != nil {
+		t.Fatal(err)
+	}
+	cached, age, err := ConnectFailureCached(remote, now.Add(29*time.Second))
+	if err != nil || !cached || age != 29*time.Second {
+		t.Fatalf("cached/age/err = %v/%s/%v", cached, age, err)
+	}
+	cached, _, err = ConnectFailureCached(remote, now.Add(30*time.Second))
+	if err != nil || cached {
+		t.Fatalf("expired cache = %v/%v", cached, err)
+	}
+	if err := ClearConnectFailure(remote); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(HubDownPath(remote)); !os.IsNotExist(err) {
+		t.Fatalf("cache still exists: %v", err)
+	}
+}

--- a/internal/hubclient/config.go
+++ b/internal/hubclient/config.go
@@ -1,0 +1,87 @@
+package hubclient
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+const maxHubConfigBytes = 64 << 10
+
+var ErrHubConfigNotFound = errors.New("hub config not found")
+
+type HubConfig struct {
+	URL      string            `json:"url"`
+	JoinedAs []string          `json:"joined_as"`
+	Names    map[string]string `json:"names"`
+	Pool     string            `json:"pool"`
+	Pool12   string            `json:"pool12"`
+}
+
+func ReadHubConfig(hubID string) (*HubConfig, error) {
+	path, err := loop.HubConfigPath(hubID)
+	if err != nil {
+		return nil, err
+	}
+	data, err := loop.ReadFileLimit(path, maxHubConfigBytes)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", ErrHubConfigNotFound, path)
+		}
+		return nil, fmt.Errorf("read hub config %s: %w", path, err)
+	}
+	var cfg HubConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse hub config %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+func WriteHubConfig(hubID string, cfg *HubConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("write hub config: nil config")
+	}
+	path, err := loop.HubConfigPath(hubID)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := loop.EnsurePrivateDir(dir); err != nil {
+		return fmt.Errorf("create hub config directory %s: %w", dir, err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode hub config: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(dir, ".config.json.tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temporary hub config: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temporary hub config: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temporary hub config: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("fsync temporary hub config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary hub config: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("commit hub config %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/hubclient/config_test.go
+++ b/internal/hubclient/config_test.go
@@ -1,0 +1,98 @@
+package hubclient
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+func plantHubConfig(t *testing.T, hubID string, cfg HubConfig) {
+	t.Helper()
+	if err := WriteHubConfig(hubID, &cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHubConfigRoundTripPermissionsAndUnknownFieldDrop(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	want := HubConfig{
+		URL:      "ssh://alex@hub.example/pool",
+		JoinedAs: []string{"codex-tiny"},
+		Names:    map[string]string{"codex": "codex-tiny"},
+		Pool:     "/pool",
+		Pool12:   "0123456789ab",
+	}
+	plantHubConfig(t, "abcdef012345", want)
+
+	path, err := loop.HubConfigPath("abcdef012345")
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("config mode = %o, want 600", got)
+	}
+	dirInfo, err := os.Stat(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("config dir mode = %o, want 700", got)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = []byte(strings.TrimSpace(string(raw))[:len(strings.TrimSpace(string(raw)))-1] + ",\n  \"future\": true\n}\n")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadHubConfig("abcdef012345")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(*got, want) {
+		t.Fatalf("round trip = %#v, want %#v", *got, want)
+	}
+	if err := WriteHubConfig("abcdef012345", got); err != nil {
+		t.Fatal(err)
+	}
+	raw, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "future") {
+		t.Fatalf("unknown field survived rewrite: %s", raw)
+	}
+}
+
+func TestReadHubConfigNotFoundDistinctFromParseError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if _, err := ReadHubConfig("missing000000"); !errors.Is(err, ErrHubConfigNotFound) {
+		t.Fatalf("missing error = %v, want ErrHubConfigNotFound", err)
+	}
+
+	path, err := loop.HubConfigPath("invalid000000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = ReadHubConfig("invalid000000")
+	if err == nil || errors.Is(err, ErrHubConfigNotFound) {
+		t.Fatalf("parse error = %v, must differ from not found", err)
+	}
+}

--- a/internal/hubclient/session.go
+++ b/internal/hubclient/session.go
@@ -1,0 +1,426 @@
+package hubclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/hubwire"
+	"github.com/agentchute/agentchute/internal/loop"
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+type Error struct {
+	Code        string
+	Msg         string
+	Retriable   bool
+	ClaimedHeld bool
+	Cause       error
+}
+
+func (e *Error) Error() string { return e.Msg }
+func (e *Error) Unwrap() error {
+	if e.Cause != nil {
+		return e.Cause
+	}
+	switch e.Code {
+	case "E_NOT_REGISTERED":
+		return op.ErrNotRegistered
+	case "E_RECIPIENT_UNKNOWN":
+		return op.ErrRecipientUnknown
+	case "E_RECIPIENT_UNREADABLE":
+		return op.ErrRecipientUnreadable
+	case "E_RECIPIENT_STALE":
+		return op.ErrRecipientStale
+	case "E_RECIPIENT_RACING":
+		return op.ErrRecipientRacing
+	case "E_FENCED":
+		return op.ErrFenced
+	case "E_LEASE_HELD":
+		return op.ErrLeaseHeld
+	case "E_ORDER":
+		return op.ErrOrder
+	default:
+		return nil
+	}
+}
+
+func ErrorCode(err error) string {
+	var remoteErr *Error
+	if errors.As(err, &remoteErr) {
+		return remoteErr.Code
+	}
+	return ""
+}
+
+func ClaimedHeld(err error) bool {
+	var remoteErr *Error
+	return errors.As(err, &remoteErr) && remoteErr.ClaimedHeld
+}
+
+var afterSendFirstByte func()
+
+type OneShot struct {
+	transport Transport
+	reader    *hubwire.Reader
+	remote    *loop.RemoteConfig
+	agentID   string
+	nextID    int64
+	closed    bool
+	warnings  []string
+	hello     hubwire.HelloOK
+}
+
+func OpenOneShot(ctx context.Context, remote *loop.RemoteConfig, agentID, bin string) (*OneShot, error) {
+	invocation, err := BuildSSHInvocation(SSHBuildOptions{Remote: remote, AgentID: agentID})
+	if err != nil {
+		return nil, err
+	}
+	transport, err := startSSH(ctx, invocation)
+	if err != nil {
+		return nil, err
+	}
+	s, err := OpenOneShotTransport(transport, remote, agentID, bin)
+	if err != nil {
+		return nil, err
+	}
+	hubCfg, err := ReadHubConfig(remote.HubID)
+	if err != nil {
+		_ = s.Close()
+		return nil, err
+	}
+	if s.hello.Pool != hubCfg.Pool || s.hello.Pool12 != hubCfg.Pool12 {
+		_ = s.Close()
+		return nil, &Error{Code: hubwire.CodePoolMismatch, Msg: fmt.Sprintf("hub: this key now serves pool %s (id %s) on the hub, but this machine joined pool id %s (%s). The key line was re-pointed or the hub moved the pool. Re-join if the move is intended (agentchute hub join <url> --as %s), or re-authorize the key with the right --pool on the hub.", s.hello.Pool, s.hello.Pool12, hubCfg.Pool12, hubCfg.Pool, agentID)}
+	}
+	s.warnings = invocation.Warnings
+	return s, nil
+}
+
+func OpenOneShotTransport(transport Transport, remote *loop.RemoteConfig, agentID, bin string) (*OneShot, error) {
+	s := &OneShot{transport: transport, reader: hubwire.NewReader(transport), remote: remote, agentID: agentID, nextID: 1}
+	if err := s.setWriteDeadline(30 * time.Second); err != nil {
+		_ = transport.Close()
+		return nil, err
+	}
+	hello := hubwire.Hello{
+		RequestBase: hubwire.RequestBase{T: "hello", ID: s.nextID},
+		Proto:       hubwire.Protocol,
+		V:           hubwire.Version,
+		MinV:        hubwire.MinVersion,
+		Agent:       agentID,
+		Bin:         bin,
+	}
+	if err := hubwire.NewWriter(transport).Write(hello, nil); err != nil {
+		return nil, classifySSHFailure(remote, agentID, "connect", err, transport)
+	}
+	if err := s.setReadDeadline(10 * time.Second); err != nil {
+		_ = transport.Close()
+		return nil, err
+	}
+	raw, err := s.reader.Read()
+	if err != nil {
+		stage := "connect"
+		if isTimeout(err) {
+			stage = "hello-timeout"
+		}
+		return nil, classifySSHFailure(remote, agentID, stage, err, transport)
+	}
+	if raw.T == "error" {
+		return nil, wireError(raw, transport)
+	}
+	if raw.T != "hello-ok" || raw.Re != s.nextID || raw.HasBody {
+		_ = transport.Close()
+		return nil, &Error{Code: hubwire.CodeMalformedFrame, Msg: fmt.Sprintf("hub: expected hello-ok, got %q", raw.T)}
+	}
+	if err := raw.Decode(&s.hello); err != nil {
+		_ = transport.Close()
+		return nil, err
+	}
+	if s.hello.Agent != agentID {
+		_ = transport.Close()
+		return nil, &Error{Code: hubwire.CodeIdentity, Msg: fmt.Sprintf("hub: this key is authorized as %q but you are acting as %q. Fix --as/AGENTCHUTE_AGENT_ID, or join this machine as %s: agentchute hub join <url> --as %s", s.hello.Agent, agentID, agentID, agentID)}
+	}
+	s.nextID++
+	return s, nil
+}
+
+func (s *OneShot) Hello() hubwire.HelloOK { return s.hello }
+func (s *OneShot) Warnings() []string     { return append([]string(nil), s.warnings...) }
+
+func (s *OneShot) Close() error {
+	if s == nil || s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.transport.Close()
+}
+
+func (s *OneShot) Send(req op.SendReq) (op.SendResp, error) {
+	frame := hubwire.Send{
+		RequestBase: hubwire.RequestBase{T: "send", ID: s.nextID},
+		To:          req.To,
+		Ask:         req.Ask,
+		ReplyByS:    int64(req.ReplyBy / time.Second),
+		ServeToken:  req.ServeToken,
+	}
+	raw, transmitted, err := s.do(frame, req.Content, nil, true, "send-ok")
+	if err != nil {
+		if transmitted && ErrorCode(err) == "E_CHANNEL_LOST" {
+			return op.SendResp{}, &Error{Code: "E_SEND_UNKNOWN", Msg: "hub: connection lost after the send was transmitted — DELIVERY UNKNOWN", Retriable: false, Cause: err}
+		}
+		return op.SendResp{}, err
+	}
+	var wireResp hubwire.SendOK
+	if err := raw.Decode(&wireResp); err != nil {
+		return op.SendResp{}, &Error{Code: "E_SEND_UNKNOWN", Msg: "hub: malformed terminal response after the send was transmitted — DELIVERY UNKNOWN", Cause: err}
+	}
+	return op.SendResp{Filename: wireResp.Filename, Ref: wireResp.Ref, Committed: wireResp.Committed, DurabilityNote: wireResp.DurabilityNote, OwedNote: wireResp.OwedNote}, nil
+}
+
+func (s *OneShot) Check(req op.ClaimReq, emit func(op.Event) error) (op.ClaimSummary, error) {
+	raw, _, err := s.do(hubwire.Check{RequestBase: hubwire.RequestBase{T: "check", ID: s.nextID}, Limit: req.Limit, NoArchive: req.NoArchive}, nil, emit, false, "check-ok")
+	if err != nil {
+		return op.ClaimSummary{}, err
+	}
+	var resp hubwire.CheckOK
+	if err := raw.Decode(&resp); err != nil {
+		return op.ClaimSummary{}, err
+	}
+	return op.ClaimSummary{Claimed: resp.Claimed, Redelivered: resp.Redelivered, Quarantined: resp.Quarantined, OwedExpired: resp.OwedExpired}, nil
+}
+
+func (s *OneShot) Ack(emit func(op.Event) error) (op.AckSummary, error) {
+	raw, _, err := s.do(hubwire.Ack{RequestBase: hubwire.RequestBase{T: "ack", ID: s.nextID}}, nil, emit, false, "ack-ok")
+	if err != nil {
+		return op.AckSummary{}, err
+	}
+	var resp hubwire.AckOK
+	if err := raw.Decode(&resp); err != nil {
+		return op.AckSummary{}, err
+	}
+	return op.AckSummary{Acked: resp.Acked, GateClear: resp.GateClear, BlockReasons: resp.BlockReasons}, nil
+}
+
+func (s *OneShot) Register(req op.RegisterReq) (op.RegisterResp, error) {
+	wireReq := hubwire.Register{RequestBase: hubwire.RequestBase{T: "register", ID: s.nextID}, Vendor: req.Vendor, Host: req.Host, Bio: req.Bio, WorkingRepos: req.WorkingRepos, Announce: req.Announce, Sweep: req.Sweep, ServeToken: req.ServeToken}
+	raw, _, err := s.do(wireReq, nil, nil, false, "register-ok")
+	if err != nil {
+		return op.RegisterResp{}, err
+	}
+	var resp hubwire.RegisterOK
+	if err := raw.Decode(&resp); err != nil {
+		return op.RegisterResp{}, err
+	}
+	var announce *op.AnnounceView
+	if resp.Announce != nil {
+		announce = &op.AnnounceView{Sent: resp.Announce.Sent, Total: resp.Announce.Total, Warnings: resp.Announce.Warnings}
+	}
+	return op.RegisterResp{
+		Announce: announce, Pending: resp.Pending,
+		Reg:      op.RegistrationView{AgentID: resp.Reg.AgentID, ProtocolVersion: resp.Reg.ProtocolVersion, Vendor: resp.Reg.Vendor, ControlRepo: resp.Reg.ControlRepo, WorkingRepos: resp.Reg.WorkingRepos, Host: resp.Reg.Host, LastSeen: resp.Reg.LastSeen, Body: string(raw.Body)},
+		InboxDir: resp.InboxDir, Refreshed: resp.Refreshed, ExistingFound: resp.ExistingFound, ResolvedHost: resp.ResolvedHost, Warnings: resp.Warnings,
+	}, nil
+}
+
+func (s *OneShot) Status(emit func(op.Event) error) (op.StatusResp, error) {
+	raw, _, err := s.do(hubwire.Status{RequestBase: hubwire.RequestBase{T: "status", ID: s.nextID}}, nil, emit, false, "status-ok")
+	if err != nil {
+		return op.StatusResp{}, err
+	}
+	var resp hubwire.StatusOK
+	if err := raw.Decode(&resp); err != nil {
+		return op.StatusResp{}, err
+	}
+	return op.StatusResp{Agents: resp.Agents, Truncated: resp.Truncated, Now: resp.Now}, nil
+}
+
+func (s *OneShot) Gate(req op.GateReq) (op.GateResp, error) {
+	raw, _, err := s.do(hubwire.Gate{RequestBase: hubwire.RequestBase{T: "gate", ID: s.nextID}, Phase: req.Phase, RequireConfirm: req.RequireConfirm, AckStaleReg: req.AckStaleReg}, nil, nil, false, "gate-ok")
+	if err != nil {
+		return op.GateResp{}, err
+	}
+	var resp hubwire.GateOK
+	if err := raw.Decode(&resp); err != nil {
+		return op.GateResp{}, err
+	}
+	return resp.GateResp, nil
+}
+
+func (s *OneShot) Pending(req op.PendingReq, emit func(op.Event) error) (op.PendingSummary, error) {
+	raw, _, err := s.do(hubwire.Pending{RequestBase: hubwire.RequestBase{T: "pending", ID: s.nextID}, ShowBody: req.ShowBody}, nil, emit, false, "pending-ok")
+	if err != nil {
+		return op.PendingSummary{}, err
+	}
+	var resp hubwire.PendingOK
+	if err := raw.Decode(&resp); err != nil {
+		return op.PendingSummary{}, err
+	}
+	return op.PendingSummary{Unread: resp.Unread, Owed: resp.Owed, Malformed: resp.Malformed, NeedsBoot: resp.NeedsBoot}, nil
+}
+
+func (s *OneShot) CleanOwed(req op.CleanOwedReq) (op.CleanOwedResp, error) {
+	raw, _, err := s.do(hubwire.CleanOwed{RequestBase: hubwire.RequestBase{T: "clean-owed", ID: s.nextID}, Apply: req.Apply}, nil, nil, false, "clean-owed-ok")
+	if err != nil {
+		return op.CleanOwedResp{}, err
+	}
+	var resp hubwire.CleanOwedOK
+	if err := raw.Decode(&resp); err != nil {
+		return op.CleanOwedResp{}, err
+	}
+	return op.CleanOwedResp{Agent: resp.Agent, Pruned: resp.Pruned, Applied: resp.Applied}, nil
+}
+
+func (s *OneShot) do(request any, body []byte, emit func(op.Event) error, observeFirstByte bool, expected string) (hubwire.RawFrame, bool, error) {
+	if s.closed {
+		return hubwire.RawFrame{}, false, &Error{Code: "E_CHANNEL_LOST", Msg: "hub: one-shot session is closed"}
+	}
+	encoded, err := hubwire.Encode(request, body)
+	if err != nil {
+		return hubwire.RawFrame{}, false, err
+	}
+	if err := s.setWriteDeadline(30 * time.Second); err != nil {
+		return hubwire.RawFrame{}, false, err
+	}
+	transmitted := false
+	if observeFirstByte {
+		n, writeErr := s.transport.Write(encoded[:1])
+		if n > 0 {
+			transmitted = true
+			if afterSendFirstByte != nil {
+				afterSendFirstByte()
+			}
+		}
+		if writeErr == nil && n != 1 {
+			writeErr = io.ErrShortWrite
+		}
+		if writeErr != nil {
+			return hubwire.RawFrame{}, transmitted, classifySSHFailure(s.remote, s.agentID, "operation", writeErr, s.transport)
+		}
+		encoded = encoded[1:]
+	}
+	if err := writeAll(s.transport, encoded); err != nil {
+		return hubwire.RawFrame{}, transmitted, classifySSHFailure(s.remote, s.agentID, "operation", err, s.transport)
+	}
+	if !observeFirstByte {
+		transmitted = len(encoded) > 0
+	}
+	if err := s.setReadDeadline(30 * time.Second); err != nil {
+		return hubwire.RawFrame{}, transmitted, err
+	}
+	for {
+		raw, err := s.reader.Read()
+		if err != nil {
+			return hubwire.RawFrame{}, transmitted, classifySSHFailure(s.remote, s.agentID, "operation", err, s.transport)
+		}
+		if raw.Re != s.nextID {
+			return hubwire.RawFrame{}, transmitted, &Error{Code: hubwire.CodeMalformedFrame, Msg: fmt.Sprintf("hub: response %q references request %d, want %d", raw.T, raw.Re, s.nextID)}
+		}
+		switch raw.T {
+		case "msg", "note", "owed-item", "ack-item":
+			if emit == nil {
+				return hubwire.RawFrame{}, transmitted, &Error{Code: hubwire.CodeMalformedFrame, Msg: fmt.Sprintf("hub: unexpected streamed frame %q", raw.T)}
+			}
+			event, err := eventOf(raw)
+			if err != nil {
+				return hubwire.RawFrame{}, transmitted, err
+			}
+			if err := emit(event); err != nil {
+				return hubwire.RawFrame{}, transmitted, err
+			}
+		case "error":
+			return hubwire.RawFrame{}, transmitted, wireError(raw, s.transport)
+		default:
+			if raw.T != expected {
+				return hubwire.RawFrame{}, transmitted, &Error{Code: hubwire.CodeMalformedFrame, Msg: fmt.Sprintf("hub: expected %s, got %q", expected, raw.T)}
+			}
+			s.nextID++
+			_ = s.Close()
+			return raw, transmitted, nil
+		}
+	}
+}
+
+func eventOf(raw hubwire.RawFrame) (op.Event, error) {
+	switch raw.T {
+	case "msg":
+		var frame hubwire.Message
+		if err := raw.Decode(&frame); err != nil {
+			return op.Event{}, err
+		}
+		var body []byte
+		if raw.HasBody {
+			body = raw.Body
+		}
+		return op.NewMessageEvent(op.MessageEvent{Filename: frame.Filename, Sender: frame.Sender, Stamp: frame.Stamp, Redelivered: frame.Redelivered, ReplyRequired: frame.ReplyRequired, ReplyRef: frame.ReplyRef, Body: body}), nil
+	case "note":
+		var frame hubwire.Note
+		if err := raw.Decode(&frame); err != nil {
+			return op.Event{}, err
+		}
+		return op.NewNoteEvent(frame.Level, frame.Msg), nil
+	case "owed-item":
+		var frame hubwire.OwedItem
+		if err := raw.Decode(&frame); err != nil {
+			return op.Event{}, err
+		}
+		return op.NewOwedEvent(op.OwedEvent{To: frame.To, From: frame.From, Seq: frame.Seq, Stamp: frame.Stamp, Suffix: frame.Suffix, By: frame.By, RecordedAt: frame.RecordedAt, Ref: frame.Ref}), nil
+	case "ack-item":
+		var frame hubwire.AckItem
+		if err := raw.Decode(&frame); err != nil {
+			return op.Event{}, err
+		}
+		return op.NewAckItemEvent(op.AckItemEvent{Filename: frame.Filename, ArchivePath: frame.ArchivePath}), nil
+	default:
+		return op.Event{}, fmt.Errorf("unsupported event frame %q", raw.T)
+	}
+}
+
+func wireError(raw hubwire.RawFrame, transport Transport) error {
+	var frame hubwire.Error
+	if err := raw.Decode(&frame); err != nil {
+		_ = transport.Close()
+		return err
+	}
+	_ = transport.Close()
+	return &Error{Code: frame.Code, Msg: frame.Msg, Retriable: frame.Retriable, ClaimedHeld: frame.ClaimedHeld}
+}
+
+func (s *OneShot) setReadDeadline(after time.Duration) error {
+	err := s.transport.SetReadDeadline(time.Now().Add(after))
+	if errors.Is(err, os.ErrNoDeadline) {
+		return nil
+	}
+	return err
+}
+
+func (s *OneShot) setWriteDeadline(after time.Duration) error {
+	err := s.transport.SetWriteDeadline(time.Now().Add(after))
+	if errors.Is(err, os.ErrNoDeadline) {
+		return nil
+	}
+	return err
+}
+
+func writeAll(w io.Writer, data []byte) error {
+	for len(data) > 0 {
+		n, err := w.Write(data)
+		if err != nil {
+			return err
+		}
+		if n <= 0 {
+			return io.ErrShortWrite
+		}
+		data = data[n:]
+	}
+	return nil
+}
+
+func isTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}

--- a/internal/hubclient/session_test.go
+++ b/internal/hubclient/session_test.go
@@ -1,0 +1,199 @@
+package hubclient_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/cli"
+	"github.com/agentchute/agentchute/internal/hubclient"
+	"github.com/agentchute/agentchute/internal/loop"
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+type harness struct {
+	t      *testing.T
+	pool   string
+	remote *loop.RemoteConfig
+	poolID string
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	pool := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pool, "AGENTCHUTE.md"), []byte("# spec\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	state := filepath.Join(pool, ".agentchute", "loop", "state")
+	if err := os.MkdirAll(state, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	poolID := "0123456789ab"
+	if err := os.WriteFile(filepath.Join(state, "pool.id"), []byte(poolID+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	remote, err := loop.ParseRemoteURL("ssh://hub.example/remote/pool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &harness{t: t, pool: pool, remote: remote, poolID: poolID}
+}
+
+func (h *harness) session(agent string) *hubclient.OneShot {
+	h.t.Helper()
+	client, server := net.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	h.t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- cli.ServeHubSession(ctx, server, cli.HubSessionConfig{Agent: agent, Pool: h.pool, PoolID: h.poolID, HubBin: "test"})
+	}()
+	h.t.Cleanup(func() {
+		_ = client.Close()
+		select {
+		case err := <-done:
+			if err != nil {
+				h.t.Errorf("hub session: %v", err)
+			}
+		case <-time.After(time.Second):
+			h.t.Error("hub session did not exit")
+		}
+	})
+	s, err := hubclient.OpenOneShotTransport(client, h.remote, agent, "test-client")
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	return s
+}
+
+func (h *harness) register(agent, vendor string) op.RegisterResp {
+	h.t.Helper()
+	resp, err := h.session(agent).Register(op.RegisterReq{Vendor: &vendor, Host: "client-host"})
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	return resp
+}
+
+func TestOneShotRegisterStatusSendCheckAck(t *testing.T) {
+	h := newHarness(t)
+	reg := h.register("codex", "openai")
+	if reg.Reg.Vendor != "openai" || reg.Reg.Host != "client-host" {
+		t.Fatalf("register response = %#v", reg)
+	}
+	h.register("claude-code", "anthropic")
+
+	status, err := h.session("codex").Status(func(op.Event) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(status.Agents) != 2 || status.Now.IsZero() {
+		t.Fatalf("status = %#v", status)
+	}
+
+	sent, err := h.session("codex").Send(op.SendReq{To: "claude-code", Content: loop.ComposeMessage("codex", "", "body")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sent.Committed || sent.Filename == "" {
+		t.Fatalf("send = %#v", sent)
+	}
+
+	var pendingMessages []op.MessageEvent
+	pending, err := h.session("claude-code").Pending(op.PendingReq{ShowBody: true}, func(ev op.Event) error {
+		if ev.Message != nil {
+			pendingMessages = append(pendingMessages, *ev.Message)
+		}
+		return nil
+	})
+	if err != nil || pending.Unread != 1 || len(pendingMessages) != 1 || len(pendingMessages[0].Body) == 0 {
+		t.Fatalf("pending/messages = %#v/%#v, err=%v", pending, pendingMessages, err)
+	}
+	gate, err := h.session("claude-code").Gate(op.GateReq{Phase: op.GatePhaseFinish})
+	if err != nil || !gate.Blocked || gate.UnreadCount != 1 {
+		t.Fatalf("gate = %#v, err=%v", gate, err)
+	}
+
+	var messages []op.MessageEvent
+	claimed, err := h.session("claude-code").Check(op.ClaimReq{}, func(ev op.Event) error {
+		if ev.Message != nil {
+			messages = append(messages, *ev.Message)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claimed.Claimed != 1 || len(messages) != 1 || string(messages[0].Body) == "" {
+		t.Fatalf("claim/messages = %#v/%#v", claimed, messages)
+	}
+
+	acked, err := h.session("claude-code").Ack(func(op.Event) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acked.Acked != 1 {
+		t.Fatalf("ack = %#v", acked)
+	}
+
+	cleaned, err := h.session("codex").CleanOwed(op.CleanOwedReq{})
+	if err != nil || cleaned.Agent != "codex" || cleaned.Applied || cleaned.Pruned == nil {
+		t.Fatalf("clean-owed = %#v, err=%v", cleaned, err)
+	}
+}
+
+func TestOneShotRegisterResolvesVendorAndAnnouncesHubSide(t *testing.T) {
+	h := newHarness(t)
+	h.register("codex-tiny", "openai")
+	h.register("grok", "xai")
+
+	resp, err := h.session("codex-tiny").Register(op.RegisterReq{Host: "new-host", Announce: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Reg.Vendor != "openai" {
+		t.Fatalf("resolved vendor = %q, want openai", resp.Reg.Vendor)
+	}
+	if resp.Announce == nil || resp.Announce.Sent != 1 || resp.Announce.Total != 1 {
+		t.Fatalf("announce = %#v", resp.Announce)
+	}
+	entries, err := os.ReadDir(filepath.Join(h.pool, ".agentchute", "loop", "inbox", "grok"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".md" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("hub-side grok inbox count = %d, want 1", count)
+	}
+}
+
+func TestOneShotBootRegisterSweepsHubSide(t *testing.T) {
+	h := newHarness(t)
+	h.register("codex", "openai")
+	h.register("stale-peer", "test")
+	stalePath := filepath.Join(h.pool, ".agentchute", "loop", "agents", "stale-peer.md")
+	reg, err := loop.ReadRegistration(stalePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reg.LastSeen = time.Now().UTC().Add(-2 * loop.DefaultStaleAfter)
+	if err := loop.WriteRegistration(stalePath, reg); err != nil {
+		t.Fatal(err)
+	}
+	vendor := "openai"
+	if _, err := h.session("codex").Register(op.RegisterReq{Vendor: &vendor, Host: "client-host", Sweep: true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Fatalf("stale hub registration still exists: %v", err)
+	}
+}

--- a/internal/hubclient/ssh.go
+++ b/internal/hubclient/ssh.go
@@ -1,0 +1,265 @@
+package hubclient
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+const controlPathTokenWidth = 64
+
+type SSHBuildOptions struct {
+	Remote        *loop.RemoteConfig
+	AgentID       string
+	Channel       bool
+	TempRoots     []string
+	EnsureOwned   func(string) error
+	PreferredRoot string
+	UserID        string
+}
+
+type SSHInvocation struct {
+	Args     []string
+	Warnings []string
+}
+
+func BuildSSHInvocation(opts SSHBuildOptions) (SSHInvocation, error) {
+	if opts.Remote == nil {
+		return SSHInvocation{}, fmt.Errorf("build ssh invocation: missing remote config")
+	}
+	if err := loop.ValidateAgentID(opts.AgentID); err != nil {
+		return SSHInvocation{}, fmt.Errorf("build ssh invocation: %w", err)
+	}
+	key := filepath.Join(opts.Remote.HubDir, "keys", opts.AgentID+"_ed25519")
+	args := []string{
+		"-T",
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=5",
+	}
+	if opts.Channel {
+		args = append(args, "-o", "ServerAliveInterval=5", "-o", "ServerAliveCountMax=2")
+	} else {
+		args = append(args, "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=2")
+	}
+	args = append(args,
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "UserKnownHostsFile="+filepath.Join(opts.Remote.HubDir, "known_hosts"),
+		"-o", "IdentitiesOnly=yes", "-i", key,
+		"-o", "ClearAllForwardings=yes",
+	)
+	var warnings []string
+	if opts.Channel {
+		args = append(args, "-o", "ControlMaster=no", "-o", "ControlPath=none")
+	} else {
+		muxDir, attempted, err := selectMuxDir(opts)
+		if err != nil {
+			args = append(args, "-o", "ControlMaster=no", "-o", "ControlPath=none")
+			warnings = append(warnings, fmt.Sprintf("ssh multiplexing disabled: no owned ControlPath directory fits the 100-byte socket budget (tried %s)", strings.Join(attempted, ", ")))
+		} else {
+			args = append(args, "-o", "ControlMaster=auto", "-o", "ControlPath="+filepath.Join(muxDir, "%C"), "-o", "ControlPersist=60s")
+		}
+	}
+	args = append(args, "-o", "LogLevel=ERROR")
+	if opts.Remote.Port != 22 {
+		args = append(args, "-p", strconv.Itoa(opts.Remote.Port))
+	}
+	args = append(args, opts.Remote.Destination(), "agentchute-hub")
+	return SSHInvocation{Args: args, Warnings: warnings}, nil
+}
+
+func selectMuxDir(opts SSHBuildOptions) (string, []string, error) {
+	ensure := opts.EnsureOwned
+	if ensure == nil {
+		ensure = loop.EnsureOwnedSocketDir
+	}
+	preferred := filepath.Join(opts.Remote.HubDir, "mux")
+	if opts.PreferredRoot != "" {
+		preferred = filepath.Join(opts.PreferredRoot, "mux")
+	}
+	attempted := []string{preferred}
+	if controlPathFits(preferred) {
+		if err := loop.EnsurePrivateDir(preferred); err == nil {
+			return preferred, attempted, nil
+		}
+	}
+	roots := opts.TempRoots
+	if roots == nil {
+		roots = []string{os.TempDir(), "/tmp"}
+	}
+	uid := opts.UserID
+	if uid == "" {
+		uid = currentUserID()
+	}
+	seen := map[string]bool{}
+	for _, root := range roots {
+		candidate := filepath.Join(root, "agentchute-hub-"+uid, opts.Remote.HubID)
+		if seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+		attempted = append(attempted, candidate)
+		if !controlPathFits(candidate) {
+			continue
+		}
+		if err := ensure(candidate); err != nil {
+			continue
+		}
+		return candidate, attempted, nil
+	}
+	return "", attempted, errors.New("no usable mux directory")
+}
+
+func controlPathFits(muxDir string) bool {
+	return len(muxDir)+1+controlPathTokenWidth < 100
+}
+
+func currentUserID() string {
+	u, err := user.Current()
+	if err == nil && u.Uid != "" {
+		return u.Uid
+	}
+	return "unknown"
+}
+
+type Transport interface {
+	io.ReadWriteCloser
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
+}
+
+type processTransport struct {
+	cmd       *exec.Cmd
+	stdin     *os.File
+	stdout    *os.File
+	stderr    bytes.Buffer
+	cancel    context.CancelFunc
+	waitCh    chan error
+	closeOnce sync.Once
+	closeDone chan struct{}
+	err       error
+}
+
+func startSSH(ctx context.Context, invocation SSHInvocation) (Transport, error) {
+	childCtx, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(childCtx, "ssh", invocation.Args...)
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	stdin, ok := stdinPipe.(*os.File)
+	if !ok {
+		cancel()
+		return nil, fmt.Errorf("ssh stdin is not an os.File")
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	stdout, ok := stdoutPipe.(*os.File)
+	if !ok {
+		cancel()
+		return nil, fmt.Errorf("ssh stdout is not an os.File")
+	}
+	p := &processTransport{cmd: cmd, stdin: stdin, stdout: stdout, cancel: cancel, waitCh: make(chan error, 1), closeDone: make(chan struct{})}
+	cmd.Stderr = &p.stderr
+	if err := cmd.Start(); err != nil {
+		cancel()
+		if errors.Is(err, exec.ErrNotFound) {
+			return nil, &Error{Code: "E_NO_SSH", Msg: "hub: the `ssh` binary was not found on this machine. Install the OpenSSH client (macOS: preinstalled — check PATH; Debian/Ubuntu: apt install openssh-client), then retry."}
+		}
+		return nil, err
+	}
+	go func() { p.waitCh <- cmd.Wait() }()
+	return p, nil
+}
+
+func (p *processTransport) Read(b []byte) (int, error)  { return p.stdout.Read(b) }
+func (p *processTransport) Write(b []byte) (int, error) { return p.stdin.Write(b) }
+func (p *processTransport) SetReadDeadline(t time.Time) error {
+	return p.stdout.SetReadDeadline(t)
+}
+func (p *processTransport) SetWriteDeadline(t time.Time) error { return p.stdin.SetWriteDeadline(t) }
+func (p *processTransport) Close() error {
+	p.closeOnce.Do(func() {
+		defer close(p.closeDone)
+		_ = p.stdin.Close()
+		select {
+		case p.err = <-p.waitCh:
+		case <-time.After(time.Second):
+			p.cancel()
+			p.err = <-p.waitCh
+		}
+		p.cancel()
+	})
+	<-p.closeDone
+	return p.err
+}
+func (p *processTransport) diagnostics() (string, error) {
+	return p.stderr.String(), p.err
+}
+
+func classifySSHFailure(remote *loop.RemoteConfig, agentID, stage string, cause error, transport Transport) error {
+	stderr := ""
+	waitErr := error(nil)
+	if p, ok := transport.(*processTransport); ok {
+		_ = p.Close()
+		stderr, waitErr = p.diagnostics()
+	} else {
+		_ = transport.Close()
+	}
+	lower := strings.ToLower(stderr)
+	if strings.Contains(lower, "remote host identification has changed") || strings.Contains(lower, "host key verification failed") {
+		return &Error{Code: "E_HOSTKEY_CHANGED", Msg: fmt.Sprintf("hub: HOST KEY CHANGED for %s — refusing to connect. If the hub was reinstalled, confirm with its operator, then run: agentchute hub join --reset-hostkey. If not, treat this as a possible interception.", remote.Host)}
+	}
+	if strings.Contains(lower, "permission denied") {
+		msg := fmt.Sprintf("hub: hub refused this key for %s. Either it was never authorized or it was revoked.", remote.Destination())
+		if hubCfg, err := ReadHubConfig(remote.HubID); err == nil {
+			if pubkey, err := readActivePublicKey(remote, agentID); err == nil {
+				msg += fmt.Sprintf(" Run this ON THE HUB, then retry here:\n  agentchute hub authorize --agent %s --pool %s --key %q", agentID, hubCfg.Pool, pubkey)
+			}
+		}
+		return &Error{Code: "E_UNAUTHORIZED", Msg: msg}
+	}
+	var exitErr *exec.ExitError
+	if errors.As(waitErr, &exitErr) && exitErr.ExitCode() == 127 {
+		return &Error{Code: "E_HUB_NO_BINARY", Msg: "hub: connected, but the hub could not run agentchute (remote exit 127 — command not found at /usr/local/bin/agentchute). Reinstall agentchute on the hub, or re-authorize this key so its line points at the current binary path."}
+	}
+	if stage == "hello-timeout" {
+		return &Error{Code: "E_HELLO_TIMEOUT", Msg: "hub: connected but no protocol answer in 10s. The hub-side agentchute may be hung or broken; on the hub run: agentchute doctor"}
+	}
+	if stage == "connect" {
+		return &Error{Code: "E_CONNECT", Msg: fmt.Sprintf("hub: cannot reach %s:%d (connect failed after 5s). Check network/VPN/tailnet, then retry; `agentchute doctor` runs this same probe. (If this machine should no longer be joined to this hub, delete .agentchute-control-repo.)", remote.Host, remote.Port), Retriable: true, Cause: cause}
+	}
+	return &Error{Code: "E_CHANNEL_LOST", Msg: "hub: channel to the hub was lost", Retriable: true, Cause: cause}
+}
+
+func readActivePublicKey(remote *loop.RemoteConfig, agentID string) (string, error) {
+	active := filepath.Join(remote.HubDir, "keys", agentID+"_ed25519")
+	target, err := filepath.EvalSymlinks(active)
+	if err != nil {
+		return "", err
+	}
+	data, err := loop.ReadFileLimit(target+".pub", 64<<10)
+	if err != nil {
+		return "", err
+	}
+	pubkey := strings.TrimSpace(string(data))
+	if pubkey == "" {
+		return "", fmt.Errorf("active public key is empty")
+	}
+	return pubkey, nil
+}

--- a/internal/hubclient/ssh_test.go
+++ b/internal/hubclient/ssh_test.go
@@ -1,0 +1,178 @@
+package hubclient
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+func TestBuildSSHInvocationGolden(t *testing.T) {
+	hubDir, err := os.MkdirTemp("/tmp", "h")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(hubDir) })
+	remote := &loop.RemoteConfig{User: "alex", Host: "hub.example", Port: 2222, HubID: "0123456789ab", HubDir: hubDir}
+	got, err := BuildSSHInvocation(SSHBuildOptions{Remote: remote, AgentID: "codex", EnsureOwned: func(string) error { return nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"-T",
+		"-o", "BatchMode=yes",
+		"-o", "ConnectTimeout=5",
+		"-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=2",
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "UserKnownHostsFile=" + filepath.Join(hubDir, "known_hosts"),
+		"-o", "IdentitiesOnly=yes", "-i", filepath.Join(hubDir, "keys", "codex_ed25519"),
+		"-o", "ClearAllForwardings=yes",
+		"-o", "ControlMaster=auto", "-o", "ControlPath=" + filepath.Join(hubDir, "mux", "%C"), "-o", "ControlPersist=60s",
+		"-o", "LogLevel=ERROR",
+		"-p", "2222", "alex@hub.example", "agentchute-hub",
+	}
+	if !reflect.DeepEqual(got.Args, want) {
+		t.Fatalf("argv =\n%q\nwant\n%q", got.Args, want)
+	}
+	if len(got.Warnings) != 0 {
+		t.Fatalf("warnings = %v", got.Warnings)
+	}
+
+	channel, err := BuildSSHInvocation(SSHBuildOptions{Remote: remote, AgentID: "codex", Channel: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(channel.Args, " ")
+	for _, want := range []string{"ServerAliveInterval=5", "ControlMaster=no", "ControlPath=none"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("channel argv missing %q: %v", want, channel.Args)
+		}
+	}
+	if strings.Contains(joined, "ControlPersist") {
+		t.Fatalf("channel argv contains ControlPersist: %v", channel.Args)
+	}
+}
+
+func TestBuildSSHInvocationControlPathFallbacks(t *testing.T) {
+	remote := &loop.RemoteConfig{Host: "hub", Port: 22, HubID: "0123456789ab", HubDir: "/" + strings.Repeat("deep/", 30)}
+	shortRoot := "/tmp"
+	got, err := BuildSSHInvocation(SSHBuildOptions{
+		Remote: remote, AgentID: "codex", TempRoots: []string{shortRoot},
+		EnsureOwned: func(string) error { return nil }, UserID: "0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantPrefix := "ControlPath=" + filepath.Join(shortRoot, "agentchute-hub-0", remote.HubID, "%C")
+	if !strings.Contains(strings.Join(got.Args, " "), wantPrefix) {
+		t.Fatalf("fallback argv = %v, want %s", got.Args, wantPrefix)
+	}
+
+	disabled, err := BuildSSHInvocation(SSHBuildOptions{
+		Remote: remote, AgentID: "codex", TempRoots: []string{"/" + strings.Repeat("too-long/", 30)},
+		EnsureOwned: func(string) error { return errors.New("unusable") }, UserID: "0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(disabled.Args, " ")
+	if !strings.Contains(joined, "ControlMaster=no") || !strings.Contains(joined, "ControlPath=none") {
+		t.Fatalf("disabled argv = %v", disabled.Args)
+	}
+	if len(disabled.Warnings) != 1 || !strings.Contains(disabled.Warnings[0], "tried") {
+		t.Fatalf("disabled warnings = %v, want exactly one", disabled.Warnings)
+	}
+}
+
+func TestClassifySSHFailureCodes(t *testing.T) {
+	exit127 := exec.Command("sh", "-c", "exit 127").Run()
+	remote := &loop.RemoteConfig{User: "alex", Host: "hub.example", Port: 22}
+	tests := []struct {
+		name    string
+		stage   string
+		stderr  string
+		waitErr error
+		want    string
+	}{
+		{name: "changed host key", stage: "connect", stderr: "REMOTE HOST IDENTIFICATION HAS CHANGED", want: "E_HOSTKEY_CHANGED"},
+		{name: "authentication refused", stage: "connect", stderr: "Permission denied (publickey).", want: "E_UNAUTHORIZED"},
+		{name: "remote binary absent", stage: "connect", waitErr: exit127, want: "E_HUB_NO_BINARY"},
+		{name: "hello timeout", stage: "hello-timeout", want: "E_HELLO_TIMEOUT"},
+		{name: "connect failed", stage: "connect", want: "E_CONNECT"},
+		{name: "established channel lost", stage: "operation", want: "E_CHANNEL_LOST"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdin, err := os.CreateTemp(t.TempDir(), "ssh-stdin")
+			if err != nil {
+				t.Fatal(err)
+			}
+			waitCh := make(chan error, 1)
+			waitCh <- tt.waitErr
+			transport := &processTransport{
+				stdin: stdin, stderr: *bytes.NewBufferString(tt.stderr),
+				cancel: func() {}, waitCh: waitCh, closeDone: make(chan struct{}),
+			}
+			got := classifySSHFailure(remote, "codex", tt.stage, errors.New("transport failed"), transport)
+			if code := ErrorCode(got); code != tt.want {
+				t.Fatalf("code = %q, want %q (error %v)", code, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestStartSSHMissingBinary(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	_, err := startSSH(context.Background(), SSHInvocation{})
+	if code := ErrorCode(err); code != "E_NO_SSH" {
+		t.Fatalf("code = %q, want E_NO_SSH (error %v)", code, err)
+	}
+}
+
+func TestUnauthorizedIncludesReadyToPasteAuthorization(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	remote, err := loop.ParseRemoteURL("ssh://alex@hub.example/remote/pool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteHubConfig(remote.HubID, &HubConfig{Pool: "/remote/pool", Pool12: "0123456789ab"}); err != nil {
+		t.Fatal(err)
+	}
+	keysDir := filepath.Join(remote.HubDir, "keys")
+	if err := os.MkdirAll(keysDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(keysDir, "codex_ed25519.v1")
+	if err := os.WriteFile(target, []byte("private fixture\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pubkey := "ssh-ed25519 AAAAC3NzaFixture agentchute:codex"
+	if err := os.WriteFile(target+".pub", []byte(pubkey+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Base(target), filepath.Join(keysDir, "codex_ed25519")); err != nil {
+		t.Fatal(err)
+	}
+	stdin, err := os.CreateTemp(t.TempDir(), "ssh-stdin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitCh := make(chan error, 1)
+	waitCh <- nil
+	transport := &processTransport{
+		stdin: stdin, stderr: *bytes.NewBufferString("Permission denied (publickey)."),
+		cancel: func() {}, waitCh: waitCh, closeDone: make(chan struct{}),
+	}
+	got := classifySSHFailure(remote, "codex", "connect", errors.New("transport failed"), transport)
+	want := "Run this ON THE HUB, then retry here:\n  agentchute hub authorize --agent codex --pool /remote/pool --key \"" + pubkey + "\""
+	if ErrorCode(got) != "E_UNAUTHORIZED" || !strings.Contains(got.Error(), want) {
+		t.Fatalf("unauthorized error = %q, want complete authorization command %q", got, want)
+	}
+}

--- a/internal/loop/config.go
+++ b/internal/loop/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	ControlRepo string // absolute repo root containing AGENTCHUTE.md
 	LoopDir     string // absolute .<vendor>/loop directory
 	Vendor      string // vendor namespace, without leading dot
+	Remote      *RemoteConfig
 
 	// ControlRepoOrigin records which step of the discovery cascade resolved
 	// ControlRepo, for visibility in `status` and `register` output. Values:
@@ -72,9 +73,24 @@ type DiscoverOpts struct {
 // First hit wins. The resulting Config records which step won via
 // ControlRepoOrigin for visibility.
 func Discover(opts DiscoverOpts) (*Config, error) {
-	controlRepo, origin, shadowed, err := discoverControlRepo(opts)
+	controlRepo, origin, shadowed, remote, err := discoverControlRepo(opts)
 	if err != nil {
 		return nil, err
+	}
+	if remote != nil {
+		vendor, err := vendorFromLoopDir(remote.ShadowLoopDir)
+		if err != nil {
+			return nil, err
+		}
+		return &Config{
+			ControlRepo:       controlRepo,
+			LoopDir:           remote.ShadowLoopDir,
+			Vendor:            vendor,
+			Remote:            remote,
+			ControlRepoOrigin: origin,
+			LoopDirOrigin:     "remote",
+			ShadowedPointers:  shadowed,
+		}, nil
 	}
 
 	loopDir, loopOrigin, err := discoverLoopDir(controlRepo, opts)
@@ -205,23 +221,37 @@ func (c *Config) EnsureRunnerSocketDir(socketPath string) error {
 	return ensurePrivateDir(dir)
 }
 
-func discoverControlRepo(opts DiscoverOpts) (controlRepo, origin string, shadowed []string, err error) {
+// EnsureOwnedSocketDir creates a private per-user directory and verifies its
+// ownership before it is used for Unix-domain sockets in a shared temp root.
+func EnsureOwnedSocketDir(dir string) error {
+	return ensureOwnedRunnerSocketDir(dir)
+}
+
+func discoverControlRepo(opts DiscoverOpts) (controlRepo, origin string, shadowed []string, remote *RemoteConfig, err error) {
 	// 1. Explicit --control-repo flag wins.
 	if strings.TrimSpace(opts.ControlRepoFlag) != "" {
+		if isRemoteLocator(opts.ControlRepoFlag) {
+			repo, remote, err := discoverRemoteControlRepo(opts.ControlRepoFlag, opts)
+			return repo, "flag", nil, remote, err
+		}
 		repo, err := validateExplicitControlRepo(opts.ControlRepoFlag)
 		if err != nil {
-			return "", "", nil, err
+			return "", "", nil, nil, err
 		}
-		return repo, "flag", nil, nil
+		return repo, "flag", nil, nil, nil
 	}
 
 	// 2. AGENTCHUTE_CONTROL_REPO env var.
 	if strings.TrimSpace(opts.EnvControlRepo) != "" {
+		if isRemoteLocator(opts.EnvControlRepo) {
+			repo, remote, err := discoverRemoteControlRepo(opts.EnvControlRepo, opts)
+			return repo, "env", nil, remote, err
+		}
 		repo, err := validateExplicitControlRepo(opts.EnvControlRepo)
 		if err != nil {
-			return "", "", nil, err
+			return "", "", nil, nil, err
 		}
-		return repo, "env", nil, nil
+		return repo, "env", nil, nil, nil
 	}
 
 	// 3. .agentchute-control-repo pointer file (cwd or ancestor).
@@ -230,18 +260,22 @@ func discoverControlRepo(opts DiscoverOpts) (controlRepo, origin string, shadowe
 		if perr != nil {
 			// Pointer discovery errors (malformed pointer, broken target) are
 			// hard errors — the operator put a pointer there on purpose.
-			return "", "", nil, fmt.Errorf("pointer file discovery: %w", perr)
+			return "", "", nil, nil, fmt.Errorf("pointer file discovery: %w", perr)
 		}
 		if ptr != nil {
+			if isRemoteLocator(ptr.ResolvedTarget) {
+				repo, remote, err := discoverRemoteControlRepo(ptr.ResolvedTarget, opts)
+				return repo, "pointer:" + ptr.PointerFilePath, ptr.Shadowed, remote, err
+			}
 			if !fileExists(filepath.Join(ptr.ResolvedTarget, specFileName)) {
-				return "", "", nil, fmt.Errorf("pointer %s -> %q: target does not contain %s",
+				return "", "", nil, nil, fmt.Errorf("pointer %s -> %q: target does not contain %s",
 					ptr.PointerFilePath, ptr.ResolvedTarget, specFileName)
 			}
 			if !hasFixedLoopDir(ptr.ResolvedTarget) {
-				return "", "", nil, fmt.Errorf("pointer %s -> %q: target has no %s/%s directory",
+				return "", "", nil, nil, fmt.Errorf("pointer %s -> %q: target has no %s/%s directory",
 					ptr.PointerFilePath, ptr.ResolvedTarget, fixedDotDir, loopDirName)
 			}
-			return ptr.ResolvedTarget, "pointer:" + ptr.PointerFilePath, ptr.Shadowed, nil
+			return ptr.ResolvedTarget, "pointer:" + ptr.PointerFilePath, ptr.Shadowed, nil, nil
 		}
 	}
 
@@ -249,13 +283,49 @@ func discoverControlRepo(opts DiscoverOpts) (controlRepo, origin string, shadowe
 	if opts.Cwd != "" {
 		if repo, err := findControlRepo(opts.Cwd); err == nil {
 			if hasFixedLoopDir(repo) {
-				return repo, "cwd", nil, nil
+				return repo, "cwd", nil, nil, nil
 			}
 		}
 	}
 
-	return "", "", nil, fmt.Errorf("%w: no --control-repo flag, no AGENTCHUTE_CONTROL_REPO env, no %s pointer in cwd ancestors, and no AGENTCHUTE.md + %s/%s dir found walking up from %q",
+	return "", "", nil, nil, fmt.Errorf("%w: no --control-repo flag, no AGENTCHUTE_CONTROL_REPO env, no %s pointer in cwd ancestors, and no AGENTCHUTE.md + %s/%s dir found walking up from %q",
 		ErrNoControlRepo, PointerFileName, fixedDotDir, loopDirName, opts.Cwd)
+}
+
+func discoverRemoteControlRepo(raw string, opts DiscoverOpts) (string, *RemoteConfig, error) {
+	if strings.TrimSpace(opts.LoopDirFlag) != "" || strings.TrimSpace(opts.EnvLoopDir) != "" {
+		return "", nil, fmt.Errorf("ssh control repo cannot be combined with --loop-dir or AGENTCHUTE_LOOP_DIR")
+	}
+	remote, err := ParseRemoteURL(raw)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := RequireRemoteJoin(remote); err != nil {
+		return "", nil, err
+	}
+	localRepo, err := remoteLocalControlRepo(opts.Cwd)
+	if err != nil {
+		return "", nil, err
+	}
+	return localRepo, remote, nil
+}
+
+func remoteLocalControlRepo(cwd string) (string, error) {
+	if strings.TrimSpace(cwd) == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolve cwd for remote control repo: %w", err)
+		}
+	}
+	if repo, err := findControlRepo(cwd); err == nil {
+		return repo, nil
+	}
+	abs, err := filepath.Abs(cwd)
+	if err != nil {
+		return "", fmt.Errorf("resolve cwd for remote control repo: %w", err)
+	}
+	return abs, nil
 }
 
 // validateExplicitControlRepo checks that a flag- or env-provided control

--- a/internal/loop/pointer.go
+++ b/internal/loop/pointer.go
@@ -115,6 +115,9 @@ func ResolvePointerTarget(pointerDir, raw string) (string, error) {
 	if raw == "" {
 		return "", fmt.Errorf("pointer target is empty")
 	}
+	if isRemoteLocator(raw) {
+		return raw, nil
+	}
 	if !filepath.IsAbs(raw) {
 		raw = filepath.Join(pointerDir, raw)
 	}

--- a/internal/loop/remote.go
+++ b/internal/loop/remote.go
@@ -1,0 +1,180 @@
+package loop
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	remoteNamePattern  = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+	ErrRemoteNotJoined = errors.New("remote hub is not joined on this machine")
+)
+
+func isRemoteLocator(raw string) bool {
+	return strings.HasPrefix(strings.TrimSpace(raw), "ssh://")
+}
+
+// RemoteConfig is the pure-local derivation of an ssh:// control-repo locator.
+// Pool and Pool12 come from hello-ok via config.json, never from URL text.
+type RemoteConfig struct {
+	URL           string
+	User          string
+	Host          string
+	Port          int
+	PoolPath      string
+	HubID         string
+	HubDir        string
+	ConfigPath    string
+	ShadowLoopDir string
+}
+
+func (r *RemoteConfig) Destination() string {
+	if r == nil {
+		return ""
+	}
+	if r.User == "" {
+		return r.Host
+	}
+	return r.User + "@" + r.Host
+}
+
+// ParseRemoteURL validates and canonicalizes the ssh locator without dialing.
+func ParseRemoteURL(raw string) (*RemoteConfig, error) {
+	raw = strings.TrimSpace(raw)
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ssh control repo %q: %w", raw, err)
+	}
+	if u.Scheme != "ssh" || u.Opaque != "" || u.RawQuery != "" || u.Fragment != "" || u.Host == "" {
+		return nil, fmt.Errorf("invalid ssh control repo %q: expected ssh://[user@]host[:port]/absolute/path", raw)
+	}
+	user := ""
+	if u.User != nil {
+		if _, ok := u.User.Password(); ok {
+			return nil, fmt.Errorf("invalid ssh control repo %q: passwords are not allowed", raw)
+		}
+		user = u.User.Username()
+		if u.User.String() != user || !validRemoteName(user) {
+			return nil, fmt.Errorf("invalid ssh control repo %q: user must match [A-Za-z0-9._-]+ and not start with '-'", raw)
+		}
+	}
+	host := u.Hostname()
+	if !validRemoteName(host) {
+		return nil, fmt.Errorf("invalid ssh control repo %q: host must match [A-Za-z0-9._-]+ and not start with '-'", raw)
+	}
+	host = strings.ToLower(host)
+	port := 22
+	if p := u.Port(); p != "" {
+		port, err = strconv.Atoi(p)
+		if err != nil || port < 1 || port > 65535 {
+			return nil, fmt.Errorf("invalid ssh control repo %q: port must be 1-65535", raw)
+		}
+	} else if strings.HasSuffix(u.Host, ":") {
+		return nil, fmt.Errorf("invalid ssh control repo %q: empty port", raw)
+	}
+	if u.Path == "" || !strings.HasPrefix(u.Path, "/") {
+		return nil, fmt.Errorf("invalid ssh control repo %q: pool path must be absolute", raw)
+	}
+	canonicalPath := u.EscapedPath()
+	if canonicalPath == "" {
+		canonicalPath = "/"
+	}
+	if canonicalPath != "/" {
+		canonicalPath = strings.TrimRight(canonicalPath, "/")
+	}
+	authority := host
+	if user != "" {
+		authority = user + "@" + authority
+	}
+	if port != 22 {
+		authority += ":" + strconv.Itoa(port)
+	}
+	canonical := "ssh://" + authority + canonicalPath
+	sum := sha256.Sum256([]byte(canonical))
+	hubID := hex.EncodeToString(sum[:])[:12]
+	hubDir, err := HubDir(hubID)
+	if err != nil {
+		return nil, err
+	}
+	return &RemoteConfig{
+		URL: canonical, User: user, Host: host, Port: port, PoolPath: u.Path,
+		HubID: hubID, HubDir: hubDir, ConfigPath: filepath.Join(hubDir, "config.json"),
+		ShadowLoopDir: filepath.Join(hubDir, fixedDotDir, loopDirName),
+	}, nil
+}
+
+func validRemoteName(value string) bool {
+	return value != "" && !strings.HasPrefix(value, "-") && remoteNamePattern.MatchString(value)
+}
+
+func HubDir(hubID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for hub state: %w", err)
+	}
+	if strings.TrimSpace(home) == "" {
+		return "", fmt.Errorf("resolve home directory for hub state: empty home")
+	}
+	return filepath.Join(home, ".agentchute", "hub", hubID), nil
+}
+
+func HubConfigPath(hubID string) (string, error) {
+	dir, err := HubDir(hubID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "config.json"), nil
+}
+
+func ShadowLoopDir(hubID string) (string, error) {
+	dir, err := HubDir(hubID)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fixedDotDir, loopDirName), nil
+}
+
+type RemoteNotJoinedError struct {
+	URL        string
+	ConfigPath string
+}
+
+func (e *RemoteNotJoinedError) Error() string {
+	configPath := e.ConfigPath
+	if home, err := os.UserHomeDir(); err == nil {
+		if rel, err := filepath.Rel(home, e.ConfigPath); err == nil && rel != "." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			configPath = filepath.Join("~", rel)
+		}
+	}
+	return fmt.Sprintf("hub: .agentchute-control-repo points at %s, but this machine never joined that hub (no %s). If this machine IS the hub, a joined machine probably committed its pointer file — delete .agentchute-control-repo here (and `git rm` it if tracked). If this machine should be joined, run: agentchute hub join <that-url> --as <id>", e.URL, configPath)
+}
+
+func (e *RemoteNotJoinedError) Unwrap() error { return ErrRemoteNotJoined }
+
+func IsRemoteNotJoined(err error) bool { return errors.Is(err, ErrRemoteNotJoined) }
+
+// RequireRemoteJoin is a stat-only check. internal/loop never parses config.json.
+func RequireRemoteJoin(remote *RemoteConfig) error {
+	if remote == nil {
+		return nil
+	}
+	info, err := os.Stat(remote.ConfigPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &RemoteNotJoinedError{URL: remote.URL, ConfigPath: remote.ConfigPath}
+		}
+		return fmt.Errorf("stat hub config %s: %w", remote.ConfigPath, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("hub config %s is not a regular file", remote.ConfigPath)
+	}
+	return nil
+}

--- a/internal/loop/remote_test.go
+++ b/internal/loop/remote_test.go
@@ -1,0 +1,152 @@
+package loop
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseRemoteURLGrammarAndCanonicalForm(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{"ssh://Alex@HUB.Example:22/absolute/pool/", "ssh://Alex@hub.example/absolute/pool"},
+		{"ssh://host-alias:2222/pool", "ssh://host-alias:2222/pool"},
+		{"ssh://host/", "ssh://host/"},
+	}
+	for _, tt := range tests {
+		got, err := ParseRemoteURL(tt.raw)
+		if err != nil {
+			t.Fatalf("ParseRemoteURL(%q): %v", tt.raw, err)
+		}
+		if got.URL != tt.want {
+			t.Errorf("ParseRemoteURL(%q).URL = %q, want %q", tt.raw, got.URL, tt.want)
+		}
+		if len(got.HubID) != 12 {
+			t.Errorf("ParseRemoteURL(%q).HubID = %q", tt.raw, got.HubID)
+		}
+	}
+}
+
+func TestParseRemoteURLRejectsInvalidGrammar(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	for _, raw := range []string{
+		"http://host/pool",
+		"ssh://host",
+		"ssh://-host/pool",
+		"ssh://-user@host/pool",
+		"ssh://user:password@host/pool",
+		"ssh://host:0/pool",
+		"ssh://host:65536/pool",
+		"ssh://host:/pool",
+		"ssh://host/pool?query=1",
+		"ssh://host/pool#fragment",
+		"ssh://host name/pool",
+	} {
+		if _, err := ParseRemoteURL(raw); err == nil {
+			t.Errorf("ParseRemoteURL(%q) unexpectedly succeeded", raw)
+		}
+	}
+}
+
+func TestDiscoverRemoteJoinedUsesShadowAndLocalRepo(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	repo := t.TempDir()
+	mustWrite(t, filepath.Join(repo, specFileName), []byte("# spec\n"))
+	cwd := filepath.Join(repo, "nested")
+	mustMkdir(t, cwd)
+	remote, err := ParseRemoteURL("ssh://Nobody@UNROUTABLE.Invalid:22/remote/pool/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, remote.ConfigPath, []byte("{}\n"))
+
+	cfg, err := Discover(DiscoverOpts{Cwd: cwd, ControlRepoFlag: "ssh://Nobody@UNROUTABLE.Invalid:22/remote/pool/"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Remote == nil || cfg.Remote.URL != "ssh://Nobody@unroutable.invalid/remote/pool" {
+		t.Fatalf("Remote = %#v", cfg.Remote)
+	}
+	if cfg.ControlRepo != repo {
+		t.Fatalf("ControlRepo = %q, want local repo %q", cfg.ControlRepo, repo)
+	}
+	wantShadow := filepath.Join(home, ".agentchute", "hub", remote.HubID, ".agentchute", "loop")
+	if cfg.LoopDir != wantShadow || cfg.Remote.ShadowLoopDir != wantShadow {
+		t.Fatalf("shadow = %q / %q, want %q", cfg.LoopDir, cfg.Remote.ShadowLoopDir, wantShadow)
+	}
+	if cfg.Vendor != "agentchute" || cfg.LoopDirOrigin != "remote" {
+		t.Fatalf("Vendor/LoopDirOrigin = %q/%q", cfg.Vendor, cfg.LoopDirOrigin)
+	}
+}
+
+func TestDiscoverRemoteNotJoinedAndExplicitLoopRefusal(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	url := "ssh://host.example/remote/pool"
+	_, err := Discover(DiscoverOpts{Cwd: cwd, ControlRepoFlag: url})
+	if !errors.Is(err, ErrRemoteNotJoined) {
+		t.Fatalf("unjoined error = %v, want ErrRemoteNotJoined", err)
+	}
+	remote, err := ParseRemoteURL(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, remote.ConfigPath, []byte("{}\n"))
+	_, err = Discover(DiscoverOpts{Cwd: cwd, ControlRepoFlag: url, EnvLoopDir: "/tmp/loop"})
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("explicit loop error = %v", err)
+	}
+}
+
+func TestDiscoverRemoteEnvBeatsPointer(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	envURL := "ssh://env.example/env/pool"
+	pointerURL := "ssh://pointer.example/pointer/pool"
+	for _, raw := range []string{envURL, pointerURL} {
+		remote, err := ParseRemoteURL(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustWrite(t, remote.ConfigPath, []byte("{}\n"))
+	}
+	mustWrite(t, filepath.Join(cwd, PointerFileName), []byte(pointerURL+"\n"))
+	cfg, err := Discover(DiscoverOpts{Cwd: cwd, EnvControlRepo: envURL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Remote == nil || cfg.Remote.URL != envURL || cfg.ControlRepoOrigin != "env" {
+		t.Fatalf("remote/origin = %#v/%q", cfg.Remote, cfg.ControlRepoOrigin)
+	}
+}
+
+func TestResolvePointerTargetPreservesSSHLocator(t *testing.T) {
+	raw := "ssh://User@Host.Example/absolute/pool"
+	got, err := ResolvePointerTarget(t.TempDir(), raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != raw {
+		t.Fatalf("ResolvePointerTarget = %q, want unchanged %q", got, raw)
+	}
+}
+
+func TestRequireRemoteJoinRejectsNonRegularConfigPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	remote, err := ParseRemoteURL("ssh://host.example/pool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(remote.ConfigPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := RequireRemoteJoin(remote); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("non-regular config error = %v", err)
+	}
+}

--- a/internal/loop/remote_test.go
+++ b/internal/loop/remote_test.go
@@ -126,6 +126,29 @@ func TestDiscoverRemoteEnvBeatsPointer(t *testing.T) {
 	}
 }
 
+func TestDiscoverRemotePointerBranchesBeforeLocalRepoChecks(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	cwd := t.TempDir()
+	raw := "ssh://User@HUB.Example:22/remote/pool/"
+	remote, err := ParseRemoteURL(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, remote.ConfigPath, []byte("{}\n"))
+	mustWrite(t, filepath.Join(cwd, PointerFileName), []byte(raw+"\n"))
+
+	cfg, err := Discover(DiscoverOpts{Cwd: cwd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Remote == nil || cfg.Remote.URL != "ssh://User@hub.example/remote/pool" {
+		t.Fatalf("pointer discovery remote = %#v", cfg.Remote)
+	}
+	if cfg.ControlRepoOrigin != "pointer:"+filepath.Join(cwd, PointerFileName) {
+		t.Fatalf("pointer origin = %q", cfg.ControlRepoOrigin)
+	}
+}
+
 func TestResolvePointerTargetPreservesSSHLocator(t *testing.T) {
 	raw := "ssh://User@Host.Example/absolute/pool"
 	got, err := ResolvePointerTarget(t.TempDir(), raw)

--- a/internal/spectest/wire.go
+++ b/internal/spectest/wire.go
@@ -2,6 +2,7 @@ package spectest
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -83,6 +84,7 @@ func assertW1Client(t *testing.T, f SessionFactory) {
 	if err == nil {
 		t.Fatal("disconnect after first message returned nil error")
 	}
+	waitSession(t, transport)
 	if n, err := f.State().ClaimedCount("codex"); err != nil || n != 1 {
 		t.Fatalf("claimed residue = %d, %v", n, err)
 	}
@@ -101,27 +103,25 @@ func assertW1Client(t *testing.T, f SessionFactory) {
 
 type disconnectAfterCommit struct {
 	Session
-	state  StateProbe
-	agent  string
-	writes int
+	state StateProbe
+	agent string
+	reads int
 }
 
-func (d *disconnectAfterCommit) Write(p []byte) (int, error) {
-	n, err := d.Session.Write(p)
-	d.writes++
-	if d.writes == 2 {
-		go func() {
-			deadline := time.Now().Add(2 * time.Second)
-			for time.Now().Before(deadline) {
-				if count, countErr := d.state.InboxCount(d.agent); countErr == nil && count == 1 {
-					_ = d.ForceDisconnect()
-					return
-				}
-				time.Sleep(time.Millisecond)
+func (d *disconnectAfterCommit) Read(p []byte) (int, error) {
+	d.reads++
+	if d.reads == 2 {
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if count, countErr := d.state.InboxCount(d.agent); countErr == nil && count == 1 {
+				_ = d.ForceDisconnect()
+				return d.Session.Read(p)
 			}
-		}()
+			time.Sleep(time.Millisecond)
+		}
+		return 0, fmt.Errorf("send did not commit before disconnect deadline")
 	}
-	return n, err
+	return d.Session.Read(p)
 }
 
 func assertW2Client(t *testing.T, f SessionFactory) {
@@ -140,6 +140,7 @@ func assertW2Client(t *testing.T, f SessionFactory) {
 	if hubclient.ErrorCode(err) != "E_SEND_UNKNOWN" {
 		t.Fatalf("send error = %v (%s), want E_SEND_UNKNOWN", err, hubclient.ErrorCode(err))
 	}
+	waitSession(t, raw)
 	if n, err := f.State().InboxCount("grok"); err != nil || n != 1 {
 		t.Fatalf("delivery count = %d, %v", n, err)
 	}
@@ -154,11 +155,12 @@ func assertW6Client(t *testing.T, f SessionFactory) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = restore() })
-	client, _ := openClient(t, f, "codex")
+	client, transport := openClient(t, f, "codex")
 	_, err = client.Check(op.ClaimReq{}, func(op.Event) error { return nil })
 	if hubclient.ErrorCode(err) != "E_HUB_IO" || !hubclient.ClaimedHeld(err) {
 		t.Fatalf("check error = %v code=%s claimed_held=%v", err, hubclient.ErrorCode(err), hubclient.ClaimedHeld(err))
 	}
+	waitSession(t, transport)
 }
 
 type StateProbe interface {
@@ -336,6 +338,7 @@ func assertW3(t *testing.T, f SessionFactory) {
 		t.Fatalf("delivery count = %d, %v", n, err)
 	}
 	_ = channel.ForceDisconnect()
+	waitSession(t, channel)
 }
 
 func assertHandshakeError(t *testing.T, f SessionFactory, acting string, minV int, want string) {

--- a/internal/spectest/wire.go
+++ b/internal/spectest/wire.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agentchute/agentchute/internal/hubclient"
 	"github.com/agentchute/agentchute/internal/hubwire"
 	"github.com/agentchute/agentchute/internal/loop"
+	"github.com/agentchute/agentchute/internal/op"
 )
 
 // SessionFactory is the transport-neutral W harness contract. M3 supplies a
@@ -20,8 +22,143 @@ type SessionFactory interface {
 
 type Session interface {
 	io.ReadWriteCloser
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
 	ForceDisconnect() error
 	Wait(context.Context) error
+}
+
+// AssertWireClientVectors drives the three vectors whose invariant terminates
+// on the client side. The factory is the same transport-neutral contract used
+// by AssertWireVectors, so M6 can rerun these assertions over sshd unchanged.
+func AssertWireClientVectors(t *testing.T, vectors []Vector, build FactoryBuilder) {
+	t.Helper()
+	for _, vector := range vectors {
+		vector := vector
+		if vector.ID != "W1" && vector.ID != "W2" && vector.ID != "W6" {
+			continue
+		}
+		t.Run(vector.ID+"/client", func(t *testing.T) {
+			factory := build(t)
+			switch vector.ID {
+			case "W1":
+				assertW1Client(t, factory)
+			case "W2":
+				assertW2Client(t, factory)
+			case "W6":
+				assertW6Client(t, factory)
+			}
+		})
+	}
+}
+
+func openClient(t *testing.T, factory SessionFactory, agent string) (*hubclient.OneShot, Session) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	transport, err := factory.Open(ctx, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = transport.Close() })
+	remote := &loop.RemoteConfig{Host: "in-process", Port: 22}
+	client, err := hubclient.OpenOneShotTransport(transport, remote, agent, "spectest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client, transport
+}
+
+func assertW1Client(t *testing.T, f SessionFactory) {
+	if err := f.State().Deliver("grok", "codex", "claimed"); err != nil {
+		t.Fatal(err)
+	}
+	client, transport := openClient(t, f, "codex")
+	_, err := client.Check(op.ClaimReq{}, func(ev op.Event) error {
+		if ev.Message != nil {
+			return transport.ForceDisconnect()
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatal("disconnect after first message returned nil error")
+	}
+	if n, err := f.State().ClaimedCount("codex"); err != nil || n != 1 {
+		t.Fatalf("claimed residue = %d, %v", n, err)
+	}
+	client2, _ := openClient(t, f, "codex")
+	redelivered := false
+	sum, err := client2.Check(op.ClaimReq{}, func(ev op.Event) error {
+		if ev.Message != nil {
+			redelivered = ev.Message.Redelivered
+		}
+		return nil
+	})
+	if err != nil || !redelivered || sum.Redelivered != 1 {
+		t.Fatalf("redelivery = %v, summary=%+v, err=%v", redelivered, sum, err)
+	}
+}
+
+type disconnectAfterCommit struct {
+	Session
+	state  StateProbe
+	agent  string
+	writes int
+}
+
+func (d *disconnectAfterCommit) Write(p []byte) (int, error) {
+	n, err := d.Session.Write(p)
+	d.writes++
+	if d.writes == 2 {
+		go func() {
+			deadline := time.Now().Add(2 * time.Second)
+			for time.Now().Before(deadline) {
+				if count, countErr := d.state.InboxCount(d.agent); countErr == nil && count == 1 {
+					_ = d.ForceDisconnect()
+					return
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}()
+	}
+	return n, err
+}
+
+func assertW2Client(t *testing.T, f SessionFactory) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	raw, err := f.Open(ctx, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := &disconnectAfterCommit{Session: raw, state: f.State(), agent: "grok"}
+	client, err := hubclient.OpenOneShotTransport(transport, &loop.RemoteConfig{Host: "in-process", Port: 22}, "codex", "spectest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.Send(op.SendReq{To: "grok", Content: loop.ComposeMessage("codex", "", "once")})
+	if hubclient.ErrorCode(err) != "E_SEND_UNKNOWN" {
+		t.Fatalf("send error = %v (%s), want E_SEND_UNKNOWN", err, hubclient.ErrorCode(err))
+	}
+	if n, err := f.State().InboxCount("grok"); err != nil || n != 1 {
+		t.Fatalf("delivery count = %d, %v", n, err)
+	}
+}
+
+func assertW6Client(t *testing.T, f SessionFactory) {
+	if err := f.State().Deliver("grok", "codex", "held"); err != nil {
+		t.Fatal(err)
+	}
+	restore, err := f.State().StageUnreadableClaim("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = restore() })
+	client, _ := openClient(t, f, "codex")
+	_, err = client.Check(op.ClaimReq{}, func(op.Event) error { return nil })
+	if hubclient.ErrorCode(err) != "E_HUB_IO" || !hubclient.ClaimedHeld(err) {
+		t.Fatalf("check error = %v code=%s claimed_held=%v", err, hubclient.ErrorCode(err), hubclient.ClaimedHeld(err))
+	}
 }
 
 type StateProbe interface {

--- a/internal/spectest/wire_test.go
+++ b/internal/spectest/wire_test.go
@@ -27,10 +27,12 @@ type pipeSession struct {
 	done <-chan error
 }
 
-func (s *pipeSession) Read(p []byte) (int, error)  { return s.conn.Read(p) }
-func (s *pipeSession) Write(p []byte) (int, error) { return s.conn.Write(p) }
-func (s *pipeSession) Close() error                { return s.conn.Close() }
-func (s *pipeSession) ForceDisconnect() error      { return s.conn.Close() }
+func (s *pipeSession) Read(p []byte) (int, error)         { return s.conn.Read(p) }
+func (s *pipeSession) Write(p []byte) (int, error)        { return s.conn.Write(p) }
+func (s *pipeSession) Close() error                       { return s.conn.Close() }
+func (s *pipeSession) SetReadDeadline(t time.Time) error  { return s.conn.SetReadDeadline(t) }
+func (s *pipeSession) SetWriteDeadline(t time.Time) error { return s.conn.SetWriteDeadline(t) }
+func (s *pipeSession) ForceDisconnect() error             { return s.conn.Close() }
 func (s *pipeSession) Wait(ctx context.Context) error {
 	select {
 	case err := <-s.done:
@@ -133,4 +135,34 @@ func TestWireVectors(t *testing.T) {
 		}
 		return &pipeFactory{pool: pool, cfg: cfg}
 	})
+}
+
+func TestWireClientVectors(t *testing.T) {
+	vectors, err := LoadVectors("wire.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	AssertWireClientVectors(t, vectors, newPipeFactory)
+}
+
+func newPipeFactory(t *testing.T) SessionFactory {
+	pool := t.TempDir()
+	if err := os.WriteFile(filepath.Join(pool, "AGENTCHUTE.md"), []byte("# spec\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	loopDir := filepath.Join(pool, ".agentchute", "loop")
+	if err := os.MkdirAll(filepath.Join(loopDir, "state"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(loopDir, "state", "pool.id"), []byte(testPoolID+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &loop.Config{ControlRepo: pool, LoopDir: loopDir, Vendor: "agentchute"}
+	vendor := "test"
+	for _, id := range []string{"codex", "grok"} {
+		if _, err := op.Register(cfg, op.Context{ActorID: id}, op.RegisterReq{Vendor: &vendor, Host: "test"}, time.Now().UTC()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &pipeFactory{pool: pool, cfg: cfg}
 }


### PR DESCRIPTION
## Summary

- add strict `ssh://` discovery, canonical hub identity, joined config, and local shadow state
- add one-shot SSH transport, client sessions, error mapping, mux fallback, negative cache, and send ambiguity spool
- route remote CLI verbs through the hub while preserving hub-side registration, announce, sweep, status, and local guard semantics
- add names-map identity resolution, remote identity/doctor surfaces, launcher forwarding, and W1/W2/W6 client conformance

## Implementation note

The pointer discovery arm branches on `ssh://` immediately after `DiscoverPointer`, before its local `AGENTCHUTE.md` and `.agentchute/loop` checks. This is deliberate: preserving the locator in `ResolvePointerTarget` alone would only replace the old mangled-path failure with a different local-path refusal. `TestDiscoverRemotePointerBranchesBeforeLocalRepoChecks` pins the complete path.

The review/CI delta joins every wire-test hub session before `t.TempDir` cleanup, makes W2 disconnect on the terminal read only after the hub commit is observable, and keeps remote wrapper children on the canonical SSH locator without exporting the local shadow loop. The prior W3 cleanup writer was the deferred `ReleaseLease`/`withAgentLock` path from a session that outlived its test.

The final review delta replaces the isolated `claimed_held` helper test with a W6 integration assertion that drives the production remote `cmdCheck` over a fake SSH wire peer and verifies the real local guard latch. Removing the `check.go` claimed-residue branch now fails the test.

## Verification

- `tools/test.sh`
- env-stripped `go test -race ./...`
- env-stripped `cd conformance && go test -race ./...`
- Linux non-root `go test -race ./...`
- Linux `TestWireVectors/W3/reclaim_during_send -count=20 -race`
- Linux `TestWireClientVectors/W2/client -count=20 -race`
- `TestW6ClientRemoteCheckClaimedHeld -count=20 -race`

Base: `f90a96866df93d43a51c188f5af0bd0b7c9bc9d4`
Head: `86269248f7127fa199db3994dfafb904d4ac64f7`
