### PR TITLE
spec: say what §13.9a does NOT enforce, and where the structural repair is

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -470,6 +470,18 @@ Implementations that keep no state inside the hub directory are unaffected. This
 where state may live as much as how it is written: putting a writer's state inside the
 migrated tree is what creates the requirement.
 
+**What this does and does not enforce.** The requirement is enforced at acquisition: a process
+that takes the lock cannot have a migration run underneath it, and a migration refuses while
+any holder lives. It is **not** enforced at write time, and cannot be — a descriptor follows
+the inode, so a writer that never took the lock is invisible to it. Two consequences follow
+and both are accepted, not overlooked. A violator that re-resolves its path after the freeze
+has its write **orphaned** in a recreated directory; a violator holding a descriptor from
+before the freeze has its write **destroyed** with the frozen tree. Neither is reachable from
+agentchute's own code paths, which acquire the lock at a single seam; both remain reachable
+for a binary older than this contract and for any process outside agentchute. The structural
+repair is to keep lane state out of the hub-id-keyed directory entirely, so that a URL change
+renames nothing a writer can hold open.
+
 ### 13.10 Error-code registry
 
 Wire frame: `{"t":"error","re":N,"code":"E_…","msg":"<human text>","retriable":false}`


### PR DESCRIPTION
opus-xhigh's ruling on #179: **document the ceiling** for this release, file the layout change as the successor, close the write barrier on its merits.

## What changed

§13.9a stated the MUST and what happens in a compliant world. It said nothing about what is true when the MUST is **violated** — which is exactly what a reader of a structural-sounding promise needs.

It now says the requirement is enforced at **acquisition**, not at write time, and cannot be enforced at write time: a descriptor follows the inode, so a writer that never took the lock is invisible to the lock. Both consequences are named as accepted rather than left to be discovered:

- a violator that re-resolves its path after the freeze has its write **orphaned** in a recreated directory;
- a violator holding a descriptor from before the freeze has its write **destroyed** with the frozen tree.

Neither is reachable from agentchute's own paths, which take the lock at a single seam. Both stay reachable for a binary older than this contract and for any process outside agentchute — the half no barrier written in  could ever bind, which is why (1) was rejected on its merits rather than its cost.

The closing sentence names the structural repair, so this reads as a stated ceiling rather than "we are done here".

## Correcting my own framing, on the record

The design request that produced this ruling described the post-#162 residual as "orphaned". That contradicted my own next paragraph **and** this very section, which has always said the write "lands in the moved-aside tree and is destroyed with it". Part of the residual is **deleted**, not orphaned — and "only orphaning" would have made documenting the ceiling look obviously sufficient for a reason that is not true. opus-xhigh caught it; the ruling stands on the true statement instead.

## Scope

Spec text only. No behaviour change, no code touched.

Refs #179 — which is being rewritten as the layout change (lane state out of the hub-id-keyed directory), with the writer enumeration that #162's two findings did not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)