### PR TITLE
tools/test.sh: run -race, as CI and the release job already do

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -19,6 +19,20 @@ say "go test ./..."
 # shellcheck disable=SC2086
 env $strip_env go test ./... || { say "FAIL: go test"; exit 1; }
 
+# -race, because CI and the release job both run it and this ritual is what lanes
+# are told to run before pushing. Without it the local gate is strictly weaker
+# than the one judging the push, and weaker in exactly the class that is
+# invisible locally and intermittent on a loaded runner. It has already cost a
+# red that way (#148), and release.yaml runs -race too — so the same race could
+# fail the release job AFTER the tag was pushed.
+#
+# It roughly doubles wall-clock. That is the price of the local gate matching the
+# real one; anyone who wants a fast path should add an explicit skip flag rather
+# than let the default quietly differ from CI again.
+say "go test -race ./..."
+# shellcheck disable=SC2086
+env $strip_env go test -race ./... || { say "FAIL: go test -race"; exit 1; }
+
 say "cd conformance && go test ./..."
 # shellcheck disable=SC2086
 (cd conformance && env $strip_env go test ./...) || { say "FAIL: conformance go test"; exit 1; }


### PR DESCRIPTION
Closes #153.

`tools/test.sh` is the ritual every lane is told to run before pushing, and it did not run `go test -race` — which both `ci.yaml` and `release.yaml` do. The local gate was strictly weaker than the gate judging the push, and weaker in exactly the class that is invisible locally and intermittent on a loaded runner.

It has already cost a red that way (#148: a new test drove the real `runWrapper`, whose goroutines outlive it and read the package-global `os.Stdin` another test writes — `test.sh` green, ubuntu's `-race` job red). The worse version of that miss is reachable: `release.yaml` runs `-race` too, so the same race can fail the release job **after** the tag is pushed.

## Placement

After the plain `go test`, before conformance — mirroring `ci.yaml`'s order exactly, so the two read side by side. Conformance gets no `-race` here because CI gives it none.

## Two judgement calls, both recorded at the line

- **The cost is written down**: `-race` roughly doubles wall-clock. Better as a sentence at the call site than as something the next person rediscovers by waiting.
- **No skip flag**, deliberately. The issue floated one as a conditional ("if someone wants a fast path"). A default that differs from CI is the thing this change removes, so adding an opt-out in the same commit would reintroduce it as an option. If the fast path is wanted later it should be an explicit flag — a divergence you type, not one you inherit.

## Verification

`shellcheck -s sh tools/test.sh` clean, and the full ritual run end to end: PASS.

## Not folded in — a candidate follow-up

This fixes today's divergence and leaves tomorrow's undetected: nothing checks that `tools/test.sh` and `ci.yaml` agree, and nothing noticed for however long they did not. A small test that parses both and asserts every `go test` invocation in CI's build job has a counterpart in the ritual would close the class rather than the instance — the same shape as #148's one-way import check, which is enforced by parsing the package rather than by convention.

I left it out because this item was scoped as trivial and because placing such a test means picking a home for repo-hygiene checks, which there is no precedent for yet. Worth a decision rather than an inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
