### PR TITLE
two silent give-ups: a git failure and an uncomparable hostname

### DIFF
--- a/internal/cli/hub_join.go
+++ b/internal/cli/hub_join.go
@@ -625,10 +625,25 @@ func warnHubJoinShadowedBinary() {
 	fmt.Printf("  %s now holds an ssh:// hub URL. A copy that predates hub support reads that as a file path and fails with a confusing lstat error; upgrade or reorder the other copy.\n", loop.PointerFileName)
 }
 
+// appendHubPointerExclude keeps the control-repo pointer out of git's way.
+//
+// A git failure used to return nil, which is right for the common case — this
+// is not a git repository, so there is nothing to exclude — and silent for
+// every other case. Those are different: an unreadable git dir, a git that is
+// not installed, or a repository this user cannot read all end with the pointer
+// file NOT excluded, which surfaces much later as an untracked file the
+// operator did not create and may commit.
+//
+// Not being a repository stays silent. Anything else says so, and does not fail
+// the join: the pointer is written either way, and refusing to join over a
+// gitignore nicety would be a worse trade than the one being fixed.
 func appendHubPointerExclude(root string) error {
 	cmd := exec.Command("git", "-C", root, "rev-parse", "--git-path", "info/exclude")
 	out, err := cmd.Output()
 	if err != nil {
+		if !gitSaysNotARepository(err) {
+			fmt.Fprintf(os.Stderr, "warning: could not ask git where to exclude %s (%v); the pointer file may show up as untracked\n", loop.PointerFileName, gitFailureDetail(err))
+		}
 		return nil
 	}
 	path := strings.TrimSpace(string(out))
@@ -654,6 +669,28 @@ func appendHubPointerExclude(root string) error {
 	defer f.Close()
 	_, err = fmt.Fprintln(f, loop.PointerFileName)
 	return err
+}
+
+// gitSaysNotARepository reports the one failure that means "nothing to do here".
+// git writes it to stderr, which exec.Cmd.Output captures into ExitError.Stderr.
+func gitSaysNotARepository(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(exitErr.Stderr)), "not a git repository")
+}
+
+// gitFailureDetail prefers what git said over the exit status, which on its own
+// tells an operator nothing they can act on.
+func gitFailureDetail(err error) string {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if said := strings.TrimSpace(string(exitErr.Stderr)); said != "" {
+			return said
+		}
+	}
+	return err.Error()
 }
 
 func installHubJoinShims() error {

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -757,7 +757,10 @@ func runRemoteWrapperOnce(cfg *loop.Config, opts runnerOptions, cwd string) remo
 
 // localHostname returns the current host's name, trimmed. Best-effort: an
 // os.Hostname() failure returns "".
-func localHostname() string {
+// localHostname is a var so rows can drive the "this machine does not know its
+// own name" case, which is otherwise unreachable in a test and is exactly the
+// case setupHostIsProvablyLocal exists for. Production never reassigns it.
+var localHostname = func() string {
 	host, _ := os.Hostname()
 	return strings.TrimSpace(host)
 }

--- a/internal/cli/setup_reset.go
+++ b/internal/cli/setup_reset.go
@@ -201,6 +201,13 @@ func stopSetupRunner(cfg *loop.Config, agentID string) (bool, string) {
 	if !setupLocalHost(st.Host) {
 		return false, ""
 	}
+	// Stricter than the weak form for the one case it gets wrong, because what
+	// follows sends a SIGNAL: a record naming another machine, on a machine that
+	// cannot say what it is called, would otherwise have its pid compared
+	// against this process table.
+	if unknown, why := setupHostSaysElsewhereUnknown(st.Host); unknown {
+		return false, fmt.Sprintf("not stopping the runner for %s; %s", agentID, why)
+	}
 	if st.RunnerPID <= 0 || !setupProcessAlive(st.RunnerPID) {
 		return false, ""
 	}
@@ -265,6 +272,9 @@ func stopSetupLegacyPoller(cfg *loop.Config, agentID string) (bool, string) {
 	}
 	if !setupLocalHost(hb.Host) {
 		return false, ""
+	}
+	if unknown, why := setupHostSaysElsewhereUnknown(hb.Host); unknown {
+		return false, fmt.Sprintf("not stopping the legacy poller for %s; %s", agentID, why)
 	}
 	if hb.PID <= 0 || !setupProcessAlive(hb.PID) {
 		return false, ""
@@ -444,6 +454,18 @@ func signalProcess(pid int, sig os.Signal) error {
 	return p.Signal(sig)
 }
 
+// setupLocalHost answers "could this record belong to THIS machine?", and the
+// question is deliberately the weaker one.
+//
+// Two things make it unanswerable: a record with no host (written by an older
+// binary, or by the os.Hostname path fixed in #193), and this machine not
+// knowing its own name. Both return true, because every caller but one uses the
+// answer to REFUSE — to decline a wipe, an authorize, or a migration while
+// something might be live — and for those, "might be ours" is the safe answer.
+//
+// The exception is the pair that STOPS a process, where "might be ours" leads
+// to a SIGTERM rather than a refusal. Those ask setupHostIsProvablyLocal
+// instead; see stopSetupRunner.
 func setupLocalHost(host string) bool {
 	host = strings.TrimSpace(host)
 	if host == "" {
@@ -451,6 +473,33 @@ func setupLocalHost(host string) bool {
 	}
 	local := strings.TrimSpace(localHostname())
 	return local == "" || host == local
+}
+
+// setupHostSaysElsewhereUnknown reports the ONE case the weak form answers "yes"
+// to and should not, for callers that act rather than refuse: the record names a
+// machine, and this machine cannot say whether that machine is itself.
+//
+// It deliberately does NOT cover a record with no host. That case proceeds,
+// because the check immediately downstream is the stronger evidence: the
+// cmdline of a LOCAL pid, matched against this pool. A process on this machine
+// running `agentchute serve` for this pool IS ours, whatever a state file
+// forgot to write — and runner records written before the host field existed
+// carry none, so refusing them would stop `setup` from stopping runners it has
+// always stopped.
+//
+// What it does cover is the pairing that has no such backstop at the point of
+// decision: an unknown local name lets a record from another machine look
+// local, and the pid it names is then compared against THIS machine's process
+// table, where an unrelated process may sit at the same number.
+func setupHostSaysElsewhereUnknown(host string) (bool, string) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false, ""
+	}
+	if strings.TrimSpace(localHostname()) != "" {
+		return false, ""
+	}
+	return true, "this machine's hostname could not be determined, so the record's host (" + host + ") cannot be compared"
 }
 
 func setupPathMatchesRoot(path, root string) bool {

--- a/internal/cli/silent_give_ups_test.go
+++ b/internal/cli/silent_give_ups_test.go
@@ -1,0 +1,205 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentchute/agentchute/internal/loop"
+)
+
+// Tail of grok's #167 sweep. Both of these gave up silently, and in both cases
+// the silence is indistinguishable from the ordinary "nothing to do here" that
+// the same code path produces every day.
+
+// git failing is not the same as there being no git. The first is worth a word;
+// the second is the common case and must stay quiet, or every join in a
+// non-repository prints a warning and operators learn to ignore warnings.
+func TestPointerExcludeSaysSoWhenGitFailsForAnyOtherReason(t *testing.T) {
+	t.Run("not a repository stays silent", func(t *testing.T) {
+		root := t.TempDir()
+		stderr := captureStderr(t, func() {
+			if err := appendHubPointerExclude(root); err != nil {
+				t.Fatalf("a plain directory must not fail the join: %v", err)
+			}
+		})
+		if strings.TrimSpace(stderr) != "" {
+			t.Fatalf("a directory that is simply not a repository warned:\n%s", stderr)
+		}
+	})
+
+	t.Run("git missing entirely is reported", func(t *testing.T) {
+		// A PATH with no git at all: exec fails to start it, which is not an
+		// ExitError and therefore not "not a repository".
+		t.Setenv("PATH", t.TempDir())
+		root := t.TempDir()
+		stderr := captureStderr(t, func() {
+			if err := appendHubPointerExclude(root); err != nil {
+				t.Fatalf("a missing git must not fail the join: %v", err)
+			}
+		})
+		if !strings.Contains(stderr, "warning:") {
+			t.Fatalf("a git that could not run at all was silent:\n%s", stderr)
+		}
+		// It must name the file, or the warning is about nothing the operator
+		// can look for.
+		if !strings.Contains(stderr, loop.PointerFileName) {
+			t.Fatalf("the warning does not name the pointer file:\n%s", stderr)
+		}
+	})
+
+	t.Run("a real repository still gets the exclude line", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git is not installed")
+		}
+		root := t.TempDir()
+		if out, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+			t.Fatalf("git init: %v: %s", err, out)
+		}
+		if err := appendHubPointerExclude(root); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(filepath.Join(root, ".git", "info", "exclude"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(data), loop.PointerFileName) {
+			t.Fatalf("the pointer was not excluded:\n%s", data)
+		}
+	})
+}
+
+// setupLocalHost answers the WEAK question — "could this be ours?" — and returns
+// true for both unknowns, because almost every caller uses it to refuse.
+//
+// The pair that STOPS a process needs more for exactly one of those unknowns.
+// The other is deliberately left alone, and the difference is the whole point:
+// a record with no host proceeds, because the check immediately downstream is
+// stronger evidence than any hostname string — the cmdline of a LOCAL pid,
+// matched against this pool. Refusing those would stop `setup` from stopping
+// runners recorded before the host field existed.
+func TestSignalPathRefusesOnlyWhenTheHostCannotBeCompared(t *testing.T) {
+	rows := []struct {
+		name    string
+		host    string
+		local   string
+		want    bool
+		wantWhy string
+	}{
+		{
+			// The case with no backstop at the point of decision.
+			name:    "the record names a machine and we do not know our own name",
+			host:    "tiny",
+			local:   "",
+			want:    true,
+			wantWhy: "cannot be compared",
+		},
+		{
+			// Left alone on purpose: the cmdline check is the real proof, and
+			// older runner records carry no host at all.
+			name:  "the record names no host — the cmdline check decides",
+			host:  "",
+			local: "",
+		},
+		{name: "no host, known local name", host: "", local: "hub44"},
+		{name: "our name is known and matches", host: "hub44", local: "hub44"},
+		{name: "our name is known and differs", host: "tiny", local: "hub44"},
+	}
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			original := localHostname
+			localHostname = func() string { return row.local }
+			t.Cleanup(func() { localHostname = original })
+
+			got, why := setupHostSaysElsewhereUnknown(row.host)
+			if got != row.want {
+				t.Fatalf("refuses = %v (%q), want %v", got, why, row.want)
+			}
+			if row.wantWhy != "" && !strings.Contains(why, row.wantWhy) {
+				t.Fatalf("reason = %q, want it to carry %q", why, row.wantWhy)
+			}
+			if got && !strings.Contains(why, row.host) {
+				t.Fatalf("the refusal does not name the host it could not compare: %q", why)
+			}
+			if !got && why != "" {
+				t.Fatalf("a non-refusal carried a reason: %q", why)
+			}
+		})
+	}
+
+	// The weak form is unchanged, deliberately: the refusal-shaped callers
+	// depend on "might be ours" meaning yes.
+	t.Run("the weak form still says yes to both unknowns", func(t *testing.T) {
+		original := localHostname
+		localHostname = func() string { return "" }
+		t.Cleanup(func() { localHostname = original })
+		if !setupLocalHost("tiny") {
+			t.Fatal("an unknown local hostname changed the weak form's answer")
+		}
+		localHostname = func() string { return "hub44" }
+		if !setupLocalHost("") {
+			t.Fatal("a record with no host changed the weak form's answer")
+		}
+	})
+}
+
+// The caller row. Without it the rule above is a function nothing calls: the
+// mutation that deletes the guard from stopSetupRunner passes every assertion
+// in this file, which is how a helper ends up correct and unused.
+func TestStopSetupRunnerRefusesWhenItCannotCompareTheHost(t *testing.T) {
+	root := t.TempDir()
+	loopDir := filepath.Join(root, ".agentchute", "loop")
+	stateDir := filepath.Join(loopDir, "state", "codex-agentchute")
+	mustMkdir(t, stateDir)
+	mustWrite(t, filepath.Join(stateDir, "runner.json"),
+		[]byte(`{"agent_id":"codex-agentchute","host":"tiny","runner_pid":222,"started_at":"2026-01-01T00:00:00Z","status":"active"}`+"\n"))
+	cfg := &loop.Config{ControlRepo: root, LoopDir: loopDir, Vendor: "agentchute"}
+
+	signaled := map[int]bool{}
+	oldAlive, oldSignal := setupProcessAlive, setupSignalProcess
+	setupProcessAlive = func(int) bool { return true }
+	setupSignalProcess = func(pid int, _ os.Signal) error { signaled[pid] = true; return nil }
+	t.Cleanup(func() { setupProcessAlive, setupSignalProcess = oldAlive, oldSignal })
+
+	t.Run("a record from elsewhere, on a machine that cannot name itself", func(t *testing.T) {
+		original := localHostname
+		localHostname = func() string { return "" }
+		t.Cleanup(func() { localHostname = original })
+
+		stopped, note := stopSetupRunner(cfg, "codex-agentchute")
+		if stopped || signaled[222] {
+			t.Fatalf("signalled a pid from a record naming another machine (stopped=%v)", stopped)
+		}
+		// Silence here would be the old behaviour wearing a different shape:
+		// the operator needs to know why nothing was stopped.
+		if !strings.Contains(note, "hostname could not be determined") {
+			t.Fatalf("the refusal said nothing usable: %q", note)
+		}
+		if !strings.Contains(note, "tiny") {
+			t.Fatalf("the refusal does not name the host it could not compare: %q", note)
+		}
+	})
+
+	// The control: with our own name known and matching, the same record is
+	// stopped exactly as before. Without this the row above is satisfied by a
+	// function that never stops anything.
+	t.Run("the same record on the machine it names is still stopped", func(t *testing.T) {
+		original := localHostname
+		localHostname = func() string { return "tiny" }
+		t.Cleanup(func() { localHostname = original })
+		oldCmdline := setupProcessCommandLine
+		setupProcessCommandLine = func(int) string {
+			return "/usr/local/bin/agentchute serve --as codex-agentchute --control-repo " + root + " --loop-dir " + loopDir + " -- codex"
+		}
+		t.Cleanup(func() { setupProcessCommandLine = oldCmdline })
+
+		if stopped, note := stopSetupRunner(cfg, "codex-agentchute"); !stopped {
+			t.Fatalf("a runner on this very machine was not stopped: %q", note)
+		}
+		if !signaled[222] {
+			t.Fatal("no signal was sent")
+		}
+	})
+}


