### PR TITLE
reap: call a master reaped only when the socket is provably gone

### DIFF
--- a/internal/cli/hub_migrate.go
+++ b/internal/cli/hub_migrate.go
@@ -20,6 +20,12 @@ var hubDirNameRE = regexp.MustCompile(`^[0-9a-f]{12}$`)
 
 var hubMigrationReapMux = reapHubMigrationMux
 
+// hubMigrationReapOne is the per-agent reap behind a seam. A row swaps it to
+// drive the failure branch, which is otherwise only reachable by making a
+// process-wide ControlPath directory unreadable — a shared path that live lanes
+// on this machine use, so a test must not touch it.
+var hubMigrationReapOne = hubclient.ReapSSHMux
+
 func findHubMigrationCandidate(remote *loop.RemoteConfig, opts hubJoinOptions) (string, error) {
 	current, currentErr := hubclient.ReadHubConfig(remote.HubID)
 	currentExists := currentErr == nil
@@ -580,6 +586,18 @@ func writeHubMigrationConfig(path string, cfg *hubclient.HubConfig) error {
 	return os.Rename(tmpPath, path)
 }
 
+// reapHubMigrationMux closes any live one-shot master rooted in the OLD hub
+// directory before the migration moves it.
+//
+// It WARNS rather than failing the migration, and both halves of that are
+// deliberate. Warning, because a failed reap is not proof that anything is wrong
+// — and because the write-lock contract (§13.9a) is what actually keeps a live
+// lane and a migration apart: a migration takes both hub ids exclusively and
+// refuses while any holder lives, so this reap is cleanup, not the guard.
+// Reporting, because every error here was being discarded, so the one case that
+// matters — a master this process could not reach, which may still be alive and
+// still pinned to the old forced-command snapshot — looked exactly like the
+// common case of there being nothing to reap.
 func reapHubMigrationMux(cfg *hubclient.HubConfig, oldDir string) {
 	remote, err := loop.ParseRemoteURL(cfg.URL)
 	if err != nil || len(cfg.JoinedAs) == 0 {
@@ -588,6 +606,8 @@ func reapHubMigrationMux(cfg *hubclient.HubConfig, oldDir string) {
 	remote.HubDir = oldDir
 	for _, agentID := range cfg.JoinedAs {
 		keyPath := filepath.Join(oldDir, "keys", agentID+"_ed25519")
-		_ = hubclient.ReapSSHMux(remote, agentID, keyPath, oldDir)
+		if err := hubMigrationReapOne(remote, agentID, keyPath, oldDir); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: could not close the multiplex master for %s before the move (%v); if a connection to the old hub directory is still open it keeps the old forced-command snapshot until it ends\n", agentID, err)
+		}
 	}
 }

--- a/internal/cli/hub_migrate_reap_test.go
+++ b/internal/cli/hub_migrate_reap_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/agentchute/agentchute/internal/hubclient"
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// grok's #167 sweep: reapHubMigrationMux discarded every reap error with `_ =`,
+// so the one case that matters — a master this process could NOT reach, which
+// may still be alive and still pinned to the old forced-command snapshot —
+// looked exactly like the common case of there being nothing to reap.
+func TestMigrationReapReportsWhatItCouldNotClose(t *testing.T) {
+	original := hubMigrationReapOne
+	t.Cleanup(func() { hubMigrationReapOne = original })
+
+	t.Run("a failed reap is reported, naming the agent and the reason", func(t *testing.T) {
+		hubMigrationReapOne = func(*loop.RemoteConfig, string, string, string) error {
+			return errors.New("permission denied on the control socket")
+		}
+		stderr := captureStderr(t, func() {
+			reapHubMigrationMux(&hubclient.HubConfig{
+				URL:      "ssh://alex@hub44/srv/pool",
+				JoinedAs: []string{"codex-tiny"},
+			}, t.TempDir())
+		})
+		if !strings.Contains(stderr, "codex-tiny") {
+			t.Fatalf("the warning does not name the agent whose master survived:\n%s", stderr)
+		}
+		if !strings.Contains(stderr, "permission denied on the control socket") {
+			t.Fatalf("the warning does not carry the reason:\n%s", stderr)
+		}
+		// It must say what the surviving connection COSTS, or it reads as noise
+		// about an internal detail and gets ignored.
+		if !strings.Contains(stderr, "forced-command") {
+			t.Fatalf("the warning does not say what a surviving master means:\n%s", stderr)
+		}
+	})
+
+	// The control. A successful reap — including the common "there was no socket"
+	// case — must stay silent, or every migration prints a warning and operators
+	// learn to skip them.
+	t.Run("a successful reap says nothing", func(t *testing.T) {
+		hubMigrationReapOne = func(*loop.RemoteConfig, string, string, string) error { return nil }
+		stderr := captureStderr(t, func() {
+			reapHubMigrationMux(&hubclient.HubConfig{
+				URL:      "ssh://alex@hub44/srv/pool",
+				JoinedAs: []string{"codex-tiny"},
+			}, t.TempDir())
+		})
+		if strings.TrimSpace(stderr) != "" {
+			t.Fatalf("a clean reap printed a warning:\n%s", stderr)
+		}
+	})
+
+	// And a failure must NOT abort the migration: the write-lock contract is what
+	// keeps a live lane and a migration apart, and this reap is cleanup.
+	t.Run("a failed reap still reaps the remaining agents", func(t *testing.T) {
+		var seen []string
+		hubMigrationReapOne = func(_ *loop.RemoteConfig, agentID, _, _ string) error {
+			seen = append(seen, agentID)
+			return errors.New("boom")
+		}
+		_ = captureStderr(t, func() {
+			reapHubMigrationMux(&hubclient.HubConfig{
+				URL:      "ssh://alex@hub44/srv/pool",
+				JoinedAs: []string{"codex-tiny", "opus-high"},
+			}, t.TempDir())
+		})
+		if len(seen) != 2 {
+			t.Fatalf("reaped %v; a failure on the first agent stopped the rest", seen)
+		}
+	})
+}

--- a/internal/hubclient/mux_reap_test.go
+++ b/internal/hubclient/mux_reap_test.go
@@ -1,0 +1,68 @@
+package hubclient
+
+import "testing"
+
+// grok's #167 sweep: `ssh -O check`/`-O exit` exits non-zero for several
+// different reasons and the reap collapsed them into one condition.
+//
+// The four strings below are MEASURED from the same command, not guessed:
+// a missing socket, a socket in a directory this process cannot enter, a path
+// holding something that is not a socket, and a socket whose connect is refused.
+// Only the first proves no master is running, and only the first may be reported
+// as a successful reap.
+func TestMuxReapTreatsOnlyAnAbsentSocketAsReaped(t *testing.T) {
+	rows := []struct {
+		name     string
+		output   string
+		wantGone bool
+	}{
+		{
+			name:     "no socket there — the only proof of absence",
+			output:   "Control socket connect(/tmp/rp/a.sock): No such file or directory\n",
+			wantGone: true,
+		},
+		{
+			// The one that matters. A socket this process cannot reach may be a
+			// perfectly live master owned by another account; calling it reaped
+			// tells a rotation or migration the old connection is closed when it
+			// is not — which is how a stale forced-command snapshot survives.
+			name:   "permission denied — may be a LIVE master",
+			output: "Control socket connect(/tmp/rp/lk/x): Permission denied\n",
+		},
+		{
+			name:   "not a socket — proves nothing about a master",
+			output: "Control socket connect(/tmp/rp/plain): Socket operation on non-socket\n",
+		},
+		{
+			// Looks like proof and is not: a unix socket whose listen backlog is
+			// full refuses connects while its listener is alive, and a stale
+			// socket file from a crashed master gives the identical error.
+			name:   "connection refused — indistinguishable from a busy live master",
+			output: "Control socket connect(/tmp/rp/dead.sock): Connection refused\n",
+		},
+		{
+			// Not a connect failure at all: ssh rejected the path before trying.
+			name:   "path too long — never reached the socket",
+			output: "ControlPath too long ('/very/long/path' >= 104 bytes)\n",
+		},
+		{
+			name:   "unrelated failure",
+			output: "ssh: connect to host hub.example port 22: Connection timed out\n",
+		},
+	}
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			if got := muxSocketIsGone(row.output); got != row.wantGone {
+				t.Fatalf("muxSocketIsGone(%q) = %v, want %v", row.output, got, row.wantGone)
+			}
+		})
+	}
+}
+
+// Case-insensitively, because the test that this replaced lowercased its input
+// and the replacement must not quietly become stricter than measured output.
+func TestMuxReapMatchIsCaseInsensitive(t *testing.T) {
+	if !muxSocketIsGone("CONTROL SOCKET CONNECT(/tmp/x): NO SUCH FILE OR DIRECTORY") {
+		t.Fatal("an uppercase rendering of the absent-socket message was not recognised")
+	}
+}

