### PR TITLE
hub join: record a fingerprint via keyscan when known_hosts cannot, and stop discarding the error

### DIFF
--- a/internal/cli/hub_join.go
+++ b/internal/cli/hub_join.go
@@ -193,7 +193,24 @@ func runHubJoin(root string, remote *loop.RemoteConfig, opts hubJoinOptions) err
 	if err != nil {
 		return err
 	}
-	fingerprint, _ := hubJoinFingerprint(remote)
+	fingerprint, readErr := hubJoinFingerprint(remote)
+	if fingerprint == "" {
+		// known_hosts yielded nothing usable. MIGRATION has had an ssh-keyscan
+		// fallback for exactly this since it shipped; join had none, recorded an
+		// empty fingerprint, and discarded the error that said why — and nothing
+		// re-records it, so findHubMigrationCandidate skips that hub forever
+		// (#164). The path that RECORDS a value has to be at least as robust as
+		// the path that CONSUMES it.
+		//
+		// Only when known_hosts fails, deliberately: ssh-keyscan is a second
+		// connection to a host this join has already reached, and a healthy join
+		// should not pay for a probe it does not need.
+		if scanned, scanErr := hubJoinDiscoverFingerprint(remote); scanErr == nil && scanned != "" {
+			fingerprint = scanned
+		} else {
+			warnHubJoinNoFingerprint(remote, readErr, scanErr)
+		}
+	}
 	if fingerprint != "" {
 		fmt.Printf("hub key recorded: %s\n", fingerprint)
 	}
