### PR TITLE
pinning: a probe that could not run reports UNVERIFIED, not pinned

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -504,7 +504,7 @@ Wire frame: `{"t":"error","re":N,"code":"E_…","msg":"<human text>","retriable"
 
 The two arms are ordered and non-overlapping: the hub arm runs before `hello-ok` exists; the client arm only on a `hello-ok` the hub arm already let through.
 
-Client-side only (never on the wire): `E_CONNECT`, `E_UNAUTHORIZED`, `E_HOSTKEY_CHANGED`, `E_CHANNEL_LOST`, `E_SEND_UNKNOWN`, `E_HELLO_TIMEOUT`, `E_HUB_NO_BINARY`, `E_HUB_UNPINNED`, `E_NOT_JOINED`, `E_NO_SSH`. (`E_POOL_MISMATCH` is **not** in this list.)
+Client-side only (never on the wire): `E_CONNECT`, `E_UNAUTHORIZED`, `E_HOSTKEY_CHANGED`, `E_CHANNEL_LOST`, `E_SEND_UNKNOWN`, `E_HELLO_TIMEOUT`, `E_HUB_NO_BINARY`, `E_HUB_UNPINNED`, `E_HUB_PINNING_UNVERIFIED`, `E_NOT_JOINED`, `E_NO_SSH`. (`E_POOL_MISMATCH` is **not** in this list.)
 
 `E_UNPINNED` is hub-emitted and travels on the wire: a hub reached WITHOUT an
 `authorized_keys` forced command refuses to serve, because the agent id and pool for that

--- a/integration/sshd/pinning_test.go
+++ b/integration/sshd/pinning_test.go
@@ -395,9 +395,9 @@ func TestSSHDPinningProbeVerdicts(t *testing.T) {
 		before := poolTree(t, h.pool)
 		authBefore := h.authCount()
 
-		verdict, pinned := hubclient.PinningVerdict(probeRemote(h), "codex")
-		if !pinned {
-			t.Fatalf("a pinned host was reported unpinned: %s", verdict)
+		verdict, state := hubclient.PinningVerdict(probeRemote(h), "codex")
+		if state != hubclient.PinningPinned {
+			t.Fatalf("a pinned host was reported %v: %s", state, verdict)
 		}
 		if after := poolTree(t, h.pool); after != before {
 			t.Fatalf("the probe wrote into the pool:\nbefore:\n%s\nafter:\n%s", before, after)
@@ -415,9 +415,12 @@ func TestSSHDPinningProbeVerdicts(t *testing.T) {
 		addUnrestrictedAgent(t, h, "drifter")
 		rememberProbeMux(t, h, "drifter")
 
-		verdict, pinned := hubclient.PinningVerdict(probeRemote(h), "drifter")
-		if pinned {
-			t.Fatalf("an unpinned host was reported pinned; sshd applies no forced command for that key")
+		verdict, state := hubclient.PinningVerdict(probeRemote(h), "drifter")
+		if state != hubclient.PinningNotPinned {
+			// Explicitly not "anything but pinned": UNVERIFIED here would mean
+			// the probe never ran, and this row would be reporting a fixture
+			// failure as a finding about the host.
+			t.Fatalf("an unpinned host was reported %v; sshd applies no forced command for that key:\n%s", state, verdict)
 		}
 		// Row 15 on real sshd. The throwaway key the probe mints is authorized
 		// nowhere, so sshd refuses it — and that refusal is precisely what

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -265,6 +265,12 @@ func runRemoteDoctorChecks(cfg *loop.Config, agentID string, now time.Time) doct
 		if code == hubwire.CodeUnpinned || code == "E_HUB_UNPINNED" {
 			add(doctorCheck{Name: "hub_pinning", Severity: severityBlocker, Message: fmt.Sprintf("%s: %v", code, err)})
 		}
+		// The probe could not run, so nothing was observed. Reported for the same
+		// reason as the two above — the named check must appear — but as a WARN,
+		// because an unreachable probe is not evidence of an unpinned hub.
+		if code == "E_HUB_PINNING_UNVERIFIED" {
+			add(doctorCheck{Name: "hub_pinning", Severity: severityWarn, Message: fmt.Sprintf("%s: %v", code, err)})
+		}
 		return report
 	}
 	hello := session.Hello()
@@ -1395,10 +1401,25 @@ Flags:
 // mapping without opening an ssh connection; production never reassigns it.
 var hubPinningVerdict = hubclient.PinningVerdict
 
+// The severity is three-way, and the third one is the point.
+//
+// NOT PINNED is a blocker. Pinned is OK. UNVERIFIED is a WARN carrying the
+// reason — not OK, which was the defect: a probe that never ran printed the
+// sentence for a verification that had not happened. Not a blocker either,
+// because a transient probe failure would exit doctor non-zero and train
+// operators to ignore it. And explicitly not INFO: an operator scanning a report
+// for problems skims past info, which makes it functionally identical to OK for
+// the only purpose that matters.
+//
+// "I could not check" must never read as "I checked and it is fine".
 func hubPinningCheck(remote *loop.RemoteConfig, agentID string) doctorCheck {
-	message, pinned := hubPinningVerdict(remote, agentID)
-	if pinned {
+	message, state := hubPinningVerdict(remote, agentID)
+	switch state {
+	case hubclient.PinningPinned:
 		return doctorCheck{Name: "hub_pinning", Severity: severityOK, Message: "forced command applied; agent id and pool are pinned by sshd"}
+	case hubclient.PinningUnverified:
+		return doctorCheck{Name: "hub_pinning", Severity: severityWarn, Message: message}
+	default:
+		return doctorCheck{Name: "hub_pinning", Severity: severityBlocker, Message: message}
 	}
-	return doctorCheck{Name: "hub_pinning", Severity: severityBlocker, Message: message}
 }

--- a/internal/cli/doctor_pinning_test.go
+++ b/internal/cli/doctor_pinning_test.go
@@ -20,8 +20,8 @@ func TestHubPinningCheckSeverity(t *testing.T) {
 	remote := &loop.RemoteConfig{Host: "hub44", PoolPath: "/srv/pool"}
 
 	t.Run("pinned is OK, and doctor does not repeat the probe's prose", func(t *testing.T) {
-		defer swapPinningVerdict(t, func(*loop.RemoteConfig, string) (string, bool) {
-			return "some message the probe would only produce when UNPINNED", true
+		defer swapPinningVerdict(t, func(*loop.RemoteConfig, string) (string, hubclient.PinningState) {
+			return "some message the probe would only produce when UNPINNED", hubclient.PinningPinned
 		})()
 		got := hubPinningCheck(remote, "opus-high")
 		if got.Name != "hub_pinning" {
@@ -40,8 +40,8 @@ func TestHubPinningCheckSeverity(t *testing.T) {
 	// warning here reads as "noted" and ships an unpinned hub.
 	t.Run("unpinned is a BLOCKER and forwards the verdict verbatim", func(t *testing.T) {
 		verdict := "hub: NOT PINNED — hub44 ran a command this machine chose"
-		defer swapPinningVerdict(t, func(*loop.RemoteConfig, string) (string, bool) {
-			return verdict, false
+		defer swapPinningVerdict(t, func(*loop.RemoteConfig, string) (string, hubclient.PinningState) {
+			return verdict, hubclient.PinningNotPinned
 		})()
 		got := hubPinningCheck(remote, "opus-high")
 		if got.Severity != severityBlocker {
@@ -56,9 +56,9 @@ func TestHubPinningCheckSeverity(t *testing.T) {
 	// none) makes the operator-fallback remedy name a key nobody has.
 	t.Run("the agent id reaches the probe", func(t *testing.T) {
 		var seen string
-		defer swapPinningVerdict(t, func(_ *loop.RemoteConfig, agentID string) (string, bool) {
+		defer swapPinningVerdict(t, func(_ *loop.RemoteConfig, agentID string) (string, hubclient.PinningState) {
 			seen = agentID
-			return "", true
+			return "", hubclient.PinningPinned
 		})()
 		hubPinningCheck(remote, "opus-high")
 		if seen != "opus-high" {
@@ -67,7 +67,83 @@ func TestHubPinningCheckSeverity(t *testing.T) {
 	})
 }
 
-func swapPinningVerdict(t *testing.T, fn func(*loop.RemoteConfig, string) (string, bool)) func() {
+// Rows 21/22: the third severity, and its positive control.
+//
+// UNVERIFIED is a WARN carrying the reason. Not OK — that was the defect, and
+// the assertion that catches a regression to it is that the OK sentence must not
+// appear. Not a blocker either: a transient probe failure would exit doctor
+// non-zero and train operators to ignore it. And explicitly not INFO, because an
+// operator scanning for problems skims past info, which makes it functionally
+// identical to OK for the only purpose that matters.
+func TestDoctorWarnsWhenPinningCouldNotBeVerified(t *testing.T) {
+	remote := &loop.RemoteConfig{Host: "hub44", PoolPath: "/srv/pool"}
+	const reason = "could not verify pinning — the probe did not reach hub44 (Network is unreachable)"
+
+	t.Run("unverified is a WARN that carries the reason", func(t *testing.T) {
+		defer swapPinningVerdict(t, func(*loop.RemoteConfig, string) (string, hubclient.PinningState) {
+			return reason, hubclient.PinningUnverified
+		})()
+		got := hubPinningCheck(remote, "opus-high")
+		if got.Severity != severityWarn {
+			t.Fatalf("severity = %v, want WARN — OK hides it and blocker teaches operators to ignore doctor", got.Severity)
+		}
+		if got.Message != reason {
+			t.Fatalf("doctor rewrote the reason:\n got: %s\nwant: %s", got.Message, reason)
+		}
+		// The exact regression: printing the pinned sentence for a check that
+		// never ran.
+		if strings.Contains(got.Message, "pinned by sshd") {
+			t.Fatalf("an unverified probe rendered the OK sentence:\n%s", got.Message)
+		}
+	})
+
+	// The positive control for the row above: a probe that RAN and found no
+	// nonce is still OK, so the fix cannot be "warn whenever unsure".
+	t.Run("a probe that ran and found the host pinned is still OK", func(t *testing.T) {
+		defer swapPinningVerdict(t, func(*loop.RemoteConfig, string) (string, hubclient.PinningState) {
+			return "", hubclient.PinningPinned
+		})()
+		got := hubPinningCheck(remote, "opus-high")
+		if got.Severity != severityOK {
+			t.Fatalf("severity = %v, want OK", got.Severity)
+		}
+		if !strings.Contains(got.Message, "pinned by sshd") {
+			t.Fatalf("the OK arm lost its sentence: %s", got.Message)
+		}
+	})
+
+	// And the blocker arm must not have been swept into the warn bucket.
+	t.Run("not pinned is still a BLOCKER", func(t *testing.T) {
+		defer swapPinningVerdict(t, func(*loop.RemoteConfig, string) (string, hubclient.PinningState) {
+			return "hub: NOT PINNED — hub44 ran a command this machine chose", hubclient.PinningNotPinned
+		})()
+		if got := hubPinningCheck(remote, "opus-high"); got.Severity != severityBlocker {
+			t.Fatalf("severity = %v, want BLOCKER", got.Severity)
+		}
+	})
+}
+
+// The connect-failure path has the same three-way shape: E_HUB_PINNING_UNVERIFIED
+// must produce the named check as a WARN, not the blocker its two neighbours get.
+func TestDoctorReportsUnverifiedPinningOnAConnectFailure(t *testing.T) {
+	cfg := newDoctorHubFixture(t)
+	original := openRemoteOneShot
+	openRemoteOneShot = func(*loop.Config, string) (*hubclient.OneShot, error) {
+		return nil, &hubclient.Error{Code: "E_HUB_PINNING_UNVERIFIED", Msg: "hub: connected, but the hub did not run `agentchute-hub`", Retriable: true}
+	}
+	t.Cleanup(func() { openRemoteOneShot = original })
+
+	report := runRemoteDoctorChecks(cfg, "opus-high", time.Now().UTC())
+	pinning, has := doctorCheckNamed(report, "hub_pinning")
+	if !has {
+		t.Fatalf("hub_pinning absent; checks = %v", doctorCheckNames(report))
+	}
+	if pinning.Severity != severityWarn {
+		t.Fatalf("severity = %v, want WARN — an unreachable probe is not evidence of an unpinned hub", pinning.Severity)
+	}
+}
+
+func swapPinningVerdict(t *testing.T, fn func(*loop.RemoteConfig, string) (string, hubclient.PinningState)) func() {
 	t.Helper()
 	prev := hubPinningVerdict
 	hubPinningVerdict = fn
@@ -144,9 +220,9 @@ func TestDoctorReportsHubPinningOnAnUnpinnedConnectFailure(t *testing.T) {
 func TestDoctorDoesNotReprobeAfterAnUnpinnedConnectFailure(t *testing.T) {
 	cfg := newDoctorHubFixture(t)
 	probes := 0
-	defer swapPinningVerdict(t, func(*loop.RemoteConfig, string) (string, bool) {
+	defer swapPinningVerdict(t, func(*loop.RemoteConfig, string) (string, hubclient.PinningState) {
 		probes++
-		return "", true
+		return "", hubclient.PinningPinned
 	})()
 	original := openRemoteOneShot
 	openRemoteOneShot = func(*loop.Config, string) (*hubclient.OneShot, error) {

--- a/internal/hubclient/pinning.go
+++ b/internal/hubclient/pinning.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -93,6 +94,9 @@ const (
 	// pinningUnpinnedUnattributed: the host is unpinned, and the second probe could
 	// not say which producer. NARROWS NOTHING and names both remedies.
 	pinningUnpinnedUnattributed
+	// pinningUnverified: the probe COULD NOT RUN, so nothing about this host was
+	// observed. Distinct from pinned, which is a finding.
+	pinningUnverified
 )
 
 // hubProbeRunner is the seam rows swap. Production runs ssh.
@@ -238,17 +242,64 @@ var errProbeTimeout = &Error{Code: "E_PROBE_TIMEOUT", Msg: "hub: the pinning pro
 // because it can make a ProxyJump-only hub unreachable, and that applies to a
 // diagnostic just as much — so a second probe that fails to connect must never be
 // the thing that decides an operator is at fault.
-func probeHubPinning(opts SSHBuildOptions) pinningVerdict {
+func probeHubPinning(opts SSHBuildOptions) (pinningVerdict, string) {
 	invocation, nonce, err := buildPinningProbe(opts)
 	if err != nil {
-		return pinningPinned
+		// A local failure: the probe demonstrably never left this machine, so it
+		// observed nothing. This line used to return pinningPinned — printing
+		// the reassuring sentence for a verification that had not happened.
+		return pinningUnverified, err.Error()
 	}
-	stdout, _, _ := hubProbeRunner(invocation.Args, 15*time.Second)
-	if !nonceEchoed(stdout, nonce) {
-		return pinningPinned
+	stdout, stderr, runErr := hubProbeRunner(invocation.Args, 15*time.Second)
+	if nonceEchoed(stdout, nonce) {
+		return attributeUnpinnedHub(opts), ""
 	}
-	return attributeUnpinnedHub(opts)
+	// "No nonce" has two causes and they are opposites. A host that was REACHED
+	// and refused to run our command is PINNED — that is the finding. A probe
+	// that never ran observed nothing.
+	if reason, failed := sshItselfFailed(runErr, stderr); failed {
+		return pinningUnverified, reason
+	}
+	return pinningPinned, ""
 }
+
+// sshItselfFailed reports whether SSH failed, as opposed to the remote command
+// failing — and getting the difference wrong trades a false assurance for a
+// false alarm in either direction.
+//
+// A genuinely pinned host whose binary is missing exits 127: the probe ran
+// perfectly and correctly found no nonce, and calling that "unverified" would
+// break every missing-binary host. So err != nil is NOT the discriminator.
+//
+// Three things mean ssh itself failed: it could not be started at all (not on
+// PATH), our timeout fired, or it exited 255 — ssh's own reserved status, as
+// distinct from the remote command's status that it otherwise passes through
+// unchanged. Anything else, remote exit 127 included, means the probe ran.
+func sshItselfFailed(runErr error, stderr string) (string, bool) {
+	if runErr == nil {
+		return "", false
+	}
+	detail := strings.TrimSpace(lastStderrLine(stderr))
+	if detail == "" {
+		detail = runErr.Error()
+	}
+	if errors.Is(runErr, errProbeTimeout) {
+		return "the probe did not return within its timeout", true
+	}
+	var execErr *exec.Error
+	if errors.As(runErr, &execErr) {
+		return "could not run ssh: " + execErr.Err.Error(), true
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) && exitErr.ExitCode() == sshSelfFailureExit {
+		return detail, true
+	}
+	return "", false
+}
+
+// sshSelfFailureExit is 255, which ssh reserves for its own failures. Every
+// other status ssh returns is the remote command's, passed through.
+const sshSelfFailureExit = 255
 
 // attributeUnpinnedHub is 2c: probe on an identity that CANNOT be authorized.
 //
@@ -316,19 +367,58 @@ func hubUnpinnedBothRemediesSuffix() string {
 // Exported because doctor lives in internal/cli and the probes need
 // BuildSSHInvocation. It reports the narrowed message when the second probe could
 // narrow, and the both-remedies message when it could not.
-func PinningVerdict(remote *loop.RemoteConfig, agentID string) (string, bool) {
+func PinningVerdict(remote *loop.RemoteConfig, agentID string) (string, PinningState) {
 	opts := SSHBuildOptions{Remote: remote, AgentID: agentID}
 	if remote != nil {
 		opts.StateDir = remote.HubDir
 	}
-	switch hubPinningProbe(opts) {
+	verdict, reason := hubPinningProbe(opts)
+	switch verdict {
 	case pinningIntercepted:
-		return hubUnpinnedInterceptedMessage(remote), false
+		return hubUnpinnedInterceptedMessage(remote), PinningNotPinned
 	case pinningOperatorFallback:
-		return hubUnpinnedOperatorFallbackMessage(remote, agentID), false
+		return hubUnpinnedOperatorFallbackMessage(remote, agentID), PinningNotPinned
 	case pinningUnpinnedUnattributed:
-		return hubUnpinnedInterceptedMessage(remote) + " " + hubUnpinnedBothRemediesSuffix(), false
+		return hubUnpinnedInterceptedMessage(remote) + " " + hubUnpinnedBothRemediesSuffix(), PinningNotPinned
+	case pinningUnverified:
+		return hubPinningUnverifiedMessage(remote, reason), PinningUnverified
 	default:
-		return "", true
+		return "", PinningPinned
 	}
+}
+
+// PinningState is the three-way answer, exported because doctor renders all
+// three differently and a bool cannot carry the third.
+type PinningState int
+
+const (
+	PinningPinned PinningState = iota
+	PinningNotPinned
+	PinningUnverified
+)
+
+// hubPinningUnverifiedMessage says which way to lean while the answer is
+// unknown, and leans the safe way. "I could not check" must never read as "I
+// checked and it is fine".
+func hubPinningUnverifiedMessage(remote *loop.RemoteConfig, reason string) string {
+	host := "this hub"
+	if remote != nil {
+		host = remote.Host
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "no reason reported"
+	}
+	return "could not verify pinning — the probe did not reach " + host + " (" + reason + "). This check has NOT confirmed that sshd applies a forced command; re-run `agentchute doctor`, and if it keeps failing treat the hub as unverified rather than pinned."
+}
+
+// hubPinningUnverifiedExitMessage is the exit-127 arm's fourth outcome. It is
+// its own code rather than a reuse of either neighbour, because a code's name
+// IS its claim: E_HUB_NO_BINARY asserts a working forced command, and the
+// unpinned arm opens "NOT PINNED —". When the probe could not run, neither is
+// known, and reusing either swaps a false assurance for a false alarm.
+func hubPinningUnverifiedExitMessage(reason string) string {
+	if strings.TrimSpace(reason) == "" {
+		reason = "no reason reported"
+	}
+	return "hub: connected, but the hub did not run `agentchute-hub` (remote exit 127). That has two causes with opposite remedies — the binary the forced command names is missing, or no forced command was applied at all — and the check that tells them apart could not run (" + reason + "). Re-run; if it persists, check both: that agentchute exists at the path the `authorized_keys` line names, and that this host applies `authorized_keys` at all (`agentchute doctor` from the joining machine)."
 }

--- a/internal/hubclient/pinning_test.go
+++ b/internal/hubclient/pinning_test.go
@@ -196,8 +196,8 @@ func TestPinnedHubNeverReachesTheSecondProbe(t *testing.T) {
 		// writes nothing.
 		return "", "", nil
 	}
-	if got := probeHubPinning(opts); got != pinningPinned {
-		t.Fatalf("verdict = %v, want pinned", got)
+	if got, reason := probeHubPinning(opts); got != pinningPinned {
+		t.Fatalf("verdict = %v (%s), want pinned", got, reason)
 	}
 	if calls != 1 {
 		t.Fatalf("ran %d probes against a pinned hub; the second one is for narrowing an unpinned verdict", calls)
@@ -261,7 +261,7 @@ func TestExit127IsClassifiedByTheProbeNotTheShellText(t *testing.T) {
 		t.Run(row.name, func(t *testing.T) {
 			original := hubPinningProbe
 			t.Cleanup(func() { hubPinningProbe = original })
-			hubPinningProbe = func(SSHBuildOptions) pinningVerdict { return row.verdict }
+			hubPinningProbe = func(SSHBuildOptions) (pinningVerdict, string) { return row.verdict, "" }
 
 			err := classifyExit127(remote, "codex", "zsh:1: command not found: agentchute-hub\n")
 			if got := ErrorCode(err); got != row.wantCode {
@@ -291,7 +291,7 @@ func TestExit127NeverNamesAHardcodedInstallPath(t *testing.T) {
 	}
 	for _, verdict := range []pinningVerdict{pinningPinned, pinningIntercepted, pinningOperatorFallback, pinningUnpinnedUnattributed} {
 		original := hubPinningProbe
-		hubPinningProbe = func(SSHBuildOptions) pinningVerdict { return verdict }
+		hubPinningProbe = func(SSHBuildOptions) (pinningVerdict, string) { return verdict, "" }
 		got := classifyExit127(remote, "codex", "").Error()
 		hubPinningProbe = original
 		if strings.Contains(got, "/usr/local/bin/agentchute") {

--- a/internal/hubclient/pinning_unverified_test.go
+++ b/internal/hubclient/pinning_unverified_test.go
@@ -1,0 +1,218 @@
+package hubclient
+
+import (
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// 2b's third state (spec §2b-note, amended 2026-08-20).
+//
+// As first written, 2b said "anything else ⇒ pinned, including exit 127". That
+// is right for a host that was REACHED and refused to run our nonce, and wrong
+// for a probe that never ran — which the implementation reported as PINNED,
+// printing the OK sentence for a verification that had not happened.
+//
+// The discriminator is NOT `err != nil`, and getting that wrong trades a false
+// assurance for a false alarm in the other direction: a genuinely pinned host
+// whose binary is missing exits 127, and that probe ran perfectly. Only three
+// things mean SSH ITSELF failed — it could not be started, our timeout fired, or
+// it exited 255, ssh's own reserved status as distinct from the remote command's
+// status it otherwise passes through.
+
+// exitErrorWithCode produces a real *exec.ExitError, because that is what the
+// production discriminator type-asserts on. Fabricating a look-alike would test
+// the row's own fiction.
+func exitErrorWithCode(t *testing.T, code int) error {
+	t.Helper()
+	// The code is passed as an ARGUMENT, never interpolated into the command
+	// string: nothing here is attacker-controlled, but a shell string built by
+	// concatenation is a habit worth not having in the tree.
+	err := exec.Command("sh", "-c", `exit "$1"`, "sh", strconv.Itoa(code)).Run()
+	if err == nil {
+		t.Fatalf("a child asked to exit %d reported success", code)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != code {
+		t.Fatalf("wanted an ExitError with code %d, got %T %v", code, err, err)
+	}
+	return err
+}
+
+func TestProbeReportsUnverifiedOnlyWhenSSHItselfFailed(t *testing.T) {
+	rows := []struct {
+		name       string
+		stderr     string
+		err        func(t *testing.T) error
+		want       pinningVerdict
+		wantReason string
+	}{
+		{
+			// Row 17.
+			name: "ssh could not be started at all",
+			err: func(*testing.T) error {
+				return &exec.Error{Name: "ssh", Err: exec.ErrNotFound}
+			},
+			want:       pinningUnverified,
+			wantReason: "could not run ssh",
+		},
+		{
+			// Row 18.
+			name:       "the probe timed out",
+			err:        func(*testing.T) error { return errProbeTimeout },
+			want:       pinningUnverified,
+			wantReason: "did not return within its timeout",
+		},
+		{
+			// Row 19: 255 is ssh's own reserved status, and the reason must carry
+			// what ssh said or the operator gets "could not verify" with no lead.
+			name:       "ssh exited 255 — its own failure",
+			stderr:     "ssh: connect to host hub.example port 22: Operation timed out\n",
+			err:        func(t *testing.T) error { return exitErrorWithCode(t, 255) },
+			want:       pinningUnverified,
+			wantReason: "Operation timed out",
+		},
+		{
+			// ROW 20, the control that stops the over-correction. Check this one
+			// first: a fix that treats any error as unverified passes every row
+			// above and silently breaks every missing-binary host.
+			name:   "remote exit 127 — the probe RAN and found no nonce",
+			stderr: "zsh:1: command not found: agentchute-hub\n",
+			err:    func(t *testing.T) error { return exitErrorWithCode(t, 127) },
+			want:   pinningPinned,
+		},
+		{
+			name: "a clean run with no nonce is pinned",
+			err:  func(*testing.T) error { return nil },
+			want: pinningPinned,
+		},
+	}
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			opts := probeFixture(t)
+			original := hubProbeRunner
+			t.Cleanup(func() { hubProbeRunner = original })
+			hubProbeRunner = func([]string, time.Duration) (string, string, error) {
+				return "", row.stderr, row.err(t)
+			}
+
+			got, reason := probeHubPinning(opts)
+			if got != row.want {
+				t.Fatalf("verdict = %v (%q), want %v", got, reason, row.want)
+			}
+			if row.wantReason != "" && !strings.Contains(reason, row.wantReason) {
+				t.Fatalf("reason = %q, want it to carry %q", reason, row.wantReason)
+			}
+			if row.want == pinningPinned && reason != "" {
+				t.Fatalf("a pinned verdict carried a reason: %q", reason)
+			}
+		})
+	}
+}
+
+// Row 16: the one-liner that was wrong. A buildPinningProbe failure is local —
+// the probe demonstrably never left this machine — so it cannot be evidence
+// that the host is pinned.
+func TestProbeReportsUnverifiedWhenItCannotEvenBeBuilt(t *testing.T) {
+	original := hubProbeRunner
+	t.Cleanup(func() { hubProbeRunner = original })
+	ran := false
+	hubProbeRunner = func([]string, time.Duration) (string, string, error) {
+		ran = true
+		return "", "", nil
+	}
+
+	// No remote and no key: BuildSSHInvocation cannot produce an invocation.
+	got, reason := probeHubPinning(SSHBuildOptions{})
+	if got != pinningUnverified {
+		t.Fatalf("verdict = %v, want unverified", got)
+	}
+	if strings.TrimSpace(reason) == "" {
+		t.Fatal("unverified with no reason; the operator is told nothing")
+	}
+	if ran {
+		t.Fatal("the runner was invoked despite the invocation never being built")
+	}
+}
+
+// The operator-facing half. "I could not check" must never read as "I checked
+// and it is fine", and the message has to say which way to lean meanwhile.
+func TestUnverifiedVerdictLeansUnverifiedNotPinned(t *testing.T) {
+	original := hubProbeRunner
+	t.Cleanup(func() { hubProbeRunner = original })
+	hubProbeRunner = func([]string, time.Duration) (string, string, error) {
+		return "", "ssh: connect to host hub44 port 22: Network is unreachable\n", exitErrorWithCode(t, 255)
+	}
+	opts := probeFixture(t)
+	message, state := PinningVerdict(opts.Remote, "codex")
+
+	if state != PinningUnverified {
+		t.Fatalf("state = %v, want PinningUnverified", state)
+	}
+	for _, want := range []string{"could not verify pinning", "Network is unreachable", "treat the hub as unverified rather than pinned"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("message is missing %q:\n%s", want, message)
+		}
+	}
+	// The two claims it must NOT make: that the hub is unpinned, or that it is
+	// pinned. Neither was observed.
+	if strings.Contains(message, "NOT PINNED") {
+		t.Fatalf("an unverified probe asserted the hub is unpinned:\n%s", message)
+	}
+	if strings.Contains(message, "pinned by sshd") {
+		t.Fatalf("an unverified probe asserted the hub is pinned:\n%s", message)
+	}
+}
+
+// Rows 23/24: the exit-127 arm's fourth outcome, and its control.
+func TestClassifyExit127HasAFourthOutcomeWhenTheProbeCouldNotRun(t *testing.T) {
+	remote := probeFixture(t).Remote
+
+	t.Run("unverified gets its own code, retriable, asserting neither cause", func(t *testing.T) {
+		original := hubPinningProbe
+		t.Cleanup(func() { hubPinningProbe = original })
+		hubPinningProbe = func(SSHBuildOptions) (pinningVerdict, string) {
+			return pinningUnverified, "ssh: connect to host hub44 port 22: Network is unreachable"
+		}
+
+		err := classifyExit127(remote, "codex", "zsh:1: command not found: agentchute-hub\n")
+		if got := ErrorCode(err); got != "E_HUB_PINNING_UNVERIFIED" {
+			t.Fatalf("code = %s, want E_HUB_PINNING_UNVERIFIED", got)
+		}
+		var e *Error
+		if !errors.As(err, &e) || !e.Retriable {
+			t.Fatalf("the unverified arm must be retriable; the usual cause is transient: %#v", err)
+		}
+		text := err.Error()
+		// It must name BOTH causes, because it cannot tell them apart.
+		for _, want := range []string{"missing", "no forced command was applied", "Network is unreachable"} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("message is missing %q:\n%s", want, text)
+			}
+		}
+		// And it must borrow neither neighbour's claim: a code's name IS its
+		// assertion, and neither assertion is known here.
+		if strings.Contains(text, "NOT PINNED") {
+			t.Fatalf("reused the unpinned arm's claim:\n%s", text)
+		}
+		if strings.Contains(text, "the hub DOES apply a forced command") {
+			t.Fatalf("reused the missing-binary arm's claim:\n%s", text)
+		}
+	})
+
+	// The control. Without it, a change that reported every 127 as unverified
+	// would pass the row above and break every genuinely missing binary.
+	t.Run("a probe that RAN and found the host pinned is still E_HUB_NO_BINARY", func(t *testing.T) {
+		original := hubPinningProbe
+		t.Cleanup(func() { hubPinningProbe = original })
+		hubPinningProbe = func(SSHBuildOptions) (pinningVerdict, string) { return pinningPinned, "" }
+
+		err := classifyExit127(remote, "codex", "")
+		if got := ErrorCode(err); got != "E_HUB_NO_BINARY" {
+			t.Fatalf("code = %s, want E_HUB_NO_BINARY", got)
+		}
+	})
+}

--- a/internal/hubclient/ssh.go
+++ b/internal/hubclient/ssh.go
@@ -445,7 +445,10 @@ func classifyExit127(remote *loop.RemoteConfig, agentID, stderr string) error {
 	if remote != nil {
 		opts.StateDir = remote.HubDir
 	}
-	switch hubPinningProbe(opts) {
+	verdict, reason := hubPinningProbe(opts)
+	switch verdict {
+	case pinningUnverified:
+		return &Error{Code: "E_HUB_PINNING_UNVERIFIED", Msg: hubPinningUnverifiedExitMessage(reason) + lastStderrLine(stderr), Retriable: true}
 	case pinningIntercepted:
 		return &Error{Code: "E_HUB_UNPINNED", Msg: hubUnpinnedInterceptedMessage(remote) + lastStderrLine(stderr)}
 	case pinningOperatorFallback:

--- a/internal/hubclient/ssh_test.go
+++ b/internal/hubclient/ssh_test.go
@@ -198,7 +198,7 @@ func TestClassifySSHFailureCodes(t *testing.T) {
 	// pinning_test.go, where the verdict is the parameter.
 	originalProbe := hubPinningProbe
 	t.Cleanup(func() { hubPinningProbe = originalProbe })
-	hubPinningProbe = func(SSHBuildOptions) pinningVerdict { return pinningPinned }
+	hubPinningProbe = func(SSHBuildOptions) (pinningVerdict, string) { return pinningPinned, "" }
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/hubwire/codec_test.go
+++ b/internal/hubwire/codec_test.go
@@ -260,8 +260,12 @@ func TestRegistryCompleteness(t *testing.T) {
 	if Emitters[CodePoolMismatch] != EmitterBoth {
 		t.Fatalf("pool mismatch emitter = %q", Emitters[CodePoolMismatch])
 	}
-	if len(Emitters) != 28 {
-		t.Fatalf("emitter registry = %d rows, want 28", len(Emitters))
+	// 29 with E_HUB_PINNING_UNVERIFIED, the fourth outcome of the exit-127 arm.
+	// The count is asserted on purpose: a code added to the map and forgotten in
+	// the spec's table is exactly the drift this row exists to catch, so it must
+	// be moved deliberately rather than grow on its own.
+	if len(Emitters) != 29 {
+		t.Fatalf("emitter registry = %d rows, want 29", len(Emitters))
 	}
 }
 

--- a/internal/hubwire/codes.go
+++ b/internal/hubwire/codes.go
@@ -51,16 +51,19 @@ var Emitters = map[string]string{
 	// Client-emitted: only the CLIENT can run the behavioural probe that
 	// distinguishes an unpinned hub from a missing binary. The hub-side
 	// E_UNPINNED is what a pinned-but-bypassed hub reports about itself.
-	"E_HUB_UNPINNED":    EmitterClient,
-	"E_CONNECT":         EmitterClient,
-	"E_UNAUTHORIZED":    EmitterClient,
-	"E_HOSTKEY_CHANGED": EmitterClient,
-	"E_CHANNEL_LOST":    EmitterClient,
-	"E_SEND_UNKNOWN":    EmitterClient,
-	"E_HELLO_TIMEOUT":   EmitterClient,
-	"E_HUB_NO_BINARY":   EmitterClient,
-	"E_NOT_JOINED":      EmitterClient,
-	"E_NO_SSH":          EmitterClient,
+	"E_HUB_UNPINNED": EmitterClient,
+	// Client-emitted for the same reason as E_HUB_UNPINNED: only the CLIENT runs
+	// the probe, so only the client can report that the probe could not run.
+	"E_HUB_PINNING_UNVERIFIED": EmitterClient,
+	"E_CONNECT":                EmitterClient,
+	"E_UNAUTHORIZED":           EmitterClient,
+	"E_HOSTKEY_CHANGED":        EmitterClient,
+	"E_CHANNEL_LOST":           EmitterClient,
+	"E_SEND_UNKNOWN":           EmitterClient,
+	"E_HELLO_TIMEOUT":          EmitterClient,
+	"E_HUB_NO_BINARY":          EmitterClient,
+	"E_NOT_JOINED":             EmitterClient,
+	"E_NO_SSH":                 EmitterClient,
 }
 
 // ProtocolError is a named session/codec failure. Operation errors keep their


### PR DESCRIPTION
Implements the amended spec §2b-note (`~/hubtest-scratch/design/detection-spec.md`, sha256 `376cddb1…`, verified before starting), per opus-xhigh's ruling.

## The defect

2b said "anything else ⇒ pinned, including exit 127". That is right for a host that was **reached** and refused to run our nonce, and wrong for a probe that **never ran** — which the implementation reported as PINNED, printing the OK sentence for a verification that had not happened. §2c was deliberately made fail-closed on the same page; 2b had no equivalent third state.

It also *is* the one-line bug: `probeHubPinning` discarded the runner's second and third returns, so the evidence needed to tell the two cases apart was thrown away before anyone could look at it.

## The discriminator — read the control row first

**It is not `err != nil`.** A genuinely pinned host whose binary is missing exits 127, and that probe ran perfectly. A fix that treats any error as unverified passes every new row and silently breaks every missing-binary host. That mutation is one of the five, and row 20 is its control.

Only three things mean **ssh itself** failed:

- it could not be started (not on PATH),
- our timeout fired,
- it exited **255** — ssh's own reserved status, as distinct from the remote command's status it otherwise passes through unchanged.

A `buildPinningProbe` failure is unverified unconditionally: it is local, so the probe demonstrably never left this machine.

## doctor: the third severity

UNVERIFIED is a **WARN carrying the reason**.

- Not OK — that was the defect, and the regression row asserts against it by requiring the OK sentence to be **absent**.
- Not a blocker — a transient probe failure would exit doctor non-zero and train operators to ignore it.
- Explicitly not INFO — an operator scanning a report for problems skims past info, which makes it functionally identical to OK for the only purpose that matters.

"I could not check" must never read as "I checked and it is fine".

## classifyExit127: a fourth code

`E_HUB_PINNING_UNVERIFIED`, retriable, naming **both** causes. Its own code rather than a reuse of either neighbour, because a code's name IS its claim: `E_HUB_NO_BINARY` asserts a working forced command, the unpinned arm opens "NOT PINNED —", and when the probe could not run neither is known. Rows assert it borrows neither claim.

## Registry

The code in `codes.go` and in `AGENTCHUTE.md`'s client-only list. The emitter-count assertion moves 28 → 29 **deliberately**, with a note on why it is asserted at all — a code added to the map and forgotten in the spec's table is the drift that row exists to catch.

## Rows and mutations

Nine new rows (spec 16–24) plus two corrected callers. Five mutations red under a CI-like stripped PATH: remove the third state, treat any error as unverified, read a build failure as pinned, watch the wrong ssh status, render unverified as OK.

## Verification

`tools/test.sh` and the full `integration/sshd` suite under `-race` (108s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)