### PR DESCRIPTION
Tail of grok's #167 sweep. Both gave up silently, and in both cases the silence is indistinguishable from the ordinary "nothing to do here" the same path produces every day.

## `appendHubPointerExclude`

It returned `nil` on **any** git failure. Right for the common case — not a git repository, nothing to exclude — and silent for a git that is not installed, an unreadable git dir, or a repository this user cannot read. All of those end with the pointer file **not** excluded, which surfaces much later as an untracked file the operator did not create and may commit.

Not being a repository stays silent. Anything else says so, quoting what git actually said rather than an exit status. It still does not fail the join: refusing to join over a gitignore nicety would be a worse trade than the one being fixed.

## `setupLocalHost`

It answers "could this record be ours?" and returns true for both of its unknowns — a record with no host, and this machine not knowing its own name. That is the **safe** answer for almost every caller, because they use it to refuse: to decline a wipe, an authorize, or a migration while something might be live. The comment now says so; "true" looked like an accident and is a choice.

The exception is the pair that **stops a process**, where "might be ours" leads to a SIGTERM rather than a refusal. There, one unknown is genuinely unsafe: a record naming another machine, on a machine that cannot say what it is called, has its pid compared against **this** process table, where an unrelated process may sit at the same number.

### The part I got wrong first

I initially refused host-less records too. That broke a real case, and the suite caught it: the check immediately downstream is stronger evidence than any hostname string — the cmdline of a **local** pid, matched against this pool — and runner records written before the host field existed carry no host at all. Refusing them would have stopped `setup` from stopping runners it has always stopped. The narrowed rule is what shipped, and the distinction is a row.

### And a gap in my own test

My first version of the rule was tested only in isolation, so deleting the guard from `stopSetupRunner` failed **nothing** — a helper that is correct and unused looks exactly like a fix. Caught by mutation, not by reading. There is now a caller row driving `stopSetupRunner` end to end, with a control proving a runner on this very machine is still stopped.

## Verification

`tools/test.sh`, the full `integration/sshd` suite under `-race` (105s), and four mutations red under a CI-like stripped PATH: silence restored, warn on every non-repository, the signal path back to the weak form, and the reason dropping the host it could not compare.

## One thing to confirm

I inferred the shape of both findings from the code and the sweep's stated class ("can this check report success without having verified anything") rather than from grok's own wording, which I have not seen. If their inventory describes something different — particularly for `setupLocalHost`, where I deliberately did **not** make a blanket change — this is cheap to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)