@@ -662,6 +679,27 @@ func installHubJoinShims() error {
 	// tried to fix PATH. Warning here as well printed the same advice twice
 	// before either attempt had happened.
 	return setupEnsureShimPath(setupOptions{ShimDir: dir})
+}
+
+// warnHubJoinNoFingerprint is the other half of #164: the read error used to be
+// discarded outright, so a hub that could never be migrated was recorded in
+// silence.
+//
+// It warns rather than refusing. By this point the join has authenticated,
+// written its key and been accepted; stranding a working machine over a
+// diagnostic value would be a worse outcome than the one being fixed. What it
+// must not do is stay quiet, and it must say what actually breaks — an operator
+// has no reason to care about a fingerprint field, and the symptom shows up much
+// later wearing someone else's remedy.
+func warnHubJoinNoFingerprint(remote *loop.RemoteConfig, readErr, scanErr error) {
+	fmt.Fprintln(os.Stderr, "warning: joined, but this hub's host-key fingerprint could not be recorded.")
+	if readErr != nil {
+		fmt.Fprintf(os.Stderr, "  %s: %v\n", displayHomePath(filepath.Join(remote.HubDir, "known_hosts")), readErr)
+	}
+	if scanErr != nil {
+		fmt.Fprintf(os.Stderr, "  ssh-keyscan %s: %v\n", remote.Host, scanErr)
+	}
+	fmt.Fprintln(os.Stderr, "  The join itself is complete; what this costs you is later. Migrating this hub to a new URL needs the recorded fingerprint to recognise the two directories as the same hub, and with none recorded the move is never offered: a `hub join` at the new URL is treated as a FRESH join and refused for having an authorized key already. Re-run the same `hub join` command once the hub is reachable and this records itself.")
 }
 
 func readHubJoinFingerprint(remote *loop.RemoteConfig) (string, error) {

--- a/internal/cli/hub_join_fingerprint_test.go
+++ b/internal/cli/hub_join_fingerprint_test.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/agentchute/agentchute/internal/hubclient"
+	"github.com/agentchute/agentchute/internal/hubwire"
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// Issue #164. `hub join` read the host-key fingerprint from
+// <hubdir>/known_hosts, discarded the error if that failed, and recorded a
+// config with no fingerprint at all. Nothing ever re-recorded it, and
+// findHubMigrationCandidate skips a candidate whose fingerprint is empty — so
+// that hub could never be migrated. The operator instead got a duplicate-key
+// refusal telling them to pass --replace-key, which is the wrong remedy: the
+// machine had not been replaced.
+//
+// The asymmetry is the defect. Migration already has an ssh-keyscan fallback
+// (hubJoinDiscoverFingerprint) for exactly this, so the path that RECORDS the
+// value was less robust than the path that CONSUMES it.
+
+func TestHubJoinFallsBackToKeyscanWhenKnownHostsYieldsNothing(t *testing.T) {
+	root, remote := setupHubJoinTest(t)
+	withCwd(t, root, func() {
+		hubJoinFingerprint = func(*loop.RemoteConfig) (string, error) {
+			return "", errors.New("known_hosts unreadable")
+		}
+		scans := 0
+		hubJoinDiscoverFingerprint = func(*loop.RemoteConfig) (string, error) {
+			scans++
+			return "SHA256:scanned", nil
+		}
+		hubJoinProbe = func(*loop.RemoteConfig, string, string) (hubwire.HelloOK, []string, error) {
+			return successfulHubHello("codex-tiny"), nil, nil
+		}
+		if err := cmdHubJoin([]string{remote.URL, "--name", "codex"}); err != nil {
+			t.Fatal(err)
+		}
+		if scans != 1 {
+			t.Fatalf("keyscan fallback ran %d time(s), want 1", scans)
+		}
+		cfg, err := hubclient.ReadHubConfig(remote.HubID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// The whole point: a value gets recorded, and it is the one the fallback
+		// found. Recording "" here is what made the hub unmigrateable.
+		if cfg.HostKeyFingerprint != "SHA256:scanned" {
+			t.Fatalf("recorded fingerprint = %q, want the scanned one", cfg.HostKeyFingerprint)
+		}
+	})
+}
+
+// The control, and it is load-bearing. A fix that simply always keyscans would
+// pass the row above while adding a network probe to every healthy join — and
+// ssh-keyscan is a second connection to a host the join has already reached.
+func TestHubJoinDoesNotKeyscanWhenKnownHostsAnswers(t *testing.T) {
+	root, remote := setupHubJoinTest(t)
+	withCwd(t, root, func() {
+		hubJoinFingerprint = func(*loop.RemoteConfig) (string, error) {
+			return "SHA256:fromKnownHosts", nil
+		}
+		scans := 0
+		hubJoinDiscoverFingerprint = func(*loop.RemoteConfig) (string, error) {
+			scans++
+			return "SHA256:scanned", nil
+		}
+		hubJoinProbe = func(*loop.RemoteConfig, string, string) (hubwire.HelloOK, []string, error) {
+			return successfulHubHello("codex-tiny"), nil, nil
+		}
+		if err := cmdHubJoin([]string{remote.URL, "--name", "codex"}); err != nil {
+			t.Fatal(err)
+		}
+		if scans != 0 {
+			t.Fatalf("keyscan ran %d time(s) on a join whose known_hosts answered; the fallback is for when it does not", scans)
+		}
+		cfg, err := hubclient.ReadHubConfig(remote.HubID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.HostKeyFingerprint != "SHA256:fromKnownHosts" {
+			t.Fatalf("recorded fingerprint = %q, want the known_hosts one", cfg.HostKeyFingerprint)
+		}
+	})
+}
+
+// When BOTH sources fail the join still completes — it has already authenticated
+// and written the key, and refusing here would strand a working machine over a
+// diagnostic value. But it must stop being SILENT, which is the second half of
+// the issue: the error at the read site was discarded outright.
+func TestHubJoinSaysSoWhenNoFingerprintCanBeRecorded(t *testing.T) {
+	root, remote := setupHubJoinTest(t)
+	var joinErr error
+	stderr := captureStderr(t, func() {
+		withCwd(t, root, func() {
+			hubJoinFingerprint = func(*loop.RemoteConfig) (string, error) {
+				return "", errors.New("known_hosts unreadable")
+			}
+			hubJoinDiscoverFingerprint = func(*loop.RemoteConfig) (string, error) {
+				return "", errors.New("keyscan could not reach the host")
+			}
+			hubJoinProbe = func(*loop.RemoteConfig, string, string) (hubwire.HelloOK, []string, error) {
+				return successfulHubHello("codex-tiny"), nil, nil
+			}
+			joinErr = cmdHubJoin([]string{remote.URL, "--name", "codex"})
+		})
+	})
+
+	if joinErr != nil {
+		t.Fatalf("the join failed over a missing fingerprint: %v", joinErr)
+	}
+	// Both errors, because they are different problems with different fixes —
+	// an unreadable known_hosts is local, an unreachable keyscan is not.
+	for _, want := range []string{"known_hosts unreadable", "keyscan could not reach the host"} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("the discarded error is still discarded (missing %q):\n%s", want, stderr)
+		}
+	}
+	// The consequence, in the operator's terms. Without it this is a warning
+	// about an internal field nobody has a reason to care about — and the
+	// symptom arrives much later, as a duplicate-key refusal recommending
+	// --replace-key, which is the wrong remedy.
+	if !strings.Contains(strings.ToLower(stderr), "migrat") {
+		t.Fatalf("the warning does not say what breaks later:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "hub join") {
+		t.Fatalf("the warning does not say how to recover:\n%s", stderr)
+	}
+	// And it must not be mistaken for a failed join.
+	if strings.Contains(stderr, "--replace-key") {
+		t.Fatalf("the warning offers the remedy this issue exists to stop recommending:\n%s", stderr)
+	}
+
+	cfg, err := hubclient.ReadHubConfig(remote.HubID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.HostKeyFingerprint != "" {
+		t.Fatalf("recorded %q with no source able to supply one", cfg.HostKeyFingerprint)
+	}
+	// The join itself has to be complete, or the warning is describing the wrong
+	// failure: the machine is joined, it just cannot be migrated yet.
+	if !containsString(cfg.JoinedAs, "codex-tiny") {
+		t.Fatalf("join did not complete: %+v", cfg)
+	}
+}


### PR DESCRIPTION
Closes #164. Candidate fix 1 from the issue (the keyscan fallback), plus the "stop discarding the error at the read site" half.

## The defect, restated as an asymmetry

`hub join` read the host-key fingerprint from `<hubdir>/known_hosts`, discarded the error when that failed, and recorded a config with **no fingerprint**. Nothing ever re-records it, and `findHubMigrationCandidate` skips a candidate whose fingerprint is empty — so that hub can never be migrated.

The operator meets this much later and in disguise: an alias rejoin degrades into a fresh join and is refused with `"work-tiny" already has an authorized key … re-run with --replace-key`. That advice is wrong — the machine was not replaced — and following it rotates a key for nothing.

Migration has had an `ssh-keyscan` fallback for exactly this case since it shipped. Join had none. **The path that records the value was less robust than the path that consumes it.**

## What this does

- Join uses `hubJoinDiscoverFingerprint` when `known_hosts` yields nothing — the same fallback, from the same file.
- **Only** when `known_hosts` fails. `ssh-keyscan` is a second connection to a host the join has already reached, and a healthy join should not pay for a probe it does not need.
- When both sources fail it **warns**, and does not refuse. By that point the join has authenticated, written its key and been accepted; stranding a working machine over a diagnostic value would be worse than the bug being fixed.
- Both errors print, separately — an unreadable `known_hosts` is a local problem, an unreachable keyscan is not, and they have different fixes.
- The warning says what actually breaks, which is never the fingerprint field itself:

```
warning: joined, but this hub's host-key fingerprint could not be recorded.
  ~/.agentchute/hub/<id>/known_hosts: <why>
  ssh-keyscan hub44: <why>
  The join itself is complete; what this costs you is later. Migrating this hub to a
  new URL needs the recorded fingerprint to recognise the two directories as the same
  hub, and with none recorded the move is never offered: a `hub join` at the new URL
  is treated as a FRESH join and refused for having an authorized key already. Re-run
  the same `hub join` command once the hub is reachable and this records itself.
```

That last sentence is true today: `updateHubJoinConfig` records the value on any later join that can read one, so recovery needs no new flag.

## Rows

Three, six mutations red under a CI-like stripped PATH:

- `known_hosts` fails → the fallback fires once and its value is what gets recorded;
- **the control**: `known_hosts` answers → keyscan is not called at all. Load-bearing — a fix that simply always scanned would pass the row above while adding a network probe to every healthy join;
- both fail → the join still completes, both errors reach stderr, the consequence and the recovery are named, and the message does **not** mention `--replace-key`, which is the remedy this issue exists to stop recommending.

Mutations covered: no fallback; always keyscan; silent again; drop the read error; drop the consequence sentence; scan and then discard the result.

## Verification

`tools/test.sh`, `go test -race ./...`, and the full `integration/sshd` suite under `-race` (110s) — that suite drives real joins, so it is the one that would notice a regression here.

## Note for whoever picks up #180

#180 (migrations unreachable in the sshd harness) names #164 as its root cause. This PR does not change the harness, so #180 still needs its own look — but the production half it was blocked on is now fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
