### PR TITLE
loop: a heartbeat a second ahead is fresh, not maximally stale (#175)

### DIFF
--- a/internal/loop/filelock_test.go
+++ b/internal/loop/filelock_test.go
@@ -45,6 +45,24 @@ func TestWithAgentLock_SerializesConcurrentLedgerAppends(t *testing.T) {
 	cfg := newLockTestConfig(t)
 	const agentID = "claude-code"
 	const n = 50
+	// #175 sightings 1/2/4: this row failed on ubuntu CI at 5.19s and 5.01s —
+	// the package's own agentLockTimeout, to two decimal places. It is not a
+	// lost-update bug and not scheduler noise.
+	//
+	// MEASURED (macOS, GOMAXPROCS=2, -race, 25 runs): this test takes 1.32s,
+	// stable to ±0.03s. 50 contenders times agentLockRetryInterval's 25ms poll
+	// is 1.25s, so the runtime IS the poll cadence; the critical section barely
+	// registers. That leaves under 4x headroom against a 5s bound, and a
+	// poll-based lock is unfair — a goroutine can lose round after round — so a
+	// slower, loaded runner reaches the bound and RecordOwed returns the
+	// timeout error this test then reports as a failure.
+	//
+	// The property under test is that no update is LOST under concurrency, not
+	// how long the lock waits. So the bound is lifted here rather than the
+	// contention lowered: dropping n would weaken the thing being proven, and
+	// leaving it would keep a correctness row hostage to how busy a runner is.
+	withGenerousAgentLockTimeout(t)
+
 	now := time.Date(2026, 5, 19, 17, 54, 30, 0, time.UTC)
 	by := now.Add(30 * time.Minute)
 
@@ -290,5 +308,62 @@ func TestAtomicWrite_SyncDirFailureAfterRenameNotReportedAsWriteFail(t *testing.
 		if strings.HasPrefix(e.Name(), ".tmp_") {
 			t.Fatalf("leftover temp file %q after atomic write", e.Name())
 		}
+	}
+}
+
+// withGenerousAgentLockTimeout lifts the per-agent lock's bounded wait for the
+// duration of one test. agentLockTimeout is already a package var for exactly
+// this reason — the comment on it says tests lower it to keep the bounded-wait
+// row fast; these two need the opposite, and for the same reason: neither is
+// testing the bound.
+func withGenerousAgentLockTimeout(t *testing.T) {
+	t.Helper()
+	original := agentLockTimeout
+	agentLockTimeout = 60 * time.Second
+	t.Cleanup(func() { agentLockTimeout = original })
+}
+
+// The mechanism, pinned rather than left in an issue comment: with the bound
+// set below what the poll cadence costs, contention produces the timeout error
+// — which is the failure CI was reporting.
+func TestAgentLockBoundIsWhatFiftyContendersHit(t *testing.T) {
+	cfg := newLockTestConfig(t)
+	original := agentLockTimeout
+	agentLockTimeout = 40 * time.Millisecond
+	t.Cleanup(func() { agentLockTimeout = original })
+
+	now := time.Date(2026, 5, 19, 17, 54, 30, 0, time.UTC)
+	by := now.Add(30 * time.Minute)
+	const n = 50
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := MsgID{To: "codex", From: "claude-code", Seq: uint64(i + 1)}
+			if err := RecordOwed(cfg, "claude-code", key, by, now); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	failed := 0
+	for range errs {
+		failed++
+	}
+	if failed == 0 {
+		t.Skip("40ms was enough on this machine; the cadence-versus-bound relationship is what the row documents")
+	}
+	// The point: the failure is the BOUND, not corruption. Whatever did get
+	// recorded is intact and distinct — a timed-out acquirer writes nothing.
+	ledger, err := LoadOwedLedger(cfg, "claude-code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ledger.Owed)+failed != n {
+		t.Fatalf("%d recorded + %d timed out != %d; a timed-out acquire lost or corrupted an update", len(ledger.Owed), failed, n)
 	}
 }

--- a/internal/loop/floor_test.go
+++ b/internal/loop/floor_test.go
@@ -101,6 +101,13 @@ func TestMintSendStampAdvancesWithClock(t *testing.T) {
 func TestMintSendStampConcurrentMintsDistinct(t *testing.T) {
 	cfg := newSeqTestConfig(t)
 	const n = 50
+	// #175 sighting 2: this row failed on ubuntu CI at 5.01s, the package's own
+	// agentLockTimeout. Same mechanism as
+	// TestWithAgentLock_SerializesConcurrentLedgerAppends, measured there: 50
+	// contenders times the 25ms poll cadence is the runtime, leaving under 4x
+	// headroom against the bound. What this row proves is that concurrent mints
+	// are DISTINCT, not how long the lock waits.
+	withGenerousAgentLockTimeout(t)
 	now := time.Date(2026, 5, 9, 16, 8, 36, 0, time.UTC)
 	var (
 		mu   sync.Mutex

--- a/internal/loop/sweep.go
+++ b/internal/loop/sweep.go
@@ -237,18 +237,57 @@ func claimProvablyDead(cfg *Config, id string, now time.Time) bool {
 // producing an unkillable ghost row.
 func registrationAge(path string, now time.Time) (age time.Duration, ok bool) {
 	if reg, err := ReadRegistration(path); err == nil {
-		return clampNonNegativeAge(now.Sub(reg.LastSeen)), true
+		return registrationAgeFrom(now, reg.LastSeen), true
 	}
 	info, err := os.Stat(path)
 	if err != nil {
 		return 0, false
 	}
-	return clampNonNegativeAge(now.Sub(info.ModTime())), true
+	return registrationAgeFrom(now, info.ModTime()), true
 }
 
-func clampNonNegativeAge(age time.Duration) time.Duration {
-	if age < 0 {
-		return math.MaxInt64
+// registrationFutureTolerance is how far ahead of `now` a last_seen may be and
+// still count as FRESH rather than as maximally stale.
+//
+// It exists because the two sides of this subtraction do not have the same
+// precision. Registrations serialise last_seen with time.RFC3339 — SECOND
+// precision — while the sweep captures `now` at full precision. A heartbeat
+// that lands after `now` but crosses a second boundary therefore records a
+// timestamp LATER than `now`, and the old clamp turned that negative age into
+// math.MaxInt64: maximally stale, the verdict it gave to a row that had just
+// heartbeated. That is not a test flake. The under-lock re-check exists so a
+// concurrent heartbeat beats the sweep (C12), and in this window it instead
+// DELETED a live lane's registration row.
+//
+// One second is the granularity the serialisation guarantees; the second is
+// slack for the pass itself, which does real filesystem work between capturing
+// `now` and re-checking under the lock.
+//
+// A tolerance is safe in a way that removing the immortality guard would not
+// be: it grants a future-dated row only that much extra life, since the row
+// stops being future as the clock advances. Erring larger costs little if
+// cross-host clock skew ever turns up in the field. The 2-hour row in
+// TestSweepStaleRegistrationsFutureLastSeenIsNotImmortal stays sweepable, which
+// is the requirement in tension with this one and the reason the old clamp
+// existed at all.
+//
+// NOT fixed by widening the serialisation to RFC3339Nano, deliberately: rows
+// already on disk carry second precision, and the format is what other
+// implementations read. The comparison is what was wrong, so the comparison is
+// what changed.
+const registrationFutureTolerance = 2 * time.Second
+
+func registrationAgeFrom(now, lastSeen time.Time) time.Duration {
+	age := now.Sub(lastSeen)
+	if age >= 0 {
+		return age
 	}
-	return age
+	if -age <= registrationFutureTolerance {
+		// Slightly ahead: this is the second-precision artefact, and the row is
+		// as fresh as a row can be.
+		return 0
+	}
+	// Far ahead: clock skew or a hand edit. Keep the old verdict, so a bogus
+	// timestamp cannot make a row permanently sweep-immune.
+	return math.MaxInt64
 }

--- a/internal/loop/sweep_future_tolerance_test.go
+++ b/internal/loop/sweep_future_tolerance_test.go
@@ -1,0 +1,95 @@
+package loop
+
+import (
+	"math"
+	"os"
+	"testing"
+	"time"
+)
+
+// #175, sighting 3, root-caused and now fixed.
+//
+// Registrations serialise last_seen with time.RFC3339 — SECOND precision —
+// while the sweep captures `now` at full precision. A heartbeat landing after
+// `now` that crosses a second boundary records a timestamp LATER than `now`,
+// and the old clamp turned that negative age into math.MaxInt64: maximally
+// stale, for a row that had just heartbeated.
+//
+// It presented as a CI flake and is not one. The under-lock re-check exists so
+// a concurrent heartbeat beats the sweep (C12); in this window it deleted a
+// live lane's registration row instead.
+func TestRegistrationAgeTreatsASlightlyFutureHeartbeatAsFresh(t *testing.T) {
+	now := time.Date(2026, 8, 20, 12, 0, 0, 400*int(time.Millisecond), time.UTC)
+	rows := []struct {
+		name     string
+		lastSeen time.Time
+		want     time.Duration
+	}{
+		{
+			// The measured case: `now` is 12:00:00.4, the heartbeat lands at
+			// 12:00:01.05 and serialises to 12:00:01 — 600ms "in the future".
+			name:     "the second-precision artefact",
+			lastSeen: now.Truncate(time.Second).Add(time.Second),
+			want:     0,
+		},
+		{
+			name:     "exactly at the tolerance is still fresh",
+			lastSeen: now.Add(registrationFutureTolerance),
+			want:     0,
+		},
+		{
+			// The requirement in tension, and the reason the clamp existed: a
+			// row dated far ahead must not become permanently sweep-immune.
+			name:     "far ahead is still maximally stale",
+			lastSeen: now.Add(2 * time.Hour),
+			want:     math.MaxInt64,
+		},
+		{
+			name:     "just past the tolerance is maximally stale",
+			lastSeen: now.Add(registrationFutureTolerance + time.Second),
+			want:     math.MaxInt64,
+		},
+		{
+			name:     "an ordinary past heartbeat is its real age",
+			lastSeen: now.Add(-90 * time.Second),
+			want:     90 * time.Second,
+		},
+	}
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			if got := registrationAgeFrom(now, row.lastSeen); got != row.want {
+				t.Fatalf("age = %v, want %v", got, row.want)
+			}
+		})
+	}
+}
+
+// The end-to-end half: the same shape through SweepStaleRegistrations, made
+// deterministic rather than raced for. The heartbeat lands in the gap between
+// the outer scan and the per-candidate lock — the window C12 is about — and
+// carries a last_seen a second ahead of the sweep's `now`, which is exactly
+// what a real heartbeat crossing a second boundary writes.
+func TestSweepKeepsARowWhoseHeartbeatLandedASecondAhead(t *testing.T) {
+	cfg := newLeaseTestConfig(t)
+	now := time.Now().UTC()
+	seedSweepRegistration(t, cfg, "just-heartbeated", now.Add(-2*time.Hour))
+	seedSweepRegistration(t, cfg, "still-dead", now.Add(-2*time.Hour))
+
+	t.Cleanup(func() { afterSweepScanHook = nil })
+	afterSweepScanHook = func() {
+		// A second ahead of the sweep's now: the artefact, without needing a
+		// real second to pass or a sleep to make it likely.
+		seedSweepRegistration(t, cfg, "just-heartbeated", now.Add(time.Second))
+	}
+
+	removed, err := SweepStaleRegistrations(cfg, "self", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(removed) != 1 || removed[0] != "still-dead" {
+		t.Fatalf("removed = %v, want [still-dead] — a row that heartbeated during the pass was deleted", removed)
+	}
+	if _, err := os.Stat(cfg.AgentRegistrationPath("just-heartbeated")); err != nil {
+		t.Fatalf("the just-heartbeated row was removed: %v", err)
+	}
+}


### PR DESCRIPTION
Both halves of #175. One was a real data-loss bug wearing a flake's clothes; the other is a measured bound, not a race.

## The sweep clamp — a live lane's row could be deleted

Registrations serialise `last_seen` with `time.RFC3339` — **second** precision — while the sweep captures `now` at full precision. A heartbeat landing after `now` that crosses a second boundary records a timestamp **later** than `now`, and `clampNonNegativeAge` turned that negative age into `math.MaxInt64`: maximally stale, for a row that had just heartbeated.

That is worse than a flake. The under-lock re-check exists so a concurrent heartbeat **beats** the sweep (C12); in this window it deleted a live lane's registration row instead.

Fixed with a **tolerance** rather than by dropping the clamp, because the two requirements are in genuine tension — a far-future row must not become permanently sweep-immune (`TestSweepStaleRegistrationsFutureLastSeenIsNotImmortal`). Slightly ahead is fresh; far ahead stays maximally stale. A finite tolerance is safe in a way removing the guard is not: it grants only that much extra life, since the row stops being future as the clock advances.

**Not** fixed by widening the format to `RFC3339Nano`, deliberately: rows already on disk carry second precision, and the format is what other implementations read. The comparison was wrong, so the comparison changed.

## The serialization rows — reproduced first, and there is nothing to fix

Both failed on ubuntu at **5.19s** and **5.01s** — `agentLockTimeout`, to two decimal places.

**Measured** (macOS, `GOMAXPROCS=2`, `-race`, 25 runs): each takes **1.32s, stable to ±0.03s**. Fifty contenders × `agentLockRetryInterval`'s 25ms poll = 1.25s. The runtime **is** the poll cadence; the critical section barely registers. Under 4× headroom against a 5s bound, on a lock whose polling is unfair — a goroutine can lose round after round — is what a loaded runner eats.

So the bound is lifted for those two rows, through the var that already exists for this purpose (its own comment says tests lower it; these need the opposite, for the same reason). What they prove is that **no update is lost** and that **mints are distinct** — not how long the lock waits. Lowering `n` would have weakened the thing being proven; leaving it keeps a correctness row hostage to how busy a runner is.

The cadence-versus-bound relationship is now a **row** rather than an issue comment: with the bound set below what polling costs, contention produces the timeout error — and the row also asserts a timed-out acquirer loses nothing (recorded + timed out = total).

## Reported, not fixed

1.32s of wall-clock for fifty acquisitions of a lock that is uncontended in substance is a fact about `agentLockRetryInterval` that deserves a deliberate decision. Changing the poll cadence or adding backoff is fleet-wide lock behaviour and not something to slip into a flake fix.

## Verification

`tools/test.sh`; `internal/loop` hammered at `-race -count=40`; six mutations red under a CI-like stripped PATH (restore the old clamp, make any future immortal, widen the tolerance past the immortality guard, and the three above).

Closes #175 · relates to #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)