--- a/internal/hubclient/ssh.go
+++ b/internal/hubclient/ssh.go
@@ -66,10 +66,38 @@ func ReapSSHMux(remote *loop.RemoteConfig, agentID, keyPath, stateDir string) er
 	}
 	args = append(args, remote.Destination())
 	out, err := exec.Command("ssh", args...).CombinedOutput()
-	if err == nil || strings.Contains(strings.ToLower(string(out)), "control socket connect") {
+	if err == nil || muxSocketIsGone(string(out)) {
 		return nil
 	}
 	return fmt.Errorf("reap SSH multiplex master: %w: %s", err, strings.TrimSpace(string(out)))
+}
+
+// muxSocketIsGone reports whether ssh failed because there was no socket to talk
+// to — the one outcome that PROVES no master is running.
+//
+// The previous test matched "control socket connect" anywhere in the output,
+// which is the prefix ssh prints for every connect failure, not just absence.
+// Measured, on the same command, ssh produces four:
+//
+//	Control socket connect(<path>): No such file or directory   — gone
+//	Control socket connect(<path>): Permission denied           — cannot tell
+//	Control socket connect(<path>): Socket operation on non-socket — cannot tell
+//	Control socket connect(<path>): Connection refused          — cannot tell
+//
+// Only the first proves absence. "Permission denied" is a socket this process
+// cannot reach, which may be a perfectly live master owned by another account —
+// reporting that as a successful reap tells a rotation or a migration that the
+// old connection is closed when it is not, which is the state the forced-command
+// snapshot outlives.
+//
+// "Connection refused" looks like proof and is not: a unix socket whose listen
+// backlog is full refuses connects while the listener is very much alive. A
+// stale socket file left by a crashed master gives the same error, so the two
+// are indistinguishable from here — and only one of them is safe to call reaped.
+func muxSocketIsGone(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "control socket connect") &&
+		strings.Contains(lower, "no such file or directory")
 }
 
 func BuildSSHInvocation(opts SSHBuildOptions) (SSHInvocation, error) {


### PR DESCRIPTION
grok's #167 sweep, the reap pair. Both halves are the same defect: "the command exited non-zero" was treated as one condition, and it is four.

## `ReapSSHMux`

It treated any output containing `control socket connect` as a successful reap. That is the prefix ssh prints for **every** connect failure, not just absence. Measured on the same command:

| ssh says | means |
|---|---|
| `Control socket connect(<path>): No such file or directory` | **gone** |
| `Control socket connect(<path>): Permission denied` | cannot tell |
| `Control socket connect(<path>): Socket operation on non-socket` | cannot tell |
| `Control socket connect(<path>): Connection refused` | cannot tell |

Only the first proves no master is running. `Permission denied` is a socket this process cannot reach, which may be a perfectly live master owned by another account — reporting it as reaped tells a rotation or migration that the old connection is closed when it is not, which is how a stale forced-command snapshot outlives the change meant to invalidate it.

**`Connection refused` looks like proof and is not**, which is why it is a row rather than a comment: a unix socket whose listen backlog is full refuses connects while its listener is alive, and a stale socket file from a crashed master gives the identical error. I nearly shipped it as a success on the argument that a refused connect proves nobody is listening; the backlog case is what makes that argument wrong.

## `reapHubMigrationMux`

It discarded every error with `_ =`, so the case that matters looked exactly like the common case of there being nothing to reap. It now warns per agent, names the reason, and says what a surviving master **costs** — a warning about an internal detail with no consequence attached is one operators learn to skip.

It **warns rather than failing the migration**, deliberately. The write-lock contract (§13.9a) is what keeps a live lane and a migration apart — the migration takes both hub ids exclusively and refuses while any holder lives. This reap is cleanup, not the guard, and aborting on it would add a refusal path with real false-positive risk. A failure on one agent must also not stop the rest; that is a row.

## Rows and mutations

Ten rows. Four mutations red under a CI-like stripped PATH: restore the broad match, drop case-insensitivity, discard the errors again, strip the consequence from the warning.

One seam added: `hubMigrationReapOne`. The failure branch is otherwise only reachable by making a process-wide ControlPath directory unreadable — a shared path that live lanes on this machine use, so a test must not touch it.

## Verification

`tools/test.sh`, and the full `integration/sshd` suite under `-race` (109s), which exercises the real reap path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)