### PR TITLE
release: write v1.6.1's notes, finalise v1.6.0's, and add the step that was missing

### DIFF
--- a/docs/internal/PLAYBOOKS.md
+++ b/docs/internal/PLAYBOOKS.md
@@ -33,6 +33,31 @@ Companion to the **Working efficiently on this bus** rules in [`AGENTS.md`](../.
 4. Same checkout-cleanup obligation as gate-review step 4: if this re-gate needed its own pinned-SHA checkout, remove it before the verdict too.
 5. Verdict with the delta range cited — and re-check `headRefOid` right before sending, per gate-review step 5. A re-gate is the likeliest place for the head to move again while you work.
 
+## release-notes (before every tag)
+
+The release workflow uses `docs/releases/<tag>.md` **as the GitHub release body**, and smokes
+`test -s` on it before publishing. Two things follow, and both have bitten:
+
+1. **The file must exist before the tag is pushed.** A tag without one fails the release job at
+   its smoke gate, after the tag exists. That is recoverable only because nothing was published
+   yet — delete the tag, add the file, re-tag.
+2. **The file must be final at tag time, not a working draft.** Whatever it says becomes the
+   published release body verbatim. `docs/releases/v1.6.0.md` opened with "**In progress.** …it
+   is not a published release" and that sentence went live on the GitHub release, because the
+   file was written as an accumulating scratchpad during the milestone and nobody finalised it.
+
+So, before pushing any `v*` tag:
+
+1. `test -s docs/releases/<tag>.md` — the same check the workflow runs, run where it is cheap.
+2. Read the first paragraph as an operator would, on the release page. Strip any in-progress or
+   accumulating-notes framing; it is a published document the moment the tag lands.
+3. Confirm it states the upgrade obligation explicitly — what an operator must do, and what is
+   unchanged (protocol, wire version, whether hub and joiners must match).
+4. Only then tag.
+
+If a milestone wants a scratchpad, keep it somewhere that is not the notes file the workflow
+publishes.
+
 ## owed-audit (when `pending` grows stale — E7)
 
 1. `agentchute pending --as $ID` — list outstanding obligations with their `by` deadlines.

--- a/docs/releases/v1.6.0.md
+++ b/docs/releases/v1.6.0.md
@@ -1,6 +1,8 @@
 # agentchute v1.6.0
 
-**In progress.** This file accumulates notes until the M6 release; it is not a published release.
+One pool, one filesystem, however many machines. Remote agents join a hub over plain SSH: the hub pins each agent's identity and pool in a forced-command `authorized_keys` line, the client discovers remoteness from an `ssh://` locator, and every command works identically on the hub and on a joining machine.
+
+The hub is opt-in and additive — a single-machine pool behaves exactly as it did in v1.5.7. Protocol v2.5 and registration wire version `v: 3` are unchanged. A joining machine and its hub must run the same version; a mismatch is refused with `E_VERSION`, and the hub upgrades first.
 
 ## Operation seam (M1)
 

--- a/docs/releases/v1.6.1.md
+++ b/docs/releases/v1.6.1.md
@@ -1,0 +1,43 @@
+# agentchute v1.6.1
+
+No new capability. This is what the first days of v1.6.0 in real use turned up: one field report, one read-only sweep for a defect *class* rather than its instances, and two CI flakes that were not flakes. Every change is a fix, a refusal that was missing, or a message that told you the wrong thing.
+
+**Upgrading.** Nothing is required of you. Protocol v2.5 and registration wire version `v: 3` are unchanged, and the only registry surface is one additive client-side error code, `E_HUB_PINNING_UNVERIFIED`. A joined machine and its hub still need matching versions — upgrade the hub first, as always.
+
+## Two things that could lose your data
+
+- **A sweep could delete a live lane's registration row.** Registration rows record `last_seen` at second precision while the sweep reads the clock at full precision, so a heartbeat that landed while the sweep was running could read as *maximally stale* — in the exact window the sweep's re-check exists to protect. A `last_seen` up to two seconds ahead now counts as fresh; one far ahead still ages out, so a badly dated row cannot become permanently unsweepable ([#197](https://github.com/agentchute/agentchute/pull/197)).
+- **A disconnect could corrupt the last frame of a hub session.** sshd sends SIGHUP to a forced command when its channel goes away, and the session closed its transport without waiting for a write already in progress — so an ordinary disconnect at the wrong microsecond cut a control line in half and the other side reported a truncated frame. "The hub looks broken", for a hub that was fine. A close now waits a bounded moment for an in-flight write, and still closes if that write never finishes ([#198](https://github.com/agentchute/agentchute/pull/198)).
+
+## Messages that told you the wrong thing
+
+- `agentchute update` now quotes what the re-sync said, next to the warning that it failed. It used to report `exit status 1` alone, so an operator whose `setup` hit the symlink guard had to re-run the printed command by hand to see a message that had already been printed — a dozen lines above the warning ([#184](https://github.com/agentchute/agentchute/pull/184)).
+- `doctor`'s pinning check has a **third** answer. A probe that could not run at all now says so — a warning with the reason — instead of printing the all-clear for a check that never happened. `doctor` still exits 0 when that is the only finding, because an unreachable probe is not evidence that a hub is unpinned. On the client side that outcome is `E_HUB_PINNING_UNVERIFIED`, retriable, and it names both causes it cannot distinguish rather than asserting either ([#195](https://github.com/agentchute/agentchute/pull/195)).
+- A multiplex master is reported as reaped only when its socket is provably gone. "Permission denied" may be a live master owned by another account, and a refused connection is indistinguishable from a live one whose backlog is full — neither is proof, and neither is silently treated as success any more ([#194](https://github.com/agentchute/agentchute/pull/194)).
+
+## Joins that finish
+
+- `hub join` records the hub's host-key fingerprint via `ssh-keyscan` when `known_hosts` has nothing to offer. Without one, that hub could never be **migrated** to a new URL later — and you would meet it much later as a duplicate-key refusal suggesting `--replace-key`, which was the wrong remedy for a machine that had not been replaced. If neither source works, the join still succeeds and warns, naming what breaks later ([#185](https://github.com/agentchute/agentchute/pull/185)).
+- A key whose `.pub` never landed — an interrupted mint — used to fail the join on every re-run, with nothing naming the escape. It is now regenerated from the private key rather than replaced, because a replacement would strand a credential your hub may already have authorized ([#191](https://github.com/agentchute/agentchute/pull/191)).
+
+## Refusals that were missing
+
+- `setup --wipe-state` refuses when it cannot read the directory holding serve claims, instead of reading "unreadable" as "no claims here" and proceeding. Its post-wipe check likewise reports what it could not read separately from what it found — "I looked and found nothing" and "I could not look" are opposite answers ([#193](https://github.com/agentchute/agentchute/pull/193)).
+- A serve lease is not acquired when the machine cannot determine its own hostname. That error was being discarded and the host recorded as empty, so a frozen-but-alive lane on your own machine looked like it belonged to another one and had its id taken ([#193](https://github.com/agentchute/agentchute/pull/193)).
+- Two silent give-ups now speak: a `git` failure of any kind is no longer read as "not a repository" when excluding the control-repo pointer, and the stop-a-process path refuses rather than guessing when it cannot compare a recorded host against this machine ([#196](https://github.com/agentchute/agentchute/pull/196)).
+
+## The guard stops denying the fix it recommends
+
+`agentchute check` printed "prune with: `agentchute clean --owed`" and, in the same breath, armed the latch that denied it — and the latch clears at the end of a turn, so a lane never had a moment where it both knew about the obligation and could act on it. `clean --owed` is now permitted while latched. `clean --mailbox`, which deletes a peer's inbox, is not ([#188](https://github.com/agentchute/agentchute/pull/188)).
+
+## Honesty about what the spec enforces
+
+§13.9a stated the write-lock requirement and what happens when everyone follows it. It now also states what is true when someone does not: the requirement is enforced when the lock is *acquired*, not at each write, and it cannot be enforced at write time — so a writer that never took the lock is invisible to it. That covers no current agentchute lane, and it does cover an older binary or any process outside agentchute ([#200](https://github.com/agentchute/agentchute/pull/200)).
+
+## For contributors
+
+`tools/test.sh` runs `go test -race`, which CI and the release job always did — the ritual contributors are told to run before pushing was weaker than the gate judging the push, in exactly the class that is invisible locally. A test now fails when the two disagree ([#187](https://github.com/agentchute/agentchute/pull/187), [#189](https://github.com/agentchute/agentchute/pull/189)).
+
+## Known follow-ups
+
+[#179](https://github.com/agentchute/agentchute/issues/179) (keep lane state out of the hub-id-keyed directory — the structural repair behind the §13.9a note above), [#180](https://github.com/agentchute/agentchute/issues/180), [#190](https://github.com/agentchute/agentchute/issues/190), [#199](https://github.com/agentchute/agentchute/issues/199), plus the UX and housekeeping tier: [#170](https://github.com/agentchute/agentchute/issues/170), [#171](https://github.com/agentchute/agentchute/issues/171), [#177](https://github.com/agentchute/agentchute/issues/177), [#178](https://github.com/agentchute/agentchute/issues/178), [#152](https://github.com/agentchute/agentchute/issues/152), [#157](https://github.com/agentchute/agentchute/issues/157), [#63](https://github.com/agentchute/agentchute/issues/63).


### PR DESCRIPTION
The v1.6.1 tag failed at the release workflow's smoke gate — `test -s docs/releases/v1.6.1.md` on a file that did not exist. Diagnosing it surfaced a second, worse one: **v1.6.0.md still opened with "In progress. …it is not a published release"**, and the workflow uses that file *as* the GitHub release body — so that sentence has been live on the published v1.6.0 release.

## 1 · `docs/releases/v1.6.1.md`

Written for the operator reading it on GitHub, not for the repo. It opens with the two things that could lose data, then messages that told you the wrong thing, joins that finish, refusals that were missing, the guard, the spec-honesty note, and a contributor section.

The **upgrade note is explicit and near the top**, because that is the question a release page is opened to answer: nothing required, one additive client-side error code (`E_HUB_PINNING_UNVERIFIED`), protocol v2.5 and wire `v: 3` unchanged, hub and joiners still must match.

Facts are #201's changelog section; the voice is not. A changelog entry records what a project did; a release body is a message to someone deciding whether to act.

## 2 · `docs/releases/v1.6.0.md`

The in-progress line is gone and replaced with a real opening paragraph.

**One judgement call:** I did *not* add a date line. No other file in `docs/releases` carries one, and the two candidates disagree — the tag is `2026-08-18 21:53` local, `2026-08-19 01:53` UTC, and `CHANGELOG.md` uses the local convention. Inventing one here would create a discrepancy for someone to find later.

## 3 · The step that was missing

There was **no release playbook at all** — nothing told anyone the notes file must exist before the tag, or that it becomes the published body verbatim.

`docs/internal/PLAYBOOKS.md` gains a `release-notes` ritual stating both facts, with the two failures that produced them named, plus a four-step pre-tag check (run the workflow's own `test -s` where it is cheap; read the first paragraph as an operator would; confirm the upgrade obligation is stated; then tag). It closes with the thing that actually caused this: **if a milestone wants a scratchpad, keep it somewhere the workflow does not publish.**

## Verification

`test -s docs/releases/v1.6.1.md` — the workflow's own gate — and `tools/test.sh`.

Note for the merge sequence: the live v1.6.0 release body still needs editing separately from the corrected file; merging this does not update an already-published release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)