### PR TITLE
hub join: regenerate a missing .pub instead of looping on it

### DIFF
--- a/internal/cli/hub_key_missing_pub_test.go
+++ b/internal/cli/hub_key_missing_pub_test.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Issue #166, the sixth transition in A2's staged-rotation recovery set.
+//
+// ssh-keygen writes the private file and then the public one, and mintHubKey
+// fsyncs the keys dir only after both — so an interruption in that window is a
+// real on-disk state: the version's private half present, its `.pub` absent.
+// prepareHubKey adopted the orphan (correct: the hub may already have authorized
+// it), the join then died at readHubPublicKey, and a plain re-run returned
+// cleanly with the identical broken state. The obvious operator action looped
+// forever, and nothing in the error named `--rotate-key` as the escape.
+//
+// The repair was already in the same file: checkHubKeyPassphraseFree runs
+// `ssh-keygen -y`, whose stdout IS the public key derived from the private one,
+// and threw that stdout away. Regenerating is also the only SAFE repair —
+// minting a replacement would strand a credential the hub may already have
+// authorized and present a different one, the failure family #165 is about.
+
+func TestHubKeyRecoveryRegeneratesAMissingPublicHalf(t *testing.T) {
+	dir, keysDir := newHubKeyDir(t)
+	if _, _, err := prepareHubKey(dir, "codex-tiny"); err != nil {
+		t.Fatal(err)
+	}
+	active := filepath.Join(keysDir, "codex-tiny_ed25519")
+	original := readKeyFile(t, active+".v1.pub")
+
+	// The crash state: private half survives, public half never landed, and the
+	// active symlink was not written either.
+	if err := os.Remove(active + ".v1.pub"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(active); err != nil {
+		t.Fatal(err)
+	}
+
+	state, minted, err := prepareHubKey(dir, "codex-tiny")
+	if err != nil {
+		t.Fatalf("recovery failed instead of converging: %v", err)
+	}
+	if minted {
+		t.Fatal("recovery MINTED over a key whose private half was intact; the hub may already have authorized it")
+	}
+	if state.Active.Number != 1 {
+		t.Fatalf("adopted version = v%d, want v1", state.Active.Number)
+	}
+	// Regenerated, and regenerated CORRECTLY — a .pub that exists but describes
+	// a different key would authorize the wrong credential, which is worse than
+	// the missing file.
+	if got := readKeyFile(t, active+".v1.pub"); got != original {
+		t.Fatalf("regenerated public half does not match the private one:\n want=%s\n  got=%s", original, got)
+	}
+	// The convergence claim, stated as the thing the join actually does: this is
+	// the call that used to fail and send the operator back into the loop.
+	pub, err := readHubPublicKey(state.Active)
+	if err != nil {
+		t.Fatalf("the join still cannot read the public key after recovery: %v", err)
+	}
+	// readKeyFile returns the base64 body; readHubPublicKey returns the whole
+	// line. Compare on the body, which is the part that decides which key the
+	// hub authorizes.
+	if !strings.Contains(pub, original) {
+		t.Fatalf("readHubPublicKey returned %q, which does not carry the original key body %q", pub, original)
+	}
+	if versions := countKeyVersions(t, keysDir, "codex-tiny"); versions != 1 {
+		t.Fatalf("recovery left %d versions, want 1", versions)
+	}
+}
+
+// The same missing file reached by the other path: the active symlink is intact,
+// so prepareHubKey never enters the adopt branch. Without this row a repair
+// placed only in the orphan branch looks complete and leaves the commoner state
+// — crash after the symlink, .pub still missing — looping exactly as before.
+func TestHubKeyRegeneratesAMissingPublicHalfWithTheSymlinkIntact(t *testing.T) {
+	dir, keysDir := newHubKeyDir(t)
+	if _, _, err := prepareHubKey(dir, "codex-tiny"); err != nil {
+		t.Fatal(err)
+	}
+	active := filepath.Join(keysDir, "codex-tiny_ed25519")
+	original := readKeyFile(t, active+".v1.pub")
+	if err := os.Remove(active + ".v1.pub"); err != nil {
+		t.Fatal(err)
+	}
+
+	state, _, err := prepareHubKey(dir, "codex-tiny")
+	if err != nil {
+		t.Fatalf("recovery failed instead of converging: %v", err)
+	}
+	if got := readKeyFile(t, active+".v1.pub"); got != original {
+		t.Fatalf("public half not regenerated on the symlink-intact path:\n want=%s\n  got=%s", original, got)
+	}
+	if _, err := readHubPublicKey(state.Active); err != nil {
+		t.Fatalf("readHubPublicKey still fails: %v", err)
+	}
+}
+
+// A .pub that is already there must be left exactly alone. Rewriting it on every
+// join would be a write nobody asked for on the credential path, and it would
+// hide a real mismatch by overwriting the evidence.
+func TestHubKeyLeavesAnExistingPublicHalfUntouched(t *testing.T) {
+	dir, keysDir := newHubKeyDir(t)
+	if _, _, err := prepareHubKey(dir, "codex-tiny"); err != nil {
+		t.Fatal(err)
+	}
+	pubPath := filepath.Join(keysDir, "codex-tiny_ed25519.v1.pub")
+	// A comment field ssh-keygen -y would NOT reproduce: if the file is rewritten
+	// this is what disappears.
+	raw, err := os.ReadFile(pubPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	marked := strings.TrimSpace(string(raw)) + " operator-added-comment\n"
+	if err := os.WriteFile(pubPath, []byte(marked), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := prepareHubKey(dir, "codex-tiny"); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(pubPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(after); got != marked {
+		t.Fatalf("an existing public half was rewritten:\n want=%s\n  got=%s", marked, got)
+	}
+}
+
+// grok's #167 sweep, folded in: mintHubKey returned a hubKeyVersion naming a
+// .pub it never checked for. Same class as the rest of this file — a command
+// exits zero and the caller reads that as "both files are there".
+func TestMintHubKeyRefusesToClaimAPublicHalfItCannotSee(t *testing.T) {
+	_, keysDir := newHubKeyDir(t)
+	original := runHubSSHKeygen
+	t.Cleanup(func() { runHubSSHKeygen = original })
+	// A keygen that writes the private half and exits 0 without the public one:
+	// the interrupted-mint state, made deterministic.
+	runHubSSHKeygen = func(args ...string) ([]byte, error) {
+		path := ""
+		for i, arg := range args {
+			if arg == "-f" && i+1 < len(args) {
+				path = args[i+1]
+			}
+		}
+		if path == "" {
+			t.Fatalf("keygen invoked without -f: %v", args)
+		}
+		if err := os.WriteFile(path, []byte("PRIVATE"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return nil, nil
+	}
+
+	_, err := mintHubKey(keysDir, "codex-tiny", 1)
+	if err == nil {
+		t.Fatal("mintHubKey reported success for a key whose public half was never written")
+	}
+	if !strings.Contains(err.Error(), ".pub") {
+		t.Fatalf("the error does not name what is missing: %v", err)
+	}
+}
+
+func newHubKeyDir(t *testing.T) (dir, keysDir string) {
+	t.Helper()
+	dir = t.TempDir()
+	keysDir = filepath.Join(dir, "keys")
+	if err := os.MkdirAll(keysDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return dir, keysDir
+}

--- a/internal/cli/hub_keys.go
+++ b/internal/cli/hub_keys.go
@@ -51,6 +51,13 @@ func prepareHubKey(remoteDir, agentID string) (hubKeyState, bool, error) {
 		if len(versions) > 0 {
 			newest := versions[len(versions)-1]
 			if err := checkHubKeyPassphraseFree(newest.Private); err == nil {
+				// #166: the adopted version may be missing its public half —
+				// that is the state an interrupted mint leaves. Repair before
+				// the join reaches readHubPublicKey, or a re-run converges to
+				// the same failure and the operator loops.
+				if err := ensureHubKeyPublic(keysDir, newest); err != nil {
+					return hubKeyState{}, false, err
+				}
 				if err := os.Symlink(filepath.Base(newest.Private), base); err != nil {
 					return hubKeyState{}, false, err
 				}
@@ -84,6 +91,12 @@ func prepareHubKey(remoteDir, agentID string) (hubKeyState, bool, error) {
 	}
 	if err := checkHubKeyPassphraseFree(state.Active.Private); err != nil {
 		return hubKeyState{}, false, fmt.Errorf("hub join: active key %s is corrupt or passphrase-protected; remove the passphrase or re-run with --rotate-key", displayHomePath(state.Active.Private))
+	}
+	// The commoner half of #166: the symlink landed, the public half did not.
+	// This branch never enters the adopt path above, so repairing only there
+	// would look complete and leave this state looping exactly as before.
+	if err := ensureHubKeyPublic(keysDir, state.Active); err != nil {
+		return hubKeyState{}, false, err
 	}
 	return state, false, nil
 }
@@ -167,18 +180,108 @@ func mintHubKey(keysDir, agentID string, number int) (hubKeyVersion, error) {
 	if err != nil {
 		return hubKeyVersion{}, fmt.Errorf("ssh-keygen: %w: %s", err, strings.TrimSpace(string(out)))
 	}
+	// #167: this returned a hubKeyVersion naming a `.pub` it never looked for,
+	// so a keygen that exited 0 without writing it was reported as a complete
+	// mint — the same read-a-zero-exit-as-success shape as the rest of that
+	// sweep, and the state #166 then had to recover from.
+	public := private + ".pub"
+	if _, err := os.Stat(public); err != nil {
+		return hubKeyVersion{}, fmt.Errorf("hub join: ssh-keygen exited 0 but %s is not there: %w", displayHomePath(public), err)
+	}
 	if err := fsyncHubDir(keysDir); err != nil {
 		return hubKeyVersion{}, err
 	}
-	return hubKeyVersion{Number: number, Private: private, Public: private + ".pub"}, nil
+	return hubKeyVersion{Number: number, Private: private, Public: public}, nil
 }
 
 func checkHubKeyPassphraseFree(path string) error {
+	_, err := hubKeyPublicFromPrivate(path)
+	return err
+}
+
+// hubKeyPublicFromPrivate derives the public half from the private one and
+// returns it. `ssh-keygen -y` prints exactly the contents of the `.pub` file,
+// which is why the probe doubles as the repair (#166): the caller that used to
+// fail on a missing `.pub` already had the material to write one.
+//
+// It stays the passphrase probe too, because -y is what fails on an encrypted
+// key. Only the discarded stdout is new (#167): the previous version read a
+// zero exit as "not passphrase-protected" and threw away the answer it had
+// asked for.
+func hubKeyPublicFromPrivate(path string) (string, error) {
 	out, err := runHubSSHKeygen("-y", "-P", "", "-f", path)
 	if err != nil {
-		return fmt.Errorf("ssh-keygen key probe: %w: %s", err, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("ssh-keygen key probe: %w: %s", err, strings.TrimSpace(string(out)))
 	}
-	return nil
+	derived := strings.TrimSpace(string(out))
+	if derived == "" {
+		return "", fmt.Errorf("ssh-keygen printed no public key for %s", displayHomePath(path))
+	}
+	return derived, nil
+}
+
+// ensureHubKeyPublic writes the `.pub` half back when it is missing, deriving it
+// from the private key rather than minting a replacement.
+//
+// #166: ssh-keygen writes the private file and then the public one, so an
+// interrupted mint leaves a valid private key with no `.pub`. prepareHubKey
+// adopted it — correctly, since the hub may already have authorized it — and the
+// join then died reading the file that was never written. A plain re-run
+// reproduced the same state, so the obvious operator action looped forever.
+//
+// Regenerating is the only safe repair. Minting a replacement would strand a
+// credential the hub may already have authorized and present a different one,
+// which is the failure family #165 is about.
+//
+// A `.pub` that EXISTS is never touched: rewriting it would be an unrequested
+// write on the credential path, and it would overwrite the evidence of a real
+// mismatch instead of leaving it to be seen. Any stat error other than
+// not-exist is returned rather than treated as absence — an unreadable file is
+// not a missing one.
+func ensureHubKeyPublic(keysDir string, version hubKeyVersion) error {
+	if _, err := os.Stat(version.Public); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	derived, err := hubKeyPublicFromPrivate(version.Private)
+	if err != nil {
+		return err
+	}
+	if err := writeHubKeyPublic(version.Public, derived); err != nil {
+		return err
+	}
+	return fsyncHubDir(keysDir)
+}
+
+// writeHubKeyPublic writes through a temp file in the same directory and
+// renames, so a second interruption cannot leave a half-written `.pub` — the
+// exact shape of the state being repaired. 0644 matches what ssh-keygen writes:
+// a public key is public, and a mode nothing else uses invites a later
+// permission check to disagree with reality.
+func writeHubKeyPublic(path, contents string) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".pub.tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.WriteString(contents + "\n"); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func readHubPublicKey(version hubKeyVersion) (string, error) {


### PR DESCRIPTION
Closes #166. Disposition 1 from the issue — regenerate — plus the `mintHubKey` instance from grok's #167 sweep, folded in as agreed: same class, same file.

## The loop

`ssh-keygen` writes the private file and then the public one, and `mintHubKey` fsynced the keys dir only after both. An interruption in that window is a real on-disk state: the version's private half present, its `.pub` absent.

`prepareHubKey` adopts the orphan — correctly, since the hub may already have authorized it — the join then dies at `readHubPublicKey`, and **a plain re-run returns cleanly with the identical broken state**. The obvious operator action loops forever, and nothing in the error names `--rotate-key` as the escape.

## The repair was already in the file, being discarded

`checkHubKeyPassphraseFree` runs `ssh-keygen -y`, whose stdout **is** the public key derived from the private one, and threw it away except on error. It now returns that output, and `ensureHubKeyPublic` writes it back when the file is missing.

Regenerating rather than minting is the safe half: a replacement key would strand a credential the hub may already have authorized and present a different one — the failure family #165 is about.

## Both paths, and that is the part a single-site fix gets wrong

The adopt-orphan branch is the one the issue describes. The **active-symlink** branch never enters it, so repairing only the first would look complete while leaving the commoner state — symlink landed, `.pub` did not — looping exactly as before. That is a row, not a comment.

## Three properties, each mutation-red

- An existing `.pub` is **never** rewritten: an unrequested write on the credential path, and it would overwrite the evidence of a real mismatch rather than leave it to be seen.
- A stat error that is not not-exist is returned, not read as absence. An unreadable file is not a missing one.
- The write goes through a temp file and a rename, so a second interruption cannot leave a half-written `.pub` — the exact shape being repaired.

## The #167 fold

`mintHubKey` returned a `hubKeyVersion` naming a `.pub` it never looked for, so a keygen that exited 0 without writing one was reported as a complete mint. That is the read-a-zero-exit-as-success shape the sweep is about — and the state #166 then had to recover from. It now stats the file it claims, and says which one is missing.

## Verification

`tools/test.sh`, and the full `integration/sshd` suite under `-race` (104s) — it drives real joins through this key path, so it is where a regression here would surface. Five mutations red under a CI-like stripped PATH: drop the repair on either path, always rewrite the `.pub`, let mint claim an unseen file, and derive the public half from the wrong file.

## One note on test coverage

The issue asks that recovery converge "to a state the rotation can still finish from, not merely one that does not error". The rows assert the adopted version, the regenerated body matching the private key, that `readHubPublicKey` — the call that used to fail — now succeeds, and that no second version was created. What they do not do is drive a full rotation afterwards; the existing staged-rotation rows cover that path from a healthy state, and joining the two would be a larger change than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
