### PR TITLE
three UX defects: invented profiles, a silent half-join, a duplicating retry

### DIFF
--- a/AGENTCHUTE.md
+++ b/AGENTCHUTE.md
@@ -516,7 +516,7 @@ Wire frame: `{"t":"error","re":N,"code":"E_…","msg":"<human text>","retriable"
 
 The two arms are ordered and non-overlapping: the hub arm runs before `hello-ok` exists; the client arm only on a `hello-ok` the hub arm already let through.
 
-Client-side only (never on the wire): `E_CONNECT`, `E_UNAUTHORIZED`, `E_HOSTKEY_CHANGED`, `E_CHANNEL_LOST`, `E_SEND_UNKNOWN`, `E_HELLO_TIMEOUT`, `E_HUB_NO_BINARY`, `E_HUB_UNPINNED`, `E_HUB_PINNING_UNVERIFIED`, `E_NOT_JOINED`, `E_NO_SSH`. (`E_POOL_MISMATCH` is **not** in this list.)
+Client-side only (never on the wire): `E_CONNECT`, `E_UNAUTHORIZED`, `E_HOSTKEY_CHANGED`, `E_CHANNEL_LOST`, `E_SEND_UNKNOWN`, `E_HELLO_TIMEOUT`, `E_HUB_NO_BINARY`, `E_HUB_UNPINNED`, `E_HUB_PINNING_UNVERIFIED`, `E_RESULT_UNKNOWN`, `E_NOT_JOINED`, `E_NO_SSH`. (`E_POOL_MISMATCH` is **not** in this list.)
 
 `E_UNPINNED` is hub-emitted and travels on the wire: a hub reached WITHOUT an
 `authorized_keys` forced command refuses to serve, because the agent id and pool for that
@@ -532,6 +532,16 @@ A code's name is its claim, and when the probe never ran neither neighbour's cla
 `doctor` renders it as a **warning carrying the reason**, not as OK (which would print an
 all-clear for a check that did not happen) and not as a blocker (a transient probe failure
 must not exit `doctor` non-zero and teach operators to ignore it).
+
+`E_RESULT_UNKNOWN` is the streaming counterpart of `E_SEND_UNKNOWN`, and carries the same
+obligation. A streaming operation delivers its results as they arrive and confirms completion
+with a terminal frame; when the connection drops **after** results have been streamed and
+**before** that frame, the client has already rendered work the hub may well have committed.
+It MUST NOT report that as a plain failure, because the two situations that produce it call
+for opposite actions and it cannot distinguish them — the terminal frame is what would have
+said which. It is **not retriable**: at-least-once means a blind re-run re-delivers what the
+operator was just shown. A drop with no streamed output keeps its ordinary classification,
+where "nothing happened, re-run" is correct advice.
 
 ## 14. Namespace
 State lives under the fixed `.agentchute/loop` directory. `AGENTCHUTE.md` is shared; reference-implementation notes live in `.agentchute/loop/README.md`. (Earlier drafts used a vendor-namespaced `.<vendor>/loop/` dotdir and a `.rehumanlabs/` legacy namespace; both are gone — the namespace is now fixed. `reHuman Labs` remains the maker's credit in `README.md`; that's brand, not a namespace.)

--- a/internal/cli/entry.go
+++ b/internal/cli/entry.go
@@ -129,7 +129,7 @@ func Main(a Assets, args []string) int {
 // reserved for actual command failures — doctor's summary line used to print
 // "exit 1" for a blocker, which is a gate verdict, not a failure.
 func exitCodeForError(err error) int {
-	if err == errFailIfAny || err == errBlocked {
+	if err == errFailIfAny || err == errBlocked || err == errHubJoinIncomplete {
 		return 2
 	}
 	return 1

--- a/internal/cli/hub_join.go
+++ b/internal/cli/hub_join.go
@@ -38,6 +38,13 @@ var hubJoinHostname = os.Hostname
 var hubJoinFingerprint = readHubJoinFingerprint
 var hubJoinDiscoverFingerprint = discoverHubJoinFingerprint
 
+// errHubJoinIncomplete is a VERDICT sentinel, not a failure: the local half of
+// the join succeeded, and re-running after authorizing on the hub is the
+// intended next step — but the machine is NOT yet joined, and exiting 0 told
+// every script otherwise. It exits 2, the code this CLI already reserves for
+// "this is a verdict, not a command failure" (#178).
+var errHubJoinIncomplete = errors.New("hub join: authorization still pending on the hub; re-run after authorizing")
+
 func cmdHubJoin(args []string) error {
 	fs := flag.NewFlagSet("hub join", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -223,7 +230,13 @@ func runHubJoin(root string, remote *loop.RemoteConfig, opts hubJoinOptions) err
 			return err
 		}
 		warnHubJoinEnv(remote.URL)
-		return nil
+		// #178: this join is NOT complete — authorization is still pending on
+		// the hub — and it used to exit 0, so a script checking $? read
+		// "half-joined" as "joined". The local half really did succeed (the
+		// pointer and the hub key are recorded, and re-running is the intended
+		// next step), so this is a verdict rather than a failure, which is
+		// exactly what exit 2 already means here.
+		return errHubJoinIncomplete
 	}
 	if !hello.Writable {
 		return fmt.Errorf("joined but the hub session cannot WRITE the pool: check that user %q owns %s (ls -ld), that the .agentchute/loop tree is writable by it, and that the pool was not authorized against another user's checkout", remote.User, hello.Pool)

--- a/internal/cli/hub_join_test.go
+++ b/internal/cli/hub_join_test.go
@@ -157,8 +157,13 @@ func TestHubJoinAuthFallbackWritesProvisionalPointer(t *testing.T) {
 	hubJoinAutoAuthorize = func(*loop.RemoteConfig, string, string, bool) error {
 		return errors.New("operator ssh unavailable")
 	}
-	if err := runHubJoin(root, remote, hubJoinOptions{URL: remote.URL, AgentID: "work-tiny"}); err != nil {
-		t.Fatal(err)
+	// #178: the local half succeeds and the machine is NOT joined, so this
+	// reports the verdict rather than exiting 0. Everything below still has to
+	// hold — the provisional config and the pointer are what make re-running
+	// after authorizing work.
+	err := runHubJoin(root, remote, hubJoinOptions{URL: remote.URL, AgentID: "work-tiny"})
+	if !errors.Is(err, errHubJoinIncomplete) {
+		t.Fatalf("incomplete join returned %v, want errHubJoinIncomplete — exiting 0 tells a script it is fully joined", err)
 	}
 	cfg, err := hubclient.ReadHubConfig(remote.HubID)
 	if err != nil {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -913,15 +913,50 @@ func setupEnsureShimPath(opts setupOptions) error {
 		return nil
 	}
 
+	// #177: write to profiles that EXIST; never create one that does not.
+	//
+	// Joining a hub on a fresh macOS account created ~/.zshrc and ~/.profile,
+	// neither of which the operator had — agentchute inventing a user's login
+	// profiles as a side effect of an unrelated command, with no warning, no
+	// opt-out, and a timestamped backup left behind each time.
+	//
+	// An explicitly named --profile is different and is honoured: naming the
+	// file IS the consent that was missing.
+	named := strings.TrimSpace(opts.Profile) != ""
+	var wrote []string
 	for _, profile := range profiles {
+		if !named {
+			if _, err := os.Stat(profile); err != nil {
+				if !os.IsNotExist(err) {
+					return fmt.Errorf("read profile %s: %w", profile, err)
+				}
+				continue
+			}
+		}
 		if err := setupWritePathBlock(profile, opts.ShimDir); err != nil {
 			return err
 		}
+		wrote = append(wrote, profile)
+	}
+	if len(wrote) == 0 {
+		fmt.Printf("no shell profile found to update, and none was created (looked for: %s).\n", strings.Join(displayHomePaths(profiles), ", "))
+		fmt.Printf("Add this to your shell's startup file yourself:\n\n%s\n", setupRenderPathBlock(profiles[0], opts.ShimDir))
+		fmt.Printf("Or re-run with --profile <path> to name one (it will be created), or --no-profile to skip this step.\n")
+		return nil
 	}
 	if !onPath {
 		fmt.Printf("%s is now on PATH in your shell profile; start a new shell (or source it) before using `ac serve`\n", opts.ShimDir)
 	}
 	return nil
+}
+
+// displayHomePaths renders a list for an operator, ~-abbreviated.
+func displayHomePaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		out = append(out, displayHomePath(p))
+	}
+	return out
 }
 
 func setupPlausibleProfiles(override string) []string {

--- a/internal/cli/ux_wave_test.go
+++ b/internal/cli/ux_wave_test.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #177 — joining a hub must not invent the operator's login profiles.
+//
+// On a fresh macOS account, `hub join` created ~/.zshrc and ~/.profile, neither
+// of which existed: agentchute writing a user's shell startup files as a side
+// effect of an unrelated command, with no warning, no opt-out, and a timestamped
+// backup left behind each time.
+func TestSetupDoesNotCreateAProfileThatDidNotExist(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("PATH", "/usr/bin:/bin")
+	shimDir := filepath.Join(home, ".agentchute", "bin")
+
+	stdout := captureStdout2(t, func() {
+		if err := setupEnsureShimPath(setupOptions{ShimDir: shimDir}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	for _, name := range []string{".zshrc", ".profile"} {
+		if _, err := os.Stat(filepath.Join(home, name)); err == nil {
+			t.Fatalf("agentchute created ~/%s, which did not exist", name)
+		}
+	}
+	// Silence would be worse than the old behaviour: PATH is genuinely not set
+	// up, and the operator has to be told what to add.
+	if !strings.Contains(stdout, "none was created") {
+		t.Fatalf("no warning that nothing was updated:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, setupPathExpr(shimDir)) {
+		t.Fatalf("the operator is not told what to add:\n%s", stdout)
+	}
+	// And how to get the old behaviour back deliberately.
+	if !strings.Contains(stdout, "--profile") || !strings.Contains(stdout, "--no-profile") {
+		t.Fatalf("neither escape hatch is named:\n%s", stdout)
+	}
+}
+
+// The control, and the reason this is a narrowing rather than a removal: a
+// profile that EXISTS is still updated, exactly as before.
+func TestSetupStillUpdatesAProfileThatExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("PATH", "/usr/bin:/bin")
+	zshrc := filepath.Join(home, ".zshrc")
+	if err := os.WriteFile(zshrc, []byte("# mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	shimDir := filepath.Join(home, ".agentchute", "bin")
+
+	if err := setupEnsureShimPath(setupOptions{ShimDir: shimDir}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(zshrc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), setupPathExpr(shimDir)) {
+		t.Fatalf("an existing profile was not updated:\n%s", data)
+	}
+	if !strings.Contains(string(data), "# mine") {
+		t.Fatalf("the operator's own content was lost:\n%s", data)
+	}
+	// The absent sibling (~/.profile) still must not appear.
+	if _, err := os.Stat(filepath.Join(home, ".profile")); err == nil {
+		t.Fatal("agentchute created ~/.profile alongside the one that existed")
+	}
+}
+
+// Naming a file is the consent that was missing, so --profile still creates it.
+func TestSetupCreatesAProfileTheOperatorNamed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("PATH", "/usr/bin:/bin")
+	named := filepath.Join(home, "my-shell-rc")
+	shimDir := filepath.Join(home, ".agentchute", "bin")
+
+	if err := setupEnsureShimPath(setupOptions{ShimDir: shimDir, Profile: named}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(named)
+	if err != nil {
+		t.Fatalf("a profile the operator named was not created: %v", err)
+	}
+	if !strings.Contains(string(data), setupPathExpr(shimDir)) {
+		t.Fatalf("named profile has no PATH block:\n%s", data)
+	}
+}
+
+// #178 — the verdict has to reach the exit code, or a script cannot see it.
+func TestIncompleteHubJoinExitsTwo(t *testing.T) {
+	if got := exitCodeForError(errHubJoinIncomplete); got != 2 {
+		t.Fatalf("exit code = %d, want 2 — a script checking $? cannot tell half-joined from joined", got)
+	}
+	// The controls: an ordinary failure is still 1, and success is still 0.
+	if got := exitCodeForError(errNotJoinedForTest()); got != 1 {
+		t.Fatalf("an ordinary error exits %d, want 1", got)
+	}
+}
+
+func errNotJoinedForTest() error { return os.ErrNotExist }
+
+func captureStdout2(t *testing.T, fn func()) string {
+	t.Helper()
+	out, err := captureStdout(t, func() error {
+		fn()
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}

--- a/internal/hubclient/result_unknown_test.go
+++ b/internal/hubclient/result_unknown_test.go
@@ -1,0 +1,74 @@
+package hubclient
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// #171 — a one-shot that fails AFTER the hub committed and streamed its work.
+//
+// The hub commits the claim and streams it, the client prints all of it, and
+// then the terminal frame is lost. The operator sees their messages followed by
+// "channel to the hub was lost", does the obvious thing, and at-least-once
+// re-delivers what they were just shown. Nothing is lost — the safety property
+// holds exactly as designed. What was wrong is the report: two situations
+// calling for opposite actions rendered identically.
+func TestResultIsUnknownOnlyWhenSomethingWasAlreadyStreamed(t *testing.T) {
+	lost := &Error{Code: "E_CHANNEL_LOST", Msg: "hub: channel to the hub was lost", Retriable: true}
+
+	t.Run("nothing streamed keeps its classification", func(t *testing.T) {
+		// The answer IS known here: nothing happened, and "re-run" is correct
+		// advice. Re-coding this would trade a false failure for a false doubt.
+		got := resultUnknownIfStreamed(lost, 0)
+		if got != error(lost) {
+			t.Fatalf("a drop with no streamed output was re-coded: %v", got)
+		}
+	})
+
+	t.Run("streamed output makes the result unknown", func(t *testing.T) {
+		got := resultUnknownIfStreamed(lost, 3)
+		if ErrorCode(got) != "E_RESULT_UNKNOWN" {
+			t.Fatalf("code = %s, want E_RESULT_UNKNOWN", ErrorCode(got))
+		}
+		var e *Error
+		if !errors.As(got, &e) {
+			t.Fatalf("not a hub error: %T", got)
+		}
+		// NOT retriable, for the same reason E_SEND_UNKNOWN is not: the safe
+		// action is to look, not to repeat.
+		if e.Retriable {
+			t.Fatal("marked retriable — a blind re-run is exactly what duplicates the output")
+		}
+		if !errors.Is(errors.Unwrap(e), error(lost)) && e.Cause != error(lost) {
+			t.Fatal("the original classification was discarded rather than carried")
+		}
+
+		text := got.Error()
+		// It must say all three things, because any one alone misleads.
+		for _, want := range []string{
+			"did happen",  // what was printed is real
+			"may have",    // the hub may have committed
+			"re-delivers", // a re-run duplicates
+		} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("message is missing %q:\n%s", want, text)
+			}
+		}
+		// And it must not assert the failure the operator would otherwise infer.
+		if strings.Contains(text, "channel to the hub was lost") {
+			t.Fatalf("re-used the bare-failure sentence this exists to replace:\n%s", text)
+		}
+		// It names how many items were already shown, so the operator can match
+		// it against what is on their screen.
+		if !strings.Contains(text, "3 item") {
+			t.Fatalf("does not say how much was already delivered:\n%s", text)
+		}
+	})
+
+	t.Run("a nil error stays nil", func(t *testing.T) {
+		if got := resultUnknownIfStreamed(nil, 5); got != nil {
+			t.Fatalf("invented an error from a successful call: %v", got)
+		}
+	})
+}

--- a/internal/hubclient/result_unknown_wired_test.go
+++ b/internal/hubclient/result_unknown_wired_test.go
@@ -1,0 +1,95 @@
+package hubclient
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/agentchute/agentchute/internal/hubwire"
+	"github.com/agentchute/agentchute/internal/loop"
+	"github.com/agentchute/agentchute/internal/op"
+)
+
+// The caller row, and it exists because the unit rows above did NOT need it to
+// pass: deleting the `streamed++` from the streaming loop left every assertion
+// in result_unknown_test.go green. A correct-and-unwired helper looks exactly
+// like a fix, so the counter is pinned where it is incremented, driving the real
+// do() loop over a real transport.
+func TestStreamingLoopMarksTheResultUnknownWhenTheDropFollowsOutput(t *testing.T) {
+	rows := []struct {
+		name        string
+		streamFirst bool
+		wantCode    string
+	}{
+		{
+			// The hub committed and streamed; the terminal frame never came.
+			name:        "a msg frame arrives, then the connection drops",
+			streamFirst: true,
+			wantCode:    "E_RESULT_UNKNOWN",
+		},
+		{
+			// Nothing was delivered, so "nothing happened, re-run" is correct.
+			name:     "the connection drops before anything is streamed",
+			wantCode: "E_CHANNEL_LOST",
+		},
+	}
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			client, server := net.Pipe()
+			remote, err := loop.ParseRemoteURL("ssh://alex@hub.example/home/alex/pool")
+			if err != nil {
+				t.Fatal(err)
+			}
+			s := &OneShot{transport: client, reader: hubwire.NewReader(client), remote: remote, agentID: "codex", nextID: 1}
+
+			go func() {
+				reader := hubwire.NewReader(server)
+				writer := hubwire.NewWriter(server)
+				if _, err := reader.Read(); err != nil { // the check request
+					return
+				}
+				if row.streamFirst {
+					_ = writer.Write(hubwire.Message{
+						ResponseBase: hubwire.ResponseBase{T: "msg", Re: 1},
+						Filename:     "20260820T000000000000Z_from-peer_rabc.md",
+						Sender:       "peer",
+						Stamp:        "20260820T000000000000Z",
+					}, []byte("body\n"))
+				}
+				// Drop without the terminal frame — the whole point.
+				_ = server.Close()
+			}()
+
+			emitted := 0
+			done := make(chan error, 1)
+			go func() {
+				_, _, doErr := s.do(
+					hubwire.Check{RequestBase: hubwire.RequestBase{T: "check", ID: 1}},
+					nil,
+					func(op.Event) error { emitted++; return nil },
+					false,
+					"check-ok",
+				)
+				done <- doErr
+			}()
+
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Fatal("a drop before the terminal frame reported success")
+				}
+				if got := ErrorCode(err); got != row.wantCode {
+					t.Fatalf("code = %s, want %s:\n%v", got, row.wantCode, err)
+				}
+				if row.streamFirst && emitted == 0 {
+					t.Fatal("nothing reached emit, so this row did not exercise the streamed case")
+				}
+				if !row.streamFirst && emitted != 0 {
+					t.Fatalf("emitted %d events on the nothing-streamed row", emitted)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatal("do() never returned")
+			}
+		})
+	}
+}

--- a/internal/hubclient/session.go
+++ b/internal/hubclient/session.go
@@ -341,10 +341,12 @@ func (s *OneShot) do(request any, body []byte, emit func(op.Event) error, observ
 	if err := s.setReadDeadline(30 * time.Second); err != nil {
 		return hubwire.RawFrame{}, transmitted, err
 	}
+	streamed := 0
 	for {
 		raw, err := s.reader.Read()
 		if err != nil {
-			return hubwire.RawFrame{}, transmitted, classifySSHFailure(s.remote, s.agentID, "operation", err, s.transport)
+			return hubwire.RawFrame{}, transmitted, resultUnknownIfStreamed(
+				classifySSHFailure(s.remote, s.agentID, "operation", err, s.transport), streamed)
 		}
 		if raw.Re != s.nextID {
 			return hubwire.RawFrame{}, transmitted, &Error{Code: hubwire.CodeMalformedFrame, Msg: fmt.Sprintf("hub: response %q references request %d, want %d", raw.T, raw.Re, s.nextID)}
@@ -361,6 +363,7 @@ func (s *OneShot) do(request any, body []byte, emit func(op.Event) error, observ
 			if err := emit(event); err != nil {
 				return hubwire.RawFrame{}, transmitted, err
 			}
+			streamed++
 		case "error":
 			return hubwire.RawFrame{}, transmitted, wireError(raw, s.transport)
 		default:
@@ -371,6 +374,41 @@ func (s *OneShot) do(request any, body []byte, emit func(op.Event) error, observ
 			_ = s.Close()
 			return raw, transmitted, nil
 		}
+	}
+}
+
+// resultUnknownIfStreamed re-codes a lost connection that arrived AFTER the hub
+// had already streamed output.
+//
+// #171: the hub commits the work, streams it, the client prints all of it, and
+// then the terminal frame is lost. The operator sees their messages followed by
+// "channel to the hub was lost" and does the obvious thing — re-runs — and
+// at-least-once re-delivers what they were just shown. Nothing is lost; the
+// safety property holds exactly as designed. What is wrong is the report: two
+// situations calling for OPPOSITE actions rendered identically.
+//
+//	nothing happened        -> re-run
+//	everything happened     -> do not re-run
+//
+// The client genuinely cannot tell which, because the terminal frame is what
+// would have told it. So it says that, rather than picking one and being wrong
+// half the time. Not retriable, for the same reason E_SEND_UNKNOWN is not: the
+// safe action is to look, not to repeat.
+//
+// A failure with NO streamed output keeps its original classification — there
+// the answer is known, and "nothing happened, re-run" is the correct advice.
+func resultUnknownIfStreamed(err error, streamed int) error {
+	if err == nil || streamed == 0 {
+		return err
+	}
+	return &Error{
+		Code: "E_RESULT_UNKNOWN",
+		Msg: fmt.Sprintf("hub: the connection dropped after the hub had already sent %d item(s) — everything printed above did happen, "+
+			"but the confirmation that would say the operation finished never arrived. DO NOT assume it failed: the hub may have "+
+			"committed the work, in which case re-running re-delivers what you were just shown (at-least-once). Check the current "+
+			"state first (`agentchute status`, or `agentchute pending` for obligations) and re-run only if it says the work is still outstanding.", streamed),
+		Retriable: false,
+		Cause:     err,
 	}
 }
 

--- a/internal/hubwire/codec_test.go
+++ b/internal/hubwire/codec_test.go
@@ -264,8 +264,8 @@ func TestRegistryCompleteness(t *testing.T) {
 	// The count is asserted on purpose: a code added to the map and forgotten in
 	// the spec's table is exactly the drift this row exists to catch, so it must
 	// be moved deliberately rather than grow on its own.
-	if len(Emitters) != 29 {
-		t.Fatalf("emitter registry = %d rows, want 29", len(Emitters))
+	if len(Emitters) != 30 {
+		t.Fatalf("emitter registry = %d rows, want 30", len(Emitters))
 	}
 }
 

--- a/internal/hubwire/codes.go
+++ b/internal/hubwire/codes.go
@@ -55,15 +55,18 @@ var Emitters = map[string]string{
 	// Client-emitted for the same reason as E_HUB_UNPINNED: only the CLIENT runs
 	// the probe, so only the client can report that the probe could not run.
 	"E_HUB_PINNING_UNVERIFIED": EmitterClient,
-	"E_CONNECT":                EmitterClient,
-	"E_UNAUTHORIZED":           EmitterClient,
-	"E_HOSTKEY_CHANGED":        EmitterClient,
-	"E_CHANNEL_LOST":           EmitterClient,
-	"E_SEND_UNKNOWN":           EmitterClient,
-	"E_HELLO_TIMEOUT":          EmitterClient,
-	"E_HUB_NO_BINARY":          EmitterClient,
-	"E_NOT_JOINED":             EmitterClient,
-	"E_NO_SSH":                 EmitterClient,
+	// Client-emitted: only the client knows whether it had already received and
+	// rendered streamed output when the connection dropped.
+	"E_RESULT_UNKNOWN":  EmitterClient,
+	"E_CONNECT":         EmitterClient,
+	"E_UNAUTHORIZED":    EmitterClient,
+	"E_HOSTKEY_CHANGED": EmitterClient,
+	"E_CHANNEL_LOST":    EmitterClient,
+	"E_SEND_UNKNOWN":    EmitterClient,
+	"E_HELLO_TIMEOUT":   EmitterClient,
+	"E_HUB_NO_BINARY":   EmitterClient,
+	"E_NOT_JOINED":      EmitterClient,
+	"E_NO_SSH":          EmitterClient,
 }
 
 // ProtocolError is a named session/codec failure. Operation errors keep their


### PR DESCRIPTION
The post-tag UX wave — #177, #178, #171. Three unrelated surfaces, one thing in common: each told an operator or a script something that was not true.

## #177 · Joining a hub invented the operator's login profiles

On a fresh macOS account, `hub join` created `~/.zshrc` **and** `~/.profile`, neither of which existed — agentchute writing a user's shell startup files as a side effect of an unrelated command, with no warning, no opt-out, and a timestamped backup left behind each time.

Profiles that **exist** are still updated, exactly as before; this is a narrowing, and the control row says so. Absent ones stay absent, and the operator is told what to add — in the same rendered form the block would have used — plus both escape hatches: `--profile <path>` (naming the file **is** the consent that was missing, so that path still creates it) and `--no-profile`.

Silence would have been worse than the old behaviour: PATH genuinely is not set up, so saying nothing would trade a surprise for a mystery.

## #178 · An incomplete join exited 0

A join that printed *"Run this ON THE HUB…"* and stopped there returned **success**, so a script checking `0` believed the machine was fully joined while authorization was still pending.

It now returns a verdict sentinel and exits **2** — the code this CLI already reserves for "a verdict, not a command failure". The local half really did succeed and re-running after authorizing is the intended next step, which is why 2 and not 1.

The existing row asserting exit-0 on that path is updated **here**, not in a follow-up — same reasoning as #176's characterization row. It was the only thing covering the behaviour, and everything else it asserts (the provisional config, the pointer) still has to hold, because those are what make the re-run work.

## #171 · A failure after the hub committed read as a plain failure

The hub commits, streams, the client prints all of it, then the terminal frame is lost. The operator sees their messages followed by "channel to the hub was lost", re-runs, and at-least-once re-delivers what they were just shown. Nothing is lost — the safety property holds exactly as designed. What was wrong is **the report**: two situations calling for opposite actions rendered identically, and the client cannot tell them apart, because the terminal frame is what would have said which.

So it says that. New client code **`E_RESULT_UNKNOWN`** — the streaming counterpart of `E_SEND_UNKNOWN`, and **not retriable** for the same reason: the safe action is to look, not to repeat. A drop with *no* streamed output keeps its ordinary classification, where "nothing happened, re-run" is correct advice. That is a row, because re-coding it would trade a false failure for a false doubt.

### Caught by mutation, not by reading

My unit rows for #171 **passed with the caller's `streamed++` deleted**. A helper that is correct and unwired looks exactly like a fix — the lesson I wrote down earlier today, meeting my own new code the same day. There is now a row driving the real streaming loop over a real transport, both arms, and both wiring mutations are red.

## Registry

`E_RESULT_UNKNOWN` in `codes.go`, `AGENTCHUTE.md`'s client-only list, a definition paragraph beside the pinning codes, and the emitter count 29 → 30 moved deliberately.

## Verification

`tools/test.sh`, the full `integration/sshd` suite under `-race` (109s), and seven mutations red under a CI-like stripped PATH.

Closes #177, #178, #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)