### PR TITLE
fail closed on unreadable state, in the three places that failed open

### DIFF
--- a/internal/cli/setup_wipe.go
+++ b/internal/cli/setup_wipe.go
@@ -514,25 +514,41 @@ func recreateWipeDirs(loopDir string) error {
 }
 
 // rescanWipeLeftovers re-scans for runtime entries that REappeared after the
-// wipe — evidence that a process recreated state mid-wipe. Returns the offending
-// relative paths (empty == clean).
-func rescanWipeLeftovers(loopDir string) []string {
-	var leftovers []string
-	for _, name := range []string{"inbox", "archive", "malformed", "live"} {
-		entries, _ := os.ReadDir(filepath.Join(loopDir, name))
+// wipe — evidence that a process recreated state mid-wipe.
+//
+// It returns two lists, and the second one is the point. Leftovers are what it
+// SAW; unverifiable are the directories it could not read. Those were previously
+// one list, because the ReadDir errors were discarded — so a directory that
+// could not be read contributed nothing and the post-wipe check reported CLEAN.
+// "I looked and found nothing" and "I could not look" are opposite answers to
+// the question being asked, and the caller was given the reassuring one.
+func rescanWipeLeftovers(loopDir string) (leftovers, unverifiable []string) {
+	scan := func(name string, keep func(entry string) bool) {
+		entries, err := os.ReadDir(filepath.Join(loopDir, name))
+		if err != nil {
+			// Not-exist is NOT excused here, unlike in the pre-wipe scan: the
+			// wipe recreates these directories immediately before this runs, so
+			// one missing now means something removed it mid-wipe — which is
+			// exactly the condition this rescan exists to detect.
+			unverifiable = append(unverifiable, fmt.Sprintf("%s (%v)", name, err))
+			return
+		}
 		for _, e := range entries {
+			if keep != nil && !keep(e.Name()) {
+				continue
+			}
 			leftovers = append(leftovers, filepath.Join(name, e.Name()))
 		}
 	}
-	stateEntries, _ := os.ReadDir(filepath.Join(loopDir, "state"))
-	for _, e := range stateEntries {
-		if e.Name() == "setup.json" || e.Name() == "pool.id" {
-			continue
-		}
-		leftovers = append(leftovers, filepath.Join("state", e.Name()))
+	for _, name := range []string{"inbox", "archive", "malformed", "live"} {
+		scan(name, nil)
 	}
+	scan("state", func(entry string) bool {
+		return entry != "setup.json" && entry != "pool.id"
+	})
 	sort.Strings(leftovers)
-	return leftovers
+	sort.Strings(unverifiable)
+	return leftovers, unverifiable
 }
 
 // ---------- live-bus refusal ----------
@@ -614,7 +630,17 @@ func scanWipeLiveSignals(cfg *loop.Config, agentIDs []string) []string {
 // one would — mirroring the ambiguous-process fail-closed discipline above.
 func scanWipeServeClaims(cfg *loop.Config, localHost string, now time.Time) []string {
 	var out []string
-	entries, _ := os.ReadDir(filepath.Join(cfg.LoopDir, "state"))
+	stateDir := filepath.Join(cfg.LoopDir, "state")
+	entries, err := os.ReadDir(stateDir)
+	if err != nil && !os.IsNotExist(err) {
+		// The directory this function reads its evidence from could not be read,
+		// and the error was being discarded — so an unreadable state/ produced an
+		// empty entry list, which is indistinguishable here from "no claims at
+		// all", and the wipe proceeded. The doc above already promises an
+		// unreadable CLAIM fails closed; an unreadable claim DIRECTORY is the
+		// same argument one level up, and it was the one case that failed open.
+		return append(out, fmt.Sprintf("serve-claim directory %s is unreadable (%v); refusing (fail closed) — a live serve cannot be ruled out", displayHomePath(stateDir), err))
+	}
 	for _, e := range entries {
 		if !e.IsDir() {
 			continue
@@ -797,8 +823,14 @@ var setupRunWipeState = func(root string, cfg *loop.Config, wrappers []string, o
 	if err := recreateWipeDirs(cfg.LoopDir); err != nil {
 		return fmt.Errorf("wipe-state: %w", err)
 	}
-	if leftovers := rescanWipeLeftovers(cfg.LoopDir); len(leftovers) > 0 {
+	leftovers, unverifiable := rescanWipeLeftovers(cfg.LoopDir)
+	if len(leftovers) > 0 {
 		return fmt.Errorf("wipe-state: runtime files reappeared during the wipe (a live process may be writing): %s", strings.Join(leftovers, ", "))
+	}
+	// Reported separately and never folded into "clean": this is the check
+	// saying it could not answer, which is not the same as answering no.
+	if len(unverifiable) > 0 {
+		return fmt.Errorf("wipe-state: the post-wipe check could not read %s, so it cannot confirm nothing reappeared; resolve the directory permissions and re-run", strings.Join(unverifiable, ", "))
 	}
 
 	// Apply the guarded clean-all removals (re-checks every guard before each

--- a/internal/cli/setup_wipe_test.go
+++ b/internal/cli/setup_wipe_test.go
@@ -182,8 +182,8 @@ func TestComputeAndExecuteWipePreservesScaffold(t *testing.T) {
 	for _, sub := range []string{"inbox", "archive", "malformed", "live", "agents", "state"} {
 		mustExist(t, filepath.Join(cfg.LoopDir, sub))
 	}
-	if leftovers := rescanWipeLeftovers(cfg.LoopDir); len(leftovers) != 0 {
-		t.Fatalf("post-wipe leftovers: %v", leftovers)
+	if leftovers, unverifiable := rescanWipeLeftovers(cfg.LoopDir); len(leftovers) != 0 || len(unverifiable) != 0 {
+		t.Fatalf("post-wipe leftovers=%v unverifiable=%v", leftovers, unverifiable)
 	}
 }
 
@@ -230,8 +230,8 @@ func TestWipeStatePreservesPoolIdentity(t *testing.T) {
 	}
 	mustExist(t, poolID)
 	mustNotExist(t, filepath.Join(cfg.LoopDir, "state", "codex"))
-	if leftovers := rescanWipeLeftovers(cfg.LoopDir); len(leftovers) != 0 {
-		t.Fatalf("post-wipe leftovers: %v", leftovers)
+	if leftovers, unverifiable := rescanWipeLeftovers(cfg.LoopDir); len(leftovers) != 0 || len(unverifiable) != 0 {
+		t.Fatalf("post-wipe leftovers=%v unverifiable=%v", leftovers, unverifiable)
 	}
 	if _, _, actual, err := validateHubPool(root, "9c4e12ab77f0", "codex"); err != nil || actual != "9c4e12ab77f0" {
 		t.Fatalf("hub session pool validation after wipe = %q, %v", actual, err)

--- a/internal/cli/setup_wipe_unreadable_test.go
+++ b/internal/cli/setup_wipe_unreadable_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// grok's #167 sweep, category 1: an absent or unreadable thing reported as a
+// satisfied condition. Both rows here are the same shape — a directory the
+// scanner could not read contributed nothing, and contributing nothing is how
+// this code spells "all clear".
+//
+// The wipe is the worst place for that shape. Its whole job is to refuse when it
+// cannot prove the pool is idle, and it advertises exactly that discipline in
+// its own comments for unreadable CLAIMS. The directory holding them was the one
+// case that failed open.
+
+func TestWipeRefusesWhenTheServeClaimDirectoryIsUnreadable(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads a 0000 directory regardless of mode")
+	}
+	_, cfg := newWipeTestRepo(t)
+	stateDir := filepath.Join(cfg.LoopDir, "state")
+	// A live serve's claim is in there. The scanner is about to be unable to see
+	// it — which must produce a refusal, not silence.
+	mustWrite(t, filepath.Join(stateDir, "codex", "serve.claim"), []byte("{}"))
+	if err := os.Chmod(stateDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o700) })
+
+	reasons := scanWipeServeClaims(cfg, "localhost", time.Now().UTC())
+	if len(reasons) == 0 {
+		t.Fatal("an unreadable serve-claim directory produced no refusal; the wipe would have proceeded with a live claim it could not see")
+	}
+	joined := strings.Join(reasons, "; ")
+	if !strings.Contains(joined, "unreadable") {
+		t.Fatalf("the refusal does not say what went wrong: %s", joined)
+	}
+	// It must name the directory, or an operator cannot act on it.
+	if !strings.Contains(joined, "state") {
+		t.Fatalf("the refusal does not name the directory: %s", joined)
+	}
+}
+
+// The control: a pool with no state directory at all has genuinely no claims,
+// and must NOT be refused. Without this the row above is satisfied by a scanner
+// that refuses everything, which would block every first-time wipe.
+func TestWipeDoesNotRefuseWhenThereIsSimplyNoStateDirectory(t *testing.T) {
+	_, cfg := newWipeTestRepo(t)
+	if err := os.RemoveAll(filepath.Join(cfg.LoopDir, "state")); err != nil {
+		t.Fatal(err)
+	}
+	if reasons := scanWipeServeClaims(cfg, "localhost", time.Now().UTC()); len(reasons) != 0 {
+		t.Fatalf("a pool with no state directory was refused: %v", reasons)
+	}
+}
+
+// The post-wipe rescan asks "did anything reappear?". "I looked and found
+// nothing" and "I could not look" are opposite answers, and the caller was being
+// handed the reassuring one whenever a directory could not be read.
+func TestPostWipeRescanReportsWhatItCouldNotRead(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads a 0000 directory regardless of mode")
+	}
+	_, cfg := newWipeTestRepo(t)
+	inbox := filepath.Join(cfg.LoopDir, "inbox")
+	if err := os.Chmod(inbox, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(inbox, 0o700) })
+
+	leftovers, unverifiable := rescanWipeLeftovers(cfg.LoopDir)
+	if len(unverifiable) == 0 {
+		t.Fatal("an unreadable runtime directory was reported as clean")
+	}
+	if !strings.Contains(strings.Join(unverifiable, "; "), "inbox") {
+		t.Fatalf("the unverifiable list does not name the directory: %v", unverifiable)
+	}
+	// And it must not be quietly folded in with real leftovers: they mean
+	// different things and lead to different actions.
+	for _, l := range leftovers {
+		if strings.HasPrefix(l, "inbox") {
+			t.Fatalf("an unreadable directory was reported as a leftover: %v", leftovers)
+		}
+	}
+}
+
+// A directory that is simply GONE after the wipe is also unverifiable, not
+// clean. The wipe recreates these immediately before the rescan, so one missing
+// here means something removed it mid-wipe — the exact condition the rescan
+// exists to catch, and the one an excused not-exist would hide.
+func TestPostWipeRescanTreatsAMissingDirectoryAsUnverifiable(t *testing.T) {
+	_, cfg := newWipeTestRepo(t)
+	if err := os.RemoveAll(filepath.Join(cfg.LoopDir, "live")); err != nil {
+		t.Fatal(err)
+	}
+	_, unverifiable := rescanWipeLeftovers(cfg.LoopDir)
+	if !strings.Contains(strings.Join(unverifiable, "; "), "live") {
+		t.Fatalf("a directory removed mid-wipe was not reported: %v", unverifiable)
+	}
+}

--- a/internal/loop/lease.go
+++ b/internal/loop/lease.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -152,11 +153,28 @@ func marshalClaim(c *ServeClaim) ([]byte, error) {
 // closing this external-exclusion gap — so unifying the two paths costs one
 // extra (uncontended, cheap) lock acquisition on the common case and changes
 // no observable behavior otherwise.
+// leaseHostname is os.Hostname behind a seam, so the failure path can be driven
+// by a row. Production never reassigns it.
+var leaseHostname = os.Hostname
+
 func AcquireServeLease(cfg *Config, id string) (*ServeLease, error) {
 	if err := ValidateAgentID(id); err != nil {
 		return nil, err
 	}
-	host, _ := os.Hostname()
+	host, err := leaseHostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		// The claim records this host, and the liveness rules read it back: a
+		// STALE claim whose pid is still alive is kept only when it belongs to
+		// THIS host, because a pid on another machine says nothing about ours.
+		// With the error discarded, host became "" — which matches no real
+		// hostname, so a frozen-but-alive lane on this very machine looked
+		// cross-host and its id was stolen out from under it. Writing "" also
+		// poisons the record for every later acquirer.
+		//
+		// There is no safe default here: an unknown host cannot be compared,
+		// only guessed at. Fail the acquire.
+		return nil, fmt.Errorf("acquire serve lease %s: cannot determine this host's name (%v); the serve claim records it and the liveness rules compare it", id, err)
+	}
 	token, err := mintServeToken()
 	if err != nil {
 		return nil, err
@@ -251,7 +269,14 @@ func AcquireServeLease(cfg *Config, id string) (*ServeLease, error) {
 		// A differing, non-empty per-boot reference proves the recorded process
 		// belonged to a prior boot even when its pid has since been recycled. An
 		// absent or matching reference preserves the pid-only fail-closed rule.
-		if existing.Host == host && pidAlive(existing.PID) &&
+		//
+		// An EMPTY recorded host is treated as "cannot prove it is elsewhere",
+		// not as "elsewhere". Claims written by a binary that discarded the
+		// os.Hostname error carry "", and reading that as a foreign host is what
+		// let a live lane be stolen; the whole point of this guard is that it
+		// refuses when it cannot prove the process is dead.
+		if pidAlive(existing.PID) &&
+			(existing.Host == "" || existing.Host == host) &&
 			(existing.BootRef == "" || bootRef == "" || existing.BootRef == bootRef) {
 			return ErrLeaseHeld
 		}

--- a/internal/loop/lease_unknown_host_test.go
+++ b/internal/loop/lease_unknown_host_test.go
@@ -1,0 +1,92 @@
+package loop
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// grok's #167 sweep, category 1: "an absent or unreadable thing reported as a
+// satisfied condition". Here the thing is this machine's own name.
+//
+// AcquireServeLease discarded the os.Hostname error, so host became "". The
+// claim records the host and the liveness rules read it back: a STALE claim
+// whose pid is still alive is kept only when it belongs to THIS host, because a
+// pid on another machine says nothing about ours. With host = "", a
+// frozen-but-alive lane on this very machine looked cross-host — and its id was
+// stolen out from under it. The empty value also poisons the record for every
+// later acquirer.
+
+func TestAcquireServeLeaseRefusesWhenTheHostIsUnknown(t *testing.T) {
+	cfg := newTestPool(t)
+	prev := leaseHostname
+	leaseHostname = func() (string, error) { return "", errors.New("hostname unavailable") }
+	t.Cleanup(func() { leaseHostname = prev })
+
+	lease, err := AcquireServeLease(cfg, "alice")
+	if err == nil {
+		t.Fatal("acquired a lease without being able to name this host; the claim it writes would be unusable evidence")
+	}
+	if lease != nil {
+		t.Fatal("returned a lease alongside an error")
+	}
+	if !strings.Contains(err.Error(), "host") {
+		t.Fatalf("the error does not say what could not be determined: %v", err)
+	}
+	// Nothing may be left behind: a claim carrying an empty host is exactly the
+	// record that breaks the next acquirer's comparison.
+	if _, statErr := os.Stat(claimPath(cfg, "alice")); statErr == nil {
+		t.Fatal("a claim was written despite the refusal")
+	}
+	// An empty name with no error is the same problem wearing a success.
+	leaseHostname = func() (string, error) { return "   ", nil }
+	if _, err := AcquireServeLease(cfg, "alice"); err == nil {
+		t.Fatal("a blank hostname with no error was accepted")
+	}
+}
+
+// The other half, and the one that matters for pools that already exist: claims
+// written by a binary that discarded the error carry Host:"". Reading that as a
+// FOREIGN host is what steals a live lane, so an empty recorded host must mean
+// "cannot prove it is elsewhere", not "elsewhere".
+func TestStaleClaimWithAnUnknownHostIsNotStolenFromALivePID(t *testing.T) {
+	cfg := newTestPool(t)
+	withPidAlive(t, func(int) bool { return true })
+	stale := time.Now().UTC().Add(-24 * time.Hour)
+	writeClaim(t, cfg, &ServeClaim{
+		ID:         "alice",
+		Host:       "", // what the discarded-error path wrote
+		PID:        os.Getpid(),
+		ServeToken: "tok-old",
+		StartedAt:  stale,
+		LastSeen:   stale,
+	})
+
+	if _, err := AcquireServeLease(cfg, "alice"); !errors.Is(err, ErrLeaseHeld) {
+		t.Fatalf("acquire over a stale claim with an unknown host and a LIVE pid = %v, want ErrLeaseHeld", err)
+	}
+
+	// The control, or the row above would also pass for an implementation that
+	// simply never steals: a stale claim from a genuinely different host, whose
+	// pid means nothing here, must still be reclaimable.
+	writeClaim(t, cfg, &ServeClaim{
+		ID:         "alice",
+		Host:       "some-other-machine",
+		PID:        os.Getpid(),
+		ServeToken: "tok-old",
+		StartedAt:  stale,
+		LastSeen:   stale,
+	})
+	if _, err := AcquireServeLease(cfg, "alice"); err != nil {
+		t.Fatalf("a stale claim from another host must be reclaimable: %v", err)
+	}
+}
+
+func newTestPool(t *testing.T) *Config {
+	t.Helper()
+	root := t.TempDir()
+	return &Config{ControlRepo: root, LoopDir: filepath.Join(root, ".agentchute", "loop"), Vendor: "agentchute"}
+}


### PR DESCRIPTION
grok's #167 sweep, category 1 — the three "fail-closed on unreadable" items, as one change. All three are the same shape: **a directory or lookup that could not be read contributed nothing, and contributing nothing is how this code spells "all clear".**

## 1. `scanWipeServeClaims` — the serve-claim directory

The `os.ReadDir` error was discarded, so an unreadable `state/` produced an empty entry list, which is indistinguishable there from "no claims at all". The wipe proceeded.

The function's own comment already promises an unreadable **claim** fails closed. An unreadable claim **directory** is that argument one level up, and it was the one case that failed open.

A genuinely absent `state/` is still fine — that is a row, not a footnote, or the fix would refuse every first-time wipe.

## 2. `rescanWipeLeftovers` — the post-wipe check

It asks "did anything reappear?" and discarded its `ReadDir` errors, so a directory it could not read reported **clean**. "I looked and found nothing" and "I could not look" are opposite answers to that question, and the caller was handed the reassuring one.

Now two lists and two messages. Not-exist is deliberately **not** excused here, unlike in the pre-wipe scan: the wipe recreates these directories immediately beforehand, so one missing means something removed it mid-wipe — the exact condition this rescan exists to catch.

## 3. `AcquireServeLease` — this machine's own name

The `os.Hostname` error was discarded and `host` became `""`. The claim records the host and the liveness rules read it back: a stale claim whose pid is still alive is kept only when it belongs to **this** host, because a pid on another machine says nothing about ours.

With `host == ""`, a frozen-but-alive lane on this very machine looked cross-host **and its id was stolen out from under it**. The empty value also poisons the record for every later acquirer.

The acquire now refuses. There is no safe default for an unknown host, only a guess. A blank name returned with no error is refused too — that is the same problem wearing a success.

**Second half, for pools that already exist**: claims written by the old path carry `Host:""`, and reading that as a *foreign* host is what does the stealing. An empty recorded host now means "cannot prove it is elsewhere". Its control row matters as much as the fix: a stale claim from a genuinely different host must still be reclaimable, or this trades a data race for a wedge.

## Rows and mutations

Seven rows; six mutations red under a CI-like stripped PATH, one per direction:

| mutation | caught by |
|---|---|
| restore the claim-directory fail-open | wipe refusal row |
| excuse a removed directory in the rescan | missing-directory row |
| fold unreadable into clean | rescan reporting row |
| discard the hostname error again | acquire-refusal row |
| read an empty host as foreign | not-stolen row |
| never steal at all | cross-host control row |

## Verification

`tools/test.sh` (now with `-race`), and the full `integration/sshd` suite under `-race` (114s) — it drives real serve leases, which is where the third fix would show a regression.

The two permission rows skip under root, since root reads a `0000` directory regardless of mode; that is a real limit of the fixture rather than a gap in the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
