### PR TITLE
update: quote what the re-sync child said, next to the warning it failed

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -307,8 +307,16 @@ func cmdUpdate(args []string) error {
 	// into hooks that might still be broken: leaving supervisors running on
 	// the OLD binary is strictly safer than fencing them into an unverified
 	// new one (2026-08-11 hook-refresh-reliability follow-up, codex vector 2).
-	if err := updateRunResync(target, setupArgs, cfg.ControlRepo); err != nil {
+	if childStderr, err := updateRunResync(target, setupArgs, cfg.ControlRepo); err != nil {
 		fmt.Fprintf(os.Stderr, "\nWARNING: binary updated to %s but `setup` re-sync FAILED: %v\n", targetTag, err)
+		// Quote what the child said, right here. It already streamed past on its
+		// way through, but by the time this WARNING prints it is a dozen lines up
+		// and the operator's eye is on the line that names only an exit status.
+		// That is issue #183: the first v1.6.0 field report spent a manual re-run
+		// to read a message that had already been printed.
+		if detail := resyncFailureDetail(childStderr); detail != "" {
+			fmt.Fprintf(os.Stderr, "re-sync said:\n%s", detail)
+		}
 		fmt.Fprintf(os.Stderr, "Finish the re-sync manually from this repo:\n  %s %s\n", target, setupCmd)
 		fmt.Fprintln(os.Stderr, "Serve leases were NOT invalidated; existing supervisors keep running on the prior binary until the re-sync succeeds.")
 		return errors.New("setup re-sync after update failed (see warning above)")
@@ -329,13 +337,84 @@ func cmdUpdate(args []string) error {
 // NEW version's templates/hooks/shims and performs the bus reset. It is a package
 // var so tests can assert the --no-resync path never invokes it. The apply path
 // runs this only when --no-resync is absent.
-var updateRunResync = func(target string, setupArgs []string, controlRepo string) error {
-	setup := exec.Command(target, setupArgs...)
-	setup.Stdout = os.Stdout
-	setup.Stderr = os.Stderr
-	setup.Stdin = os.Stdin
-	setup.Dir = controlRepo
-	return setup.Run()
+// It TEES the child's stderr rather than capturing it: the child keeps writing
+// to the terminal as it always has — a slow re-sync must not go silent until it
+// finishes — and a bounded tail is kept so the failure path can quote the end.
+// Only the last resyncStderrTailBytes are retained, because the child is the
+// thing that just failed and an unbounded buffer is one more way for a bad run
+// to hurt.
+var updateRunResync = func(target string, setupArgs []string, controlRepo string) (string, error) {
+	child := exec.Command(target, setupArgs...)
+	tail := &tailBytesWriter{limit: resyncStderrTailBytes}
+	child.Stdout = os.Stdout
+	child.Stderr = io.MultiWriter(os.Stderr, tail)
+	child.Stdin = os.Stdin
+	child.Dir = controlRepo
+	err := child.Run()
+	return tail.String(), err
+}
+
+const (
+	// resyncStderrTailLines is how many lines of the child's stderr the WARNING
+	// quotes. The quote is a pointer to the cause, not a transcript: past a
+	// dozen lines it buries the manual command printed underneath it.
+	resyncStderrTailLines = 10
+	resyncStderrTailBytes = 8 << 10
+)
+
+// tailBytesWriter keeps the last limit bytes written and drops the rest, without
+// ever blocking the writer.
+type tailBytesWriter struct {
+	buf   []byte
+	limit int
+}
+
+func (w *tailBytesWriter) Write(p []byte) (int, error) {
+	n := len(p)
+	if len(p) >= w.limit {
+		w.buf = append(w.buf[:0], p[len(p)-w.limit:]...)
+		return n, nil
+	}
+	if len(w.buf)+len(p) > w.limit {
+		drop := len(w.buf) + len(p) - w.limit
+		copy(w.buf, w.buf[drop:])
+		w.buf = w.buf[:len(w.buf)-drop]
+	}
+	w.buf = append(w.buf, p...)
+	return n, nil
+}
+
+func (w *tailBytesWriter) String() string { return string(w.buf) }
+
+// resyncFailureDetail renders the child's last words as an indented block, or
+// "" when it said nothing worth printing. It keeps the END: a command that fails
+// says why last, and the beginning is progress chatter.
+//
+// A trim is announced. Silent truncation reads as "that was all it said", which
+// is exactly how an operator stops looking for the rest of the cause.
+func resyncFailureDetail(stderr string) string {
+	var lines []string
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, strings.TrimRight(line, "\r"))
+		}
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	trimmed := 0
+	if len(lines) > resyncStderrTailLines {
+		trimmed = len(lines) - resyncStderrTailLines
+		lines = lines[trimmed:]
+	}
+	var b strings.Builder
+	if trimmed > 0 {
+		fmt.Fprintf(&b, "  (%d earlier line(s) not shown; they scrolled past above)\n", trimmed)
+	}
+	for _, line := range lines {
+		b.WriteString("  " + line + "\n")
+	}
+	return b.String()
 }
 
 // installedHookWrappers reports the wrappers whose hook files exist on disk in

--- a/internal/cli/update_resync_stderr_test.go
+++ b/internal/cli/update_resync_stderr_test.go
@@ -1,0 +1,188 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// Issue #183, from the first v1.6.0 field report. `update` reported
+//
+//	WARNING: binary updated to v1.6.0 but `setup` re-sync FAILED: exit status 1
+//
+// and the actual cause — the symlink guard refusing to write through an
+// AGENTCHUTE.md -> AGENTS.md symlink — was found only by re-running the printed
+// command by hand.
+//
+// PREMISE CORRECTION, measured before any of this was written. update does NOT
+// swallow the child's stderr. updateRunResync has wired the child's Stderr to
+// os.Stderr since v0.9.1, v1.5.7 included, and Main prints command errors to
+// stderr as well. The message DID reach the terminal. What failed is that it
+// arrived a dozen lines above a WARNING which then named only an exit status, so
+// the line an operator's eye lands on carried no cause.
+//
+// That makes "capture the stderr instead of streaming it" the wrong repair: it
+// would trade a detached message for no live output at all, and a slow setup
+// would go silent until it finished. The child still streams exactly as before;
+// a bounded tail is kept alongside it so the WARNING can quote the end.
+func TestUpdateResyncFailureQuotesWhatSetupSaid(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions used by the writable probe")
+	}
+	const guardMessage = "init: AGENTCHUTE.md is a symlink; refusing to read or write through it — replace it with a real file"
+	root, bin, srv := newUpdateResyncFixture(t)
+	defer srv.Close()
+
+	oldBase, oldTarget, oldResync := updateGitHubBase, resolveUpdateTargetForTest, updateRunResync
+	updateGitHubBase = srv.URL
+	resolveUpdateTargetForTest = bin
+	updateRunResync = func(string, []string, string) (string, error) {
+		return "writing hooks\n" + guardMessage + "\n", errors.New("exit status 1")
+	}
+	t.Cleanup(func() {
+		updateGitHubBase, resolveUpdateTargetForTest, updateRunResync = oldBase, oldTarget, oldResync
+	})
+
+	var updateErr error
+	stderr := captureStderr(t, func() {
+		withCwd(t, root, func() {
+			mustExampleRepo(t, root)
+			cfg, err := loop.Discover(loop.DiscoverOpts{Cwd: root})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := writeSetupPoolState(cfg, "runner", nil, ""); err != nil {
+				t.Fatal(err)
+			}
+			updateErr = cmdUpdate([]string{"--version", "v0.5.0"})
+		})
+	})
+
+	if updateErr == nil {
+		t.Fatal("a failed re-sync must still be a non-zero update")
+	}
+	// The issue itself: the cause, next to the warning.
+	if !strings.Contains(stderr, guardMessage) {
+		t.Fatalf("the re-sync failure did not say what the child said:\n%s", stderr)
+	}
+	// Attributed, so an operator can tell the sentence came from the child and
+	// not from update — the convention hub join already uses for ssh.
+	if !strings.Contains(stderr, "said:") {
+		t.Fatalf("the quoted output is not attributed to the child:\n%s", stderr)
+	}
+	// Still actionable: the manual command is what the field report recovered
+	// with, so it has to survive this change.
+	if !strings.Contains(stderr, "Finish the re-sync manually") {
+		t.Fatalf("the manual re-sync command is gone:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "Serve leases were NOT invalidated") {
+		t.Fatalf("the lease-safety sentence is gone:\n%s", stderr)
+	}
+}
+
+// The other half, and the one that catches a revert at the source: the REAL
+// runner, against a stand-in that writes to stderr and exits non-zero. It must
+// return what the child said AND still let the child's output through live.
+func TestUpdateRunResyncTeesTheChildStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stand-in for the child process")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "agentchute")
+	script := "#!/bin/sh\necho 'progress on stdout'\necho 'init: AGENTCHUTE.md is a symlink' >&2\nexit 1\n"
+	if err := os.WriteFile(target, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var captured string
+	var runErr error
+	live := captureStderr(t, func() {
+		captured, runErr = updateRunResync(target, []string{"--yes"}, dir)
+	})
+
+	if runErr == nil {
+		t.Fatal("the stand-in exited 1; the runner reported success")
+	}
+	if !strings.Contains(captured, "AGENTCHUTE.md is a symlink") {
+		t.Fatalf("the runner returned no trace of what the child said: %q", captured)
+	}
+	if !strings.Contains(live, "AGENTCHUTE.md is a symlink") {
+		t.Fatalf("the child's stderr no longer reaches the terminal live:\n%s", live)
+	}
+}
+
+// A failing child can be verbose. The quote is a pointer to the cause, not a
+// transcript — an unbounded one would bury the manual command underneath it.
+func TestResyncFailureDetailKeepsTheEndAndSaysItTrimmed(t *testing.T) {
+	var lines []string
+	for i := 1; i <= 40; i++ {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+	detail := resyncFailureDetail(strings.Join(lines, "\n") + "\n")
+
+	if strings.Contains(detail, "line 1\n") {
+		t.Fatalf("kept the beginning; the cause of a failure is at the END:\n%s", detail)
+	}
+	if !strings.Contains(detail, "line 40") {
+		t.Fatalf("dropped the last line, which is where the error is:\n%s", detail)
+	}
+	if got := strings.Count(detail, "line "); got > resyncStderrTailLines {
+		t.Fatalf("quoted %d lines, want at most %d", got, resyncStderrTailLines)
+	}
+	// Silent truncation reads as "that was all it said", which is how an operator
+	// stops looking for the rest.
+	if !strings.Contains(detail, "earlier line") {
+		t.Fatalf("trimmed output without saying so:\n%s", detail)
+	}
+
+	t.Run("blank output produces no empty block", func(t *testing.T) {
+		if got := resyncFailureDetail("   \n\n\t\n"); got != "" {
+			t.Fatalf("whitespace-only stderr produced a block: %q", got)
+		}
+	})
+
+	t.Run("short output is quoted whole, with no trim note", func(t *testing.T) {
+		detail := resyncFailureDetail("the only thing it said\n")
+		if !strings.Contains(detail, "the only thing it said") {
+			t.Fatalf("dropped the one line there was: %q", detail)
+		}
+		if strings.Contains(detail, "earlier line") {
+			t.Fatalf("claimed a trim that did not happen: %q", detail)
+		}
+	})
+}
+
+func newUpdateResyncFixture(t *testing.T) (root, bin string, srv *httptest.Server) {
+	t.Helper()
+	root = t.TempDir()
+	installDir := t.TempDir()
+	bin = filepath.Join(installDir, "agentchute")
+	if err := os.WriteFile(bin, []byte{0x7f, 'E', 'L', 'F', 0, 0, 0, 0}, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	asset := fmt.Sprintf("agentchute_0.5.0_%s_%s.tar.gz", runtime.GOOS, runtime.GOARCH)
+	archive := makeTarGz(t, map[string][]byte{"agentchute": []byte("NEW-BINARY-BYTES")})
+	sum := sha256.Sum256(archive)
+	checksum := hex.EncodeToString(sum[:])
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			fmt.Fprintf(w, "%s  %s\n", checksum, asset)
+		case strings.HasSuffix(r.URL.Path, asset):
+			w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return root, bin, srv
+}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -321,9 +321,9 @@ func TestUpdate_NoResyncSkipsSetupReSync(t *testing.T) {
 	updateGitHubBase = srv.URL
 	resolveUpdateTargetForTest = bin
 	resyncCalled := false
-	updateRunResync = func(target string, setupArgs []string, controlRepo string) error {
+	updateRunResync = func(target string, setupArgs []string, controlRepo string) (string, error) {
 		resyncCalled = true
-		return nil
+		return "", nil
 	}
 	t.Cleanup(func() {
 		updateGitHubBase = oldBase
@@ -448,12 +448,12 @@ func TestUpdateInvalidatesLeaseOnlyAfterSetupResyncSucceeds(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		updateRunResync = func(target string, setupArgs []string, controlRepo string) error {
+		updateRunResync = func(target string, setupArgs []string, controlRepo string) (string, error) {
 			resyncCalled = true
 			if err := loop.RenewLease(lease); err != nil {
 				t.Fatalf("lease at setup re-sync = %v, want no error (leases must not be invalidated before the resync succeeds)", err)
 			}
-			return nil
+			return "", nil
 		}
 		if err := cmdUpdate([]string{"--version", "v0.5.0"}); err != nil {
 			t.Fatalf("update with re-sync failed: %v", err)
@@ -503,8 +503,8 @@ func TestUpdate_ResyncFailureLeavesLeaseIntact(t *testing.T) {
 	oldResync := updateRunResync
 	updateGitHubBase = srv.URL
 	resolveUpdateTargetForTest = bin
-	updateRunResync = func(target string, setupArgs []string, controlRepo string) error {
-		return errors.New("injected resync failure")
+	updateRunResync = func(target string, setupArgs []string, controlRepo string) (string, error) {
+		return "", errors.New("injected resync failure")
 	}
 	t.Cleanup(func() {
 		updateGitHubBase = oldBase
@@ -613,8 +613,8 @@ func TestUpdate_ResyncVerificationFailurePreventsFinalRestartBanner(t *testing.T
 	oldResync := updateRunResync
 	updateGitHubBase = srv.URL
 	resolveUpdateTargetForTest = bin
-	updateRunResync = func(target string, setupArgs []string, controlRepo string) error {
-		return errors.New("hook compatibility verification failed: hook file(s) invoke unknown agentchute subcommand(s) after refresh: claude-code (`poller`) — run `agentchute hooks install --wrapper all --scope repo --force`")
+	updateRunResync = func(target string, setupArgs []string, controlRepo string) (string, error) {
+		return "", errors.New("hook compatibility verification failed: hook file(s) invoke unknown agentchute subcommand(s) after refresh: claude-code (`poller`) — run `agentchute hooks install --wrapper all --scope repo --force`")
 	}
 	t.Cleanup(func() {
 		updateGitHubBase = oldBase


### PR DESCRIPTION
Closes #183 — the first v1.6.0 field report.

## Premise correction, measured before writing the fix

The issue says `update` swallows the re-sync child's stderr. It does not, and the fix it proposes would have made things worse.

`updateRunResync` has wired the child's `Stderr` to `os.Stderr` since v0.9.1 — including in v1.5.7, the binary that ran this update — and `Main` prints command errors to stderr as well. The symlink guard's message **did** reach the terminal. What failed is *where*: it arrived a dozen lines above a WARNING that then named only `exit status 1`, so the line the operator's eye lands on carried no cause.

That makes "capture the stderr and include it" the wrong repair — capturing means no live output at all, and a slow re-sync would go silent until it finished.

## What this does instead

It **tees**. The child streams exactly as before; a bounded tail (8 KiB) is kept alongside it so the failure path can quote the end. The WARNING gains a `re-sync said:` block — last 10 non-empty lines, indented, attributed to the child the way `hub join` already attributes ssh:

```
WARNING: binary updated to v1.6.0 but `setup` re-sync FAILED: exit status 1
re-sync said:
  agentchute setup: init: AGENTCHUTE.md is a symlink; refusing to read or write through it — replace it with a real file
Finish the re-sync manually from this repo:
  /usr/local/bin/agentchute setup --control-repo … --yes
Serve leases were NOT invalidated; existing supervisors keep running on the prior binary until the re-sync succeeds.
```

The manual command stays above the fold — it is what the field report actually recovered with. A trim is announced rather than silent, because silent truncation reads as "that was all it said", which is how an operator stops looking for the rest.

## Rows

Three, six mutations red under a CI-like stripped PATH (`/usr/bin:/bin:/usr/sbin:/sbin:$GOBIN`):

- the full `cmdUpdate` path with an injected failing re-sync → the child's text appears, attributed, with the manual command and the lease-safety sentence intact;
- the **real** `updateRunResync` against a stand-in child that writes to stderr and exits 1 → it both returns the text and still lets it through live. Driving the seam alone would only prove the formatter formats;
- the formatter: keeps the end (a command says why it failed last), bounds the quote, announces a trim, and emits nothing at all for whitespace-only output.

Mutations covered: revert to bare exit-status reporting; capture without streaming; stream without capturing; keep the head instead of the tail; trim silently; drop the manual command.

## Verification

`tools/test.sh`, `go vet ./...`, `go test -race ./...`.

## Unrelated, noticed while here — not fixed in this PR

`CHANGELOG.md` has no `v1.6.0` section, and its `## Unreleased — operation seam` block describes material that shipped **in** v1.6.0. Flagging rather than folding in: it belongs to the release, not to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
