### PR TITLE
hub session: let an in-flight write finish before an async close (#176)

### DIFF
--- a/internal/cli/hub_session.go
+++ b/internal/cli/hub_session.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sync/atomic"
 	"time"
 
 	"github.com/agentchute/agentchute/internal/hubwire"
@@ -102,6 +103,10 @@ func (t hubSessionTiming) withDefaults() hubSessionTiming {
 }
 
 type hubSession struct {
+	// writeInFlight is true while a frame is being written. Asynchronous closes
+	// read it to avoid cutting a control line in half; see closeAfterWriteIdle.
+	writeInFlight atomic.Bool
+
 	transport    hubSessionTransport
 	reader       *hubwire.Reader
 	writer       *hubwire.Writer
@@ -153,11 +158,11 @@ func serveHubSession(ctx context.Context, transport hubSessionTransport, opts hu
 	go func() {
 		select {
 		case <-ctx.Done():
-			_ = transport.Close()
+			s.closeAfterWriteIdle()
 		case <-done:
 		}
 	}()
-	s.oneShotTimer = time.AfterFunc(timing.OneShotLifetime, func() { _ = transport.Close() })
+	s.oneShotTimer = time.AfterFunc(timing.OneShotLifetime, func() { s.closeAfterWriteIdle() })
 	defer s.oneShotTimer.Stop()
 
 	raw, err := s.read(timing.Hello)
@@ -514,15 +519,57 @@ func (s *hubSession) prepareWriteDeadline() error {
 // returns a deadline error even if the OS does not interrupt that call, so the
 // session reaches its single defer path; that existing path remains the only
 // place a held lease is released.
+// hubSessionCloseGrace is how long an asynchronous close waits for an in-flight
+// write to finish before closing anyway.
+//
+// #176: serveHubSession's ctx.Done goroutine and its one-shot timer both closed
+// the transport with nothing coordinating against a write in progress, and in
+// production ctx is signal.NotifyContext(SIGTERM, SIGHUP). sshd SIGHUPs a
+// forced command when its channel goes away, so an ordinary disconnect at the
+// wrong microsecond cut a control line in half and the peer reported a
+// truncated control frame — "the hub looks broken" for a hub that is fine.
+//
+// Why a GRACE and not a mutex: those closers ARE the unwedging mechanism. A
+// lock that makes Close wait for the write can hang a SIGTERM'd session
+// forever, and the deadline that would bound it is not reliably available —
+// stdioHubTransport wraps inherited os.Stdin/os.Stdout, which are typically not
+// pollable, so SetWriteDeadline returns ErrNoDeadline. A bounded wait keeps the
+// unwedge and buys the common case, where the write is milliseconds from done.
+//
+// Polling rather than signalling, deliberately: at 5ms it is at most 50 wakeups
+// on a path that runs once per session, and it cannot miss a wakeup or deadlock
+// the way a condition variable racing a Close can.
+const (
+	hubSessionCloseGrace     = 250 * time.Millisecond
+	hubSessionCloseGracePoll = 5 * time.Millisecond
+)
+
+// closeAfterWriteIdle closes the transport, giving an in-flight write a bounded
+// chance to finish first. It always closes.
+func (s *hubSession) closeAfterWriteIdle() {
+	deadline := s.now().Add(hubSessionCloseGrace)
+	for s.writeInFlight.Load() && s.now().Before(deadline) {
+		time.Sleep(hubSessionCloseGracePoll)
+	}
+	_ = s.transport.Close()
+}
+
 func (s *hubSession) watchIO(after time.Duration, operation func() error) error {
 	done := make(chan error, 1)
-	go func() { done <- operation() }()
+	go func() {
+		s.writeInFlight.Store(true)
+		defer s.writeInFlight.Store(false)
+		done <- operation()
+	}()
 	timer := time.NewTimer(after)
 	defer timer.Stop()
 	select {
 	case err := <-done:
 		return err
 	case <-timer.C:
+		// Deliberately the RAW close, not the graceful one: this fires because
+		// the write is stuck, so waiting for it to become idle would wait for
+		// exactly the thing that is not happening.
 		_ = s.transport.Close()
 		return os.ErrDeadlineExceeded
 	}

--- a/internal/cli/hub_session_signal_test.go
+++ b/internal/cli/hub_session_signal_test.go
@@ -1,10 +1,7 @@
 package cli
 
 import (
-	"errors"
-	"io"
 	"net"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -20,6 +17,7 @@ type halfWriteTransport struct {
 	net.Conn
 	prefix   int
 	armed    bool
+	paused   bool
 	released chan struct{}
 	once     sync.Once
 }
@@ -33,6 +31,7 @@ func (t *halfWriteTransport) Write(p []byte) (int, error) {
 	if err != nil {
 		return n, err
 	}
+	t.paused = true
 	<-t.released // the cancel lands here, mid-frame
 	rest, err := t.Conn.Write(p[t.prefix:])
 	return n + rest, err
@@ -40,25 +39,36 @@ func (t *halfWriteTransport) Write(p []byte) (int, error) {
 
 func (t *halfWriteTransport) release() { t.once.Do(func() { close(t.released) }) }
 
-// A signal arriving while a hub session is mid-write truncates the frame instead
-// of finishing it, and the client reports "truncated control frame".
+// wrotePrefixBeforeRelease reports whether the transport actually split a frame.
+// Without it, "the frame arrived whole" is also what a transport that never
+// paused would produce — the row would pass for the wrong reason.
+func (t *halfWriteTransport) wrotePrefixBeforeRelease() bool { return t.paused }
+
+// A signal arriving while a hub session is mid-write must let the frame FINISH,
+// not cut it in half.
 //
-// serveHubSession runs a goroutine that closes the transport on ctx.Done, and ctx
-// is signal.NotifyContext(SIGTERM, SIGHUP) in production (hub.go:49). Nothing
-// coordinates that close with a write in progress, so a signal delivered between
-// the first and last byte of a control line cuts the line in half. The peer has
-// already received a partial JSON object with no newline, which is exactly what
-// hubwire's reader calls a truncated control frame (codec.go:47).
+// serveHubSession runs a goroutine that closes the transport on ctx.Done, and
+// ctx is signal.NotifyContext(SIGTERM, SIGHUP) in production (hub.go:49).
+// Nothing used to coordinate that close with a write in progress, so a signal
+// delivered between the first and last byte of a control line cut the line in
+// half; the peer received a partial JSON object with no newline, which
+// hubwire's reader reports as a truncated control frame (codec.go:47).
 //
-// This is not a hypothetical teardown. sshd sends SIGHUP to a forced-command
+// That is not a hypothetical teardown. sshd sends SIGHUP to a forced-command
 // process when its channel goes away, so an ordinary disconnect at the wrong
-// microsecond produces a CORRUPT frame rather than a clean end — and the peer
-// cannot tell that from a protocol violation by the other side.
+// microsecond produced a CORRUPT frame rather than a clean end — "the hub looks
+// broken" for a hub that is fine, and the peer cannot tell that from a protocol
+// violation by the other side.
 //
-// The row constructs the timing deterministically rather than racing for it: the
-// transport is paused after a fixed prefix, the context is cancelled while it is
-// paused, and only then is the write allowed to continue.
-func TestHubSessionSignalDuringWriteTruncatesTheFrame(t *testing.T) {
+// This row was written to CHARACTERISE the truncation (de4da74) and is flipped
+// here, in the same commit as the fix, because it is the only thing covering
+// the behaviour — splitting them would leave a window with no coverage at all.
+//
+// The timing is constructed, not raced for: net.Pipe is synchronous, so a
+// partial write only lands if the peer is already reading. The reader starts
+// FIRST, the transport pauses after a fixed prefix, the context is cancelled
+// while it is paused, and only then is the write allowed to continue.
+func TestHubSessionSignalDuringWriteLetsTheFrameFinish(t *testing.T) {
 	pool, _ := newHubPool(t)
 	var transport *halfWriteTransport
 	s := startHubSession(t, pool, "codex", hubSessionTiming{}, func(c net.Conn) hubSessionTransport {
@@ -68,17 +78,16 @@ func TestHubSessionSignalDuringWriteTruncatesTheFrame(t *testing.T) {
 
 	helloHub(t, s, "codex", 1)
 
-	// net.Pipe is synchronous, so the partial write only lands if the peer is
-	// already reading. Start the read FIRST: it consumes the prefix, then blocks
-	// waiting for a newline that is never coming — which is precisely the state
-	// this row is about.
-	type result struct{ err error }
+	type result struct {
+		raw hubwire.RawFrame
+		err error
+	}
 	got := make(chan result, 1)
 	started := make(chan struct{})
 	go func() {
 		close(started)
-		_, err := s.reader.Read()
-		got <- result{err: err}
+		raw, err := s.reader.Read()
+		got <- result{raw: raw, err: err}
 	}()
 	<-started
 
@@ -87,8 +96,8 @@ func TestHubSessionSignalDuringWriteTruncatesTheFrame(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Cancel while the write is held mid-frame, then let it resume into a
-	// transport the ctx goroutine has already closed underneath it.
+	// Cancel while the hub's reply is held mid-frame, then release it well
+	// inside the grace. The close must wait for the write it interrupted.
 	time.Sleep(200 * time.Millisecond)
 	s.cancel()
 	time.Sleep(50 * time.Millisecond)
@@ -96,16 +105,69 @@ func TestHubSessionSignalDuringWriteTruncatesTheFrame(t *testing.T) {
 
 	select {
 	case r := <-got:
-		if r.err == nil {
-			t.Fatal("expected the frame to be cut short, got a complete one")
+		if r.err != nil {
+			t.Fatalf("the frame was still cut short: %v", r.err)
 		}
-		if errors.Is(r.err, io.EOF) {
-			t.Fatalf("got a clean EOF, not a truncated frame — the write was not actually in flight: %v", r.err)
+		// Proof the write was genuinely IN FLIGHT rather than never started:
+		// the prefix had already been delivered before the cancel, so a whole
+		// frame here means the remainder was allowed to follow it.
+		if !transport.wrotePrefixBeforeRelease() {
+			t.Fatal("the transport never paused mid-frame, so this row proved nothing")
 		}
-		if !strings.Contains(r.err.Error(), "truncated control frame") {
-			t.Fatalf("error = %v, want the truncated-control-frame report that red #3 produces on ubuntu", r.err)
+		if r.raw.T != "error" && r.raw.T != "status-ok" {
+			t.Fatalf("frame type = %q, want the hub's reply", r.raw.T)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("reader never returned")
+	}
+}
+
+// The other half of the same design, and the hazard the fix had to avoid: the
+// grace is BOUNDED. Those closers are the unwedging mechanism, so a write that
+// never finishes must not hold a SIGTERM'd session open forever.
+//
+// A mutex here would do exactly that, and the deadline that would bound it is
+// not available: stdioHubTransport wraps inherited os.Stdin/os.Stdout, which
+// are typically not pollable, so SetWriteDeadline returns ErrNoDeadline.
+func TestHubSessionCloseGraceIsBounded(t *testing.T) {
+	pool, _ := newHubPool(t)
+	var transport *halfWriteTransport
+	s := startHubSession(t, pool, "codex", hubSessionTiming{}, func(c net.Conn) hubSessionTransport {
+		transport = &halfWriteTransport{Conn: c, prefix: 12, released: make(chan struct{})}
+		return transport
+	}, nil)
+	t.Cleanup(transport.release)
+
+	helloHub(t, s, "codex", 1)
+
+	got := make(chan error, 1)
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		_, err := s.reader.Read()
+		got <- err
+	}()
+	<-started
+
+	transport.armed = true
+	if err := s.writer.Write(hubwire.Status{RequestBase: hubwire.RequestBase{T: "status", ID: 2}}, nil); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+
+	// Cancel and NEVER release: the write stays in flight for good.
+	cancelled := time.Now()
+	s.cancel()
+
+	select {
+	case <-got:
+		waited := time.Since(cancelled)
+		// It must not wait meaningfully longer than the grace. Generous slack,
+		// because the assertion is "bounded", not "precisely 250ms".
+		if waited > 3*time.Second {
+			t.Fatalf("the close waited %v for a write that never finished; the grace is not bounded", waited)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a stuck write held the session open past every bound — the unwedge is gone")
 	}
 }


### PR DESCRIPTION
`serveHubSession`'s `ctx.Done` goroutine and its one-shot timer both closed the transport with nothing coordinating against a write in progress, and in production `ctx` is `signal.NotifyContext(SIGTERM, SIGHUP)`.

sshd SIGHUPs a forced-command process when its channel goes away, so an ordinary disconnect at the wrong microsecond cut a control line in half: the peer received a partial JSON object with no newline and reported a truncated control frame. "The hub looks broken" for a hub that is fine — and indistinguishable from the other side violating the protocol.

## A grace, not a mutex

The issue is explicit about why, and it is the part worth checking: **those closers are the unwedging mechanism.** A lock that makes `Close` wait for the write can hang a SIGTERM'd session forever, and the deadline that would bound it is not reliably available — `stdioHubTransport` wraps inherited `os.Stdin`/`os.Stdout`, which are typically not pollable, so `SetWriteDeadline` returns `ErrNoDeadline`.

So: ~250ms of write-idle grace, then close regardless. Both halves are rows, because a fix that got either wrong would look right:

- a frame interrupted mid-write now arrives **whole**;
- a write that **never** finishes does not hold the session open — the close happens anyway.

Two smaller decisions, each a comment at its line:

- `watchIO`'s own timeout keeps the **raw** close. It fires because the write is stuck, so waiting for write-idle there would wait for exactly the thing that is not happening.
- Polling at 5ms rather than signalling: at most 50 wakeups on a path that runs once per session, and it cannot miss a wakeup or deadlock the way a condition variable racing a `Close` can.

## The row flip, in this commit

`de4da74`'s characterization row asserted the truncation. It is flipped **here** rather than in a follow-up because it is the only thing covering this behaviour, and splitting the two would leave a window with no coverage at all. That was #173's constraint, carried over when it was deduped into this issue.

Its other detail is honoured too: `net.Pipe` is synchronous, so a partial write only lands if the peer is already reading — the reader starts **first** and the timing is constructed rather than raced for.

And the flipped row has to prove the write was genuinely in flight, or "the frame arrived whole" is equally what a transport that never paused would produce. The fixture now reports whether it actually split a frame, and the row asserts it.

## Verification

`tools/test.sh`, `internal/cli` under `-race`, and the full `integration/sshd` suite under `-race` (109s) — it drives real signal-terminated sessions. Four mutations red under a CI-like stripped PATH: restore the raw close, drop the bound, never set the marker, shrink the grace below what the write needs.

